### PR TITLE
Fix #484: Remove dataset from entity

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -133,7 +133,7 @@ def get_dataset(dataset_id):
     :returns: A dataset with a connection using the provided credentials.
     """
     connection = get_connection()
-    return connection.dataset(dataset_id)
+    return Dataset(dataset_id, connection=connection)
 
 
 def _require_dataset():
@@ -195,10 +195,9 @@ def get_entities(keys, missing=None, deferred=None,
         missing=missing, deferred=deferred,
     )
 
-    new_dataset = Dataset(dataset_id, connection=connection)
     if missing is not None:
         missing[:] = [
-            helpers.entity_from_protobuf(missed_pb, dataset=new_dataset)
+            helpers.entity_from_protobuf(missed_pb)
             for missed_pb in missing]
 
     if deferred is not None:
@@ -208,8 +207,8 @@ def get_entities(keys, missing=None, deferred=None,
 
     entities = []
     for entity_pb in entity_pbs:
-        entities.append(helpers.entity_from_protobuf(
-            entity_pb, dataset=new_dataset))
+        entities.append(helpers.entity_from_protobuf(entity_pb))
+
     return entities
 
 

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -17,7 +17,6 @@
 from gcloud import connection
 from gcloud.datastore import datastore_v1_pb2 as datastore_pb
 from gcloud.datastore import helpers
-from gcloud.datastore.dataset import Dataset
 
 
 class Connection(connection.Connection):
@@ -153,19 +152,6 @@ class Connection(connection.Connection):
             return self.transaction().mutation()
         else:
             return datastore_pb.Mutation()
-
-    def dataset(self, *args, **kwargs):
-        """Factory method for Dataset objects.
-
-        :param args: All args and kwargs will be passed along to the
-                     :class:`gcloud.datastore.dataset.Dataset` initializer.
-
-        :rtype: :class:`gcloud.datastore.dataset.Dataset`
-        :returns: A dataset object that will use this connection as
-                  its transport.
-        """
-        kwargs['connection'] = self
-        return Dataset(*args, **kwargs)
 
     def lookup(self, dataset_id, key_pbs,
                missing=None, deferred=None, eventual=False):

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -32,7 +32,7 @@ from gcloud.datastore.key import Key
 INT_VALUE_CHECKER = Int64ValueChecker()
 
 
-def entity_from_protobuf(pb, dataset=None):
+def entity_from_protobuf(pb):
     """Factory method for creating an entity based on a protobuf.
 
     The protobuf should be one returned from the Cloud Datastore
@@ -45,7 +45,7 @@ def entity_from_protobuf(pb, dataset=None):
     :returns: The entity derived from the protobuf.
     """
     key = key_from_protobuf(pb.key)
-    entity = Entity.from_key(key, dataset)
+    entity = Entity(key=key)
 
     for property_pb in pb.property:
         value = _get_value_from_property_pb(property_pb)
@@ -246,7 +246,7 @@ def _set_protobuf_value(value_pb, val):
     elif attr == 'entity_value':
         e_pb = value_pb.entity_value
         e_pb.Clear()
-        key = val.key()
+        key = val.key
         if key is not None:
             e_pb.key.CopyFrom(key.to_protobuf())
         for item_key, value in val.items():

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -248,7 +248,7 @@ class Key(object):
         if entities:
             result = entities[0]
             # We assume that the backend has not changed the key.
-            result.key(self)
+            result.key = self
             return result
 
     def delete(self, connection=None):

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -390,9 +390,8 @@ class Iterator(object):
         else:
             raise ValueError('Unexpected value returned for `more_results`.')
 
-        dataset = self._query.dataset
         self._page = [
-            helpers.entity_from_protobuf(entity, dataset=dataset)
+            helpers.entity_from_protobuf(entity)
             for entity in entity_pbs]
         return self._page, self._more_results, self._start_cursor
 

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -234,7 +234,7 @@ class Test_get_entities_function(unittest2.TestCase):
         entities = self._callFUT([key], connection=connection,
                                  dataset_id=DATASET_ID, missing=missing)
         self.assertEqual(entities, [])
-        self.assertEqual([missed.key().to_protobuf() for missed in missing],
+        self.assertEqual([missed.key.to_protobuf() for missed in missing],
                          [key.to_protobuf()])
 
     def test_get_entities_miss_w_deferred(self):
@@ -288,7 +288,7 @@ class Test_get_entities_function(unittest2.TestCase):
         key = Key(KIND, ID, dataset_id=DATASET_ID)
         result, = self._callFUT([key], connection=connection,
                                 dataset_id=DATASET_ID)
-        new_key = result.key()
+        new_key = result.key
 
         # Check the returned value is as expected.
         self.assertFalse(new_key is key)
@@ -328,7 +328,7 @@ class Test_get_entities_function(unittest2.TestCase):
         }
         self.assertEqual(CUSTOM_CONNECTION._called_with, expected_called_with)
 
-        new_key = result.key()
+        new_key = result.key
         # Check the returned value is as expected.
         self.assertFalse(new_key is key)
         self.assertEqual(new_key.dataset_id, DATASET_ID)

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -210,13 +210,6 @@ class TestConnection(unittest2.TestCase):
         found = conn.mutation()
         self.assertTrue(isinstance(found, Mutation))
 
-    def test_dataset(self):
-        DATASET_ID = 'DATASET'
-        conn = self._makeOne()
-        dataset = conn.dataset(DATASET_ID)
-        self.assertTrue(dataset.connection() is conn)
-        self.assertEqual(dataset.id(), DATASET_ID)
-
     def test_lookup_single_key_empty_response(self):
         from gcloud.datastore import datastore_v1_pb2 as datastore_pb
 

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -14,7 +14,6 @@
 
 import unittest2
 
-_MARKER = object()
 _DATASET_ID = 'DATASET'
 _KIND = 'KIND'
 _ID = 1234
@@ -29,130 +28,70 @@ class TestEntity(unittest2.TestCase):
         _implicit_environ.DATASET = None
         return Entity
 
-    def _makeOne(self, dataset=_MARKER, kind=_KIND, exclude_from_indexes=()):
-        from gcloud.datastore.dataset import Dataset
-
+    def _makeOne(self, key=None, exclude_from_indexes=()):
         klass = self._getTargetClass()
-        if dataset is _MARKER:
-            dataset = Dataset(_DATASET_ID)
-        return klass(dataset, kind, exclude_from_indexes)
+        return klass(key=key, exclude_from_indexes=exclude_from_indexes)
 
     def test_ctor_defaults(self):
         klass = self._getTargetClass()
         entity = klass()
-        self.assertEqual(entity.key(), None)
-        self.assertEqual(entity.dataset(), None)
-        self.assertEqual(entity.kind(), None)
-        self.assertEqual(sorted(entity.exclude_from_indexes()), [])
+        self.assertEqual(entity.key, None)
+        self.assertEqual(entity.kind, None)
+        self.assertEqual(sorted(entity.exclude_from_indexes), [])
 
     def test_ctor_explicit(self):
-        from gcloud.datastore.dataset import Dataset
-
-        dataset = Dataset(_DATASET_ID)
         _EXCLUDE_FROM_INDEXES = ['foo', 'bar']
-        entity = self._makeOne(dataset, _KIND, _EXCLUDE_FROM_INDEXES)
-        self.assertTrue(entity.dataset() is dataset)
-        self.assertEqual(sorted(entity.exclude_from_indexes()),
+        key = _Key()
+        entity = self._makeOne(
+            key=key, exclude_from_indexes=_EXCLUDE_FROM_INDEXES)
+        self.assertEqual(sorted(entity.exclude_from_indexes),
                          sorted(_EXCLUDE_FROM_INDEXES))
-
-    def test_key_getter(self):
-        from gcloud.datastore.key import Key
-
-        entity = self._makeOne()
-        key = entity.key()
-        self.assertIsInstance(key, Key)
-        self.assertEqual(key.dataset_id, entity.dataset().id())
-        self.assertEqual(key.kind, _KIND)
-
-    def test_key_setter(self):
-        entity = self._makeOne()
-        key = object()
-        entity.key(key)
-        self.assertTrue(entity.key() is key)
-
-    def test_from_key_wo_dataset(self):
-        from gcloud.datastore.key import Key
-
-        klass = self._getTargetClass()
-        key = Key(_KIND, _ID, dataset_id='DATASET')
-        entity = klass.from_key(key)
-        self.assertTrue(entity.dataset() is None)
-        self.assertEqual(entity.kind(), _KIND)
-        key = entity.key()
-        self.assertEqual(key.kind, _KIND)
-        self.assertEqual(key.id, _ID)
-
-    def test_from_key_w_dataset(self):
-        from gcloud.datastore.dataset import Dataset
-        from gcloud.datastore.key import Key
-
-        klass = self._getTargetClass()
-        dataset = Dataset(_DATASET_ID)
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
-        entity = klass.from_key(key, dataset)
-        self.assertTrue(entity.dataset() is dataset)
-        self.assertEqual(entity.kind(), _KIND)
-        key = entity.key()
-        self.assertEqual(key.kind, _KIND)
-        self.assertEqual(key.id, _ID)
 
     def test__must_key_no_key(self):
         from gcloud.datastore.entity import NoKey
 
-        entity = self._makeOne(None, None)
+        entity = self._makeOne()
         self.assertRaises(NoKey, getattr, entity, '_must_key')
-
-    def test__must_dataset_no_dataset(self):
-        from gcloud.datastore.entity import NoDataset
-
-        entity = self._makeOne(None, None)
-        self.assertRaises(NoDataset, getattr, entity, '_must_dataset')
 
     def test_reload_no_key(self):
         from gcloud.datastore.entity import NoKey
 
-        entity = self._makeOne(None, None)
+        entity = self._makeOne()
         entity['foo'] = 'Foo'
         self.assertRaises(NoKey, entity.reload)
 
     def test_reload_miss(self):
-        dataset = _Dataset()
         key = _Key()
         key._stored = None  # Explicit miss.
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
         # Does not raise, does not update on miss.
-        self.assertTrue(entity.reload() is entity)
+        entity.reload()
         self.assertEqual(entity['foo'], 'Foo')
 
     def test_reload_hit(self):
-        dataset = _Dataset()
         key = _Key()
         NEW_VAL = 'Baz'
         key._stored = {'foo': NEW_VAL}
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
-        self.assertTrue(entity.reload() is entity)
+        entity.reload()
         self.assertEqual(entity['foo'], NEW_VAL)
         self.assertEqual(entity.keys(), ['foo'])
 
     def test_save_no_key(self):
         from gcloud.datastore.entity import NoKey
 
-        entity = self._makeOne(None, None)
+        entity = self._makeOne()
         entity['foo'] = 'Foo'
         self.assertRaises(NoKey, entity.save)
 
     def test_save_wo_transaction_wo_auto_id_wo_returned_key(self):
         connection = _Connection()
-        dataset = _Dataset(connection)
         key = _Key()
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
-        self.assertTrue(entity.save() is entity)
+        entity.save(connection=connection)
         self.assertEqual(entity['foo'], 'Foo')
         self.assertEqual(connection._saved,
                          (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
@@ -161,12 +100,10 @@ class TestEntity(unittest2.TestCase):
     def test_save_w_transaction_wo_partial_key(self):
         connection = _Connection()
         transaction = connection._transaction = _Transaction()
-        dataset = _Dataset(connection)
         key = _Key()
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
-        self.assertTrue(entity.save() is entity)
+        entity.save(connection=connection)
         self.assertEqual(entity['foo'], 'Foo')
         self.assertEqual(connection._saved,
                          (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
@@ -176,13 +113,11 @@ class TestEntity(unittest2.TestCase):
     def test_save_w_transaction_w_partial_key(self):
         connection = _Connection()
         transaction = connection._transaction = _Transaction()
-        dataset = _Dataset(connection)
         key = _Key()
         key._partial = True
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
-        self.assertTrue(entity.save() is entity)
+        entity.save(connection=connection)
         self.assertEqual(entity['foo'], 'Foo')
         self.assertEqual(connection._saved,
                          (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
@@ -198,12 +133,10 @@ class TestEntity(unittest2.TestCase):
         key_pb.path_element.add(kind=_KIND, id=_ID)
         connection = _Connection()
         connection._save_result = (True, _ID)
-        dataset = _Dataset(connection)
         key = Key('KIND', dataset_id=_DATASET_ID)
-        entity = self._makeOne(dataset, exclude_from_indexes=['foo'])
-        entity.key(key)
+        entity = self._makeOne(key=key, exclude_from_indexes=['foo'])
         entity['foo'] = 'Foo'
-        self.assertTrue(entity.save() is entity)
+        entity.save(connection=connection)
         self.assertEqual(entity['foo'], 'Foo')
         self.assertEqual(connection._saved[0], _DATASET_ID)
         self.assertEqual(connection._saved[1], key.to_protobuf())
@@ -211,19 +144,16 @@ class TestEntity(unittest2.TestCase):
         self.assertEqual(connection._saved[3], ('foo',))
         self.assertEqual(len(connection._saved), 4)
 
-        self.assertEqual(entity.key()._path, [{'kind': _KIND, 'id': _ID}])
+        self.assertEqual(entity.key._path, [{'kind': _KIND, 'id': _ID}])
 
     def test___repr___no_key_empty(self):
-        entity = self._makeOne(None, None)
+        entity = self._makeOne()
         self.assertEqual(repr(entity), '<Entity {}>')
 
     def test___repr___w_key_non_empty(self):
-        connection = _Connection()
-        dataset = _Dataset(connection)
         key = _Key()
         key._path = '/bar/baz'
-        entity = self._makeOne(dataset)
-        entity.key(key)
+        entity = self._makeOne(key=key)
         entity['foo'] = 'Foo'
         self.assertEqual(repr(entity), "<Entity/bar/baz {'foo': 'Foo'}>")
 
@@ -235,6 +165,9 @@ class _Key(object):
     _path = None
     _id = None
     _stored = None
+
+    def __init__(self, dataset_id=_DATASET_ID):
+        self.dataset_id = dataset_id
 
     def to_protobuf(self):
         return self._key
@@ -258,18 +191,8 @@ class _Dataset(dict):
         super(_Dataset, self).__init__()
         self._connection = connection
 
-    def __bool__(self):
-        # Make sure the objects are Truth-y since an empty
-        # dict with _connection set will still be False-y.
-        return True
-
-    __nonzero__ = __bool__
-
     def id(self):
         return _DATASET_ID
-
-    def connection(self):
-        return self._connection
 
 
 class _Connection(object):

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -17,8 +17,6 @@ import unittest2
 
 class Test_entity_from_protobuf(unittest2.TestCase):
 
-    _MARKER = object()
-
     def setUp(self):
         from gcloud.datastore import _implicit_environ
         self._replaced_dataset = _implicit_environ.DATASET
@@ -28,13 +26,9 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         from gcloud.datastore import _implicit_environ
         _implicit_environ.DATASET = self._replaced_dataset
 
-    def _callFUT(self, val, dataset=_MARKER):
+    def _callFUT(self, val):
         from gcloud.datastore.helpers import entity_from_protobuf
-
-        if dataset is self._MARKER:
-            return entity_from_protobuf(val)
-
-        return entity_from_protobuf(val, dataset)
+        return entity_from_protobuf(val)
 
     def test_wo_dataset(self):
         from gcloud.datastore import datastore_v1_pb2 as datastore_pb
@@ -49,10 +43,9 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         prop_pb.name = 'foo'
         prop_pb.value.string_value = 'Foo'
         entity = self._callFUT(entity_pb)
-        self.assertTrue(entity.dataset() is None)
-        self.assertEqual(entity.kind(), _KIND)
+        self.assertEqual(entity.kind, _KIND)
         self.assertEqual(entity['foo'], 'Foo')
-        key = entity.key()
+        key = entity.key
         self.assertEqual(key.dataset_id, _DATASET_ID)
         self.assertEqual(key.namespace, None)
         self.assertEqual(key.kind, _KIND)
@@ -60,7 +53,6 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
     def test_w_dataset(self):
         from gcloud.datastore import datastore_v1_pb2 as datastore_pb
-        from gcloud.datastore.dataset import Dataset
 
         _DATASET_ID = 'DATASET'
         _KIND = 'KIND'
@@ -71,12 +63,10 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         prop_pb = entity_pb.property.add()
         prop_pb.name = 'foo'
         prop_pb.value.string_value = 'Foo'
-        dataset = Dataset(_DATASET_ID)
-        entity = self._callFUT(entity_pb, dataset)
-        self.assertTrue(entity.dataset() is dataset)
-        self.assertEqual(entity.kind(), _KIND)
+        entity = self._callFUT(entity_pb)
+        self.assertEqual(entity.kind, _KIND)
         self.assertEqual(entity['foo'], 'Foo')
-        key = entity.key()
+        key = entity.key
         self.assertEqual(key.dataset_id, _DATASET_ID)
         self.assertEqual(key.namespace, None)
         self.assertEqual(key.kind, _KIND)
@@ -451,7 +441,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
 
         pb = self._makePB()
         key = Key('KIND', 123, dataset_id='DATASET')
-        entity = Entity().key(key)
+        entity = Entity(key=key)
         entity['foo'] = u'Foo'
         self._callFUT(pb, entity)
         value = pb.entity_value

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -241,7 +241,7 @@ class TestKey(unittest2.TestCase):
         key = self._makeOne(KIND, ID)
         entity = key.get(connection=cnxn)
         self.assertEqual(entity.items(), [('foo', 'Foo')])
-        self.assertTrue(entity.key() is key)
+        self.assertTrue(entity.key is key)
 
     def test_get_no_connection(self):
         from gcloud.datastore import _implicit_environ

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -491,7 +491,7 @@ class TestIterator(unittest2.TestCase):
         self.assertFalse(more_results)
         self.assertFalse(iterator._more_results)
         self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key().path,
+        self.assertEqual(entities[0].key.path,
                          [{'kind': self._KIND, 'id': self._ID}])
         self.assertEqual(entities[0]['foo'], u'Foo')
         qpb = _pb_from_query(query)
@@ -521,7 +521,7 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(iterator._end_cursor, None)
         self.assertEqual(b64decode(iterator._start_cursor), self._END)
         self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key().path,
+        self.assertEqual(entities[0].key.path,
                          [{'kind': self._KIND, 'id': self._ID}])
         self.assertEqual(entities[0]['foo'], u'Foo')
         qpb = _pb_from_query(query)
@@ -555,7 +555,7 @@ class TestIterator(unittest2.TestCase):
 
         self.assertFalse(iterator._more_results)
         self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key().path,
+        self.assertEqual(entities[0].key.path,
                          [{'kind': self._KIND, 'id': self._ID}])
         self.assertEqual(entities[0]['foo'], u'Foo')
         qpb = _pb_from_query(query)
@@ -580,7 +580,7 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(len(entities), 2)
         for entity in entities:
             self.assertEqual(
-                entity.key().path,
+                entity.key.path,
                 [{'kind': self._KIND, 'id': self._ID}])
             self.assertEqual(entities[1]['foo'], u'Foo')
         qpb1 = _pb_from_query(query)


### PR DESCRIPTION
Also:
- Dropping `dataset` and `kind` from `Entity` constructor.
- Dropping `Entity.from_path` factory.
- Removing `Connection.dataset()` quasi-factory.
- `helpers.entity_from_protobuf()` no longer accepts / needs `dataset`.
- Making `Entity.key` a data attribute instead of a getter/setter method.
- Removing `Entity.dataset()` (since no longer stored).
- Making `Entity.kind()` and `Entity.exclude_from_indexes()` into `@property`'s.
- Removing `Entity._must_dataset` (no longer needed).
- Adding optional connection argument to `Entity.save()` and `Entity.reload()`.
- Making `Entity.save()` and `Entity.reload()` return nothing.
- Updating `regression/datastore.py` for changes.

Fix #484 

**NOTE**: Has #483 as diffbase.