### PR TITLE
Address second part of 477: Remove query(), entity(), and transaction() methods from Dataset.

### DIFF
--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -15,8 +15,6 @@
 """Create / interact with gcloud datastore datasets."""
 
 from gcloud.datastore import helpers
-from gcloud.datastore.entity import Entity
-from gcloud.datastore.transaction import Transaction
 
 
 class Dataset(object):
@@ -73,35 +71,6 @@ class Dataset(object):
         """
 
         return self._id
-
-    def entity(self, kind, exclude_from_indexes=()):
-        """Create an entity bound to this dataset.
-
-        :type kind: string
-        :param kind: the "kind" of the new entity (see
-                 https://cloud.google.com/datastore/docs/concepts/entities#Datastore_Kinds_and_identifiers)
-
-        :param exclude_from_indexes: names of fields whose values are not to
-                                     be indexed.
-
-        :rtype: :class:`gcloud.datastore.entity.Entity`
-        :returns: a new Entity instance, bound to this dataset.
-        """
-        return Entity(dataset=self, kind=kind,
-                      exclude_from_indexes=exclude_from_indexes)
-
-    def transaction(self, *args, **kwargs):
-        """Create a transaction bound to this dataset.
-
-        :param args: positional arguments, passed through to the Transaction
-
-        :param kw: keyword arguments, passed through to the Transaction
-
-        :rtype: :class:`gcloud.datastore.transaction.Transaction`
-        :returns: a new Transaction instance, bound to this dataset.
-        """
-        kwargs['dataset'] = self
-        return Transaction(*args, **kwargs)
 
     def get_entity(self, key):
         """Retrieves entity from the dataset, along with its attributes.

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -40,34 +40,6 @@ class TestDataset(unittest2.TestCase):
         self.assertEqual(dataset.id(), DATASET_ID)
         self.assertTrue(dataset.connection() is CONNECTION)
 
-    def test_entity_factory_defaults(self):
-        from gcloud.datastore.entity import Entity
-        DATASET_ID = 'DATASET'
-        KIND = 'KIND'
-        dataset = self._makeOne(DATASET_ID)
-        entity = dataset.entity(KIND)
-        self.assertIsInstance(entity, Entity)
-        self.assertEqual(entity.kind(), KIND)
-        self.assertEqual(sorted(entity.exclude_from_indexes()), [])
-
-    def test_entity_factory_explicit(self):
-        from gcloud.datastore.entity import Entity
-        DATASET_ID = 'DATASET'
-        KIND = 'KIND'
-        dataset = self._makeOne(DATASET_ID)
-        entity = dataset.entity(KIND, ['foo', 'bar'])
-        self.assertIsInstance(entity, Entity)
-        self.assertEqual(entity.kind(), KIND)
-        self.assertEqual(sorted(entity.exclude_from_indexes()), ['bar', 'foo'])
-
-    def test_transaction_factory(self):
-        from gcloud.datastore.transaction import Transaction
-        DATASET_ID = 'DATASET'
-        dataset = self._makeOne(DATASET_ID)
-        transaction = dataset.transaction()
-        self.assertIsInstance(transaction, Transaction)
-        self.assertTrue(transaction.dataset() is dataset)
-
     def test_get_entity_miss(self):
         from gcloud.datastore.key import Key
         DATASET_ID = 'DATASET'

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -152,7 +152,7 @@ class TestDatastoreSaveKeys(TestDatastore):
 
     def test_save_key_self_reference(self):
         key = Key('Person', 'name')
-        entity = Entity(kind=None).key(key)
+        entity = Entity.from_key(key)
         entity['fullName'] = u'Full name'
         entity['linkedTo'] = key  # Self reference.
 
@@ -348,7 +348,7 @@ class TestDatastoreTransaction(TestDatastore):
 
     def test_transaction(self):
         key = Key('Company', 'Google')
-        entity = Entity(kind=None).key(key)
+        entity = Entity.from_key(key)
         entity['url'] = u'www.google.com'
 
         with Transaction():


### PR DESCRIPTION
**NOTE**: Has #478 as diffbase.