### PR TITLE
Add 'keys_only' method to Query.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -246,6 +246,10 @@ class Query(_implicit_environ._DatastoreBase):
             projection = [projection]
         self._projection[:] = projection
 
+    def keys_only(self):
+        """Set the projection to include only keys."""
+        self._projection[:] = ['__key__']
+
     @property
     def order(self):
         """Names of fields used to sort query results.

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -250,6 +250,12 @@ class TestQuery(unittest2.TestCase):
         query.projection = _PROJECTION2
         self.assertEqual(query.projection, _PROJECTION2)
 
+    def test_keys_only(self):
+        _KIND = 'KIND'
+        query = self._makeOne(_KIND)
+        query.keys_only()
+        self.assertEqual(query.projection, ['__key__'])
+
     def test_order_setter_empty(self):
         _KIND = 'KIND'
         query = self._makeOne(_KIND, order=['foo', '-bar'])


### PR DESCRIPTION
Sets the projection to include only entity keys.

Supercedes #466.