### PR TITLE
Add `keys` function to `Query`.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -516,6 +516,14 @@ class Query(object):
             clone._pb.projection.add().property.name = projection_name
         return clone
 
+    def keys(self):
+        """Adds a projection to get keys only
+
+        :rtype: :class:`Query`
+        :returns: A new Query instance only returns entity keys
+        """
+        return self.projection(['__key__'])
+
     def offset(self, offset=None):
         """Adds offset to the query to allow pagination.
 

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -513,6 +513,15 @@ class TestQuery(unittest2.TestCase):
         after = before.projection(_PROJECTION2)
         self.assertEqual(after.projection(), _PROJECTION2)
 
+    def test_keys(self):
+        _KIND = 'KIND'
+        before = self._makeOne(_KIND)
+        after = before.keys()
+        projection_pb = list(after.to_protobuf().projection)
+        self.assertEqual(len(projection_pb), 1)
+        prop_pb = projection_pb[0]
+        self.assertEqual(prop_pb.property.name, '__key__')
+
     def test_set_offset(self):
         _KIND = 'KIND'
         _OFFSET = 42


### PR DESCRIPTION
Keys only query are quite useful. Adding `.projection(['__key__'])` every time doesn't look very tidy.
This helper function makes keys only query easier to use.