### PR TITLE
#485: Drop Query use of Dataset object

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -22,7 +22,7 @@ from gcloud.datastore import helpers
 from gcloud.datastore.key import Key
 
 
-class Query(_implicit_environ._DatastoreBase):
+class Query(object):
     """A Query against the Cloud Datastore.
 
     This class serves as an abstraction for creating a query over data

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -17,15 +17,6 @@ import unittest2
 
 class TestQuery(unittest2.TestCase):
 
-    def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_dataset = _implicit_environ.DATASET
-        _implicit_environ.DATASET = None
-
-    def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET = self._replaced_dataset
-
     def _getTargetClass(self):
         from gcloud.datastore.query import Query
         return Query
@@ -33,9 +24,17 @@ class TestQuery(unittest2.TestCase):
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
-    def test_ctor_defaults(self):
-        query = self._getTargetClass()()
-        self.assertEqual(query.dataset, None)
+    def test_ctor_defaults_wo_implicit_dataset_id(self):
+        _DATASET = 'DATASET'
+        self.assertRaises(ValueError, self._makeOne)
+
+    def test_ctor_defaults_w_implicit_dataset_id(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+        _DATASET = 'DATASET'
+        with _Monkey(_implicit_environ, DATASET_ID=_DATASET):
+            query = self._makeOne()
+        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, None)
         self.assertEqual(query.namespace, None)
         self.assertEqual(query.ancestor, None)
@@ -45,20 +44,18 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.group_by, [])
 
     def test_ctor_explicit(self):
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
         ancestor = Key('ANCESTOR', 123, dataset_id=_DATASET)
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
         GROUP_BY = ['foo']
         query = self._makeOne(
+            dataset_id=_DATASET,
             kind=_KIND,
-            dataset=dataset,
             namespace=_NAMESPACE,
             ancestor=ancestor,
             filters=FILTERS,
@@ -66,7 +63,7 @@ class TestQuery(unittest2.TestCase):
             order=ORDER,
             group_by=GROUP_BY,
             )
-        self.assertTrue(query.dataset is dataset)
+        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, _KIND)
         self.assertEqual(query.namespace, _NAMESPACE)
         self.assertEqual(query.ancestor.path, ancestor.path)
@@ -75,26 +72,9 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.order, ORDER)
         self.assertEqual(query.group_by, GROUP_BY)
 
-    def test_dataset_setter_w_non_dataset(self):
-        query = self._makeOne()
-
-        def _assign(val):
-            query.dataset = val
-
-        self.assertRaises(ValueError, _assign, object())
-
-    def test_dataset_setter(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        dataset = Dataset(_DATASET)
-        query = self._makeOne(_KIND)
-        query.dataset = dataset
-        self.assertTrue(query.dataset is dataset)
-        self.assertEqual(query.kind, _KIND)
-
     def test_namespace_setter_w_non_string(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
 
         def _assign(val):
             query.namespace = val
@@ -102,17 +82,16 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(ValueError, _assign, object())
 
     def test_namespace_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
-        query = self._makeOne(dataset=dataset)
+        query = self._makeOne(_DATASET)
         query.namespace = _NAMESPACE
-        self.assertTrue(query.dataset is dataset)
+        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.namespace, _NAMESPACE)
 
     def test_kind_setter_w_non_string(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
 
         def _assign(val):
             query.kind = val
@@ -120,29 +99,26 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(TypeError, _assign, object())
 
     def test_kind_setter_wo_existing(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _KIND = 'KIND'
-        dataset = Dataset(_DATASET)
-        query = self._makeOne(dataset=dataset)
+        query = self._makeOne(_DATASET)
         query.kind = _KIND
-        self.assertTrue(query.dataset is dataset)
+        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, _KIND)
 
     def test_kind_setter_w_existing(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _KIND_BEFORE = 'KIND_BEFORE'
         _KIND_AFTER = 'KIND_AFTER'
-        dataset = Dataset(_DATASET)
-        query = self._makeOne(_KIND_BEFORE, dataset)
+        query = self._makeOne(_DATASET, _KIND_BEFORE)
         self.assertEqual(query.kind, _KIND_BEFORE)
         query.kind = _KIND_AFTER
-        self.assertTrue(query.dataset is dataset)
+        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, _KIND_AFTER)
 
     def test_ancestor_setter_w_non_key(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
 
         def _assign(val):
             query.ancestor = val
@@ -152,32 +128,37 @@ class TestQuery(unittest2.TestCase):
 
     def test_ancestor_setter_w_key(self):
         from gcloud.datastore.key import Key
+        _DATASET = 'DATASET'
         _NAME = u'NAME'
         key = Key('KIND', 123, dataset_id='DATASET')
-        query = self._makeOne()
+        query = self._makeOne(_DATASET)
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
         self.assertEqual(query.ancestor.path, key.path)
 
     def test_ancestor_deleter_w_key(self):
         from gcloud.datastore.key import Key
+        _DATASET = 'DATASET'
         key = Key('KIND', 123, dataset_id='DATASET')
-        query = self._makeOne(ancestor=key)
+        query = self._makeOne(_DATASET, ancestor=key)
         del query.ancestor
         self.assertTrue(query.ancestor is None)
 
     def test_add_filter_setter_w_unknown_operator(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         self.assertRaises(ValueError, query.add_filter,
                           'firstname', '~~', 'John')
 
     def test_add_filter_w_known_operator(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         query.add_filter('firstname', '=', u'John')
         self.assertEqual(query.filters, [('firstname', '=', u'John')])
 
     def test_add_filter_w_all_operators(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         query.add_filter('leq_prop', '<=', u'val1')
         query.add_filter('geq_prop', '>=', u'val2')
         query.add_filter('lt_prop', '<', u'val3')
@@ -192,7 +173,8 @@ class TestQuery(unittest2.TestCase):
 
     def test_add_filter_w_known_operator_and_entity(self):
         from gcloud.datastore.entity import Entity
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         other = Entity()
         other['firstname'] = u'John'
         other['lastname'] = u'Smith'
@@ -200,129 +182,356 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.filters, [('other', '=', other)])
 
     def test_add_filter_w_whitespace_property_name(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         PROPERTY_NAME = '  property with lots of space '
         query.add_filter(PROPERTY_NAME, '=', u'John')
         self.assertEqual(query.filters, [(PROPERTY_NAME, '=', u'John')])
 
     def test_add_filter___key__valid_key(self):
         from gcloud.datastore.key import Key
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         key = Key('Foo', dataset_id='DATASET')
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
     def test_filter___key__invalid_operator(self):
         from gcloud.datastore.key import Key
+        _DATASET = 'DATASET'
         key = Key('Foo', dataset_id='DATASET')
-        query = self._makeOne()
+        query = self._makeOne(_DATASET)
         self.assertRaises(ValueError, query.add_filter, '__key__', '<', key)
 
     def test_filter___key__invalid_value(self):
-        query = self._makeOne()
+        _DATASET = 'DATASET'
+        query = self._makeOne(_DATASET)
         self.assertRaises(ValueError, query.add_filter, '__key__', '=', None)
 
     def test_projection_setter_empty(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.projection = []
         self.assertEqual(query.projection, [])
 
     def test_projection_setter_string(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.projection = 'field1'
         self.assertEqual(query.projection, ['field1'])
 
     def test_projection_setter_non_empty(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.projection = ['field1', 'field2']
         self.assertEqual(query.projection, ['field1', 'field2'])
 
     def test_projection_setter_multiple_calls(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
         _PROJECTION1 = ['field1', 'field2']
         _PROJECTION2 = ['field3']
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.projection = _PROJECTION1
         self.assertEqual(query.projection, _PROJECTION1)
         query.projection = _PROJECTION2
         self.assertEqual(query.projection, _PROJECTION2)
 
     def test_keys_only(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.keys_only()
         self.assertEqual(query.projection, ['__key__'])
 
     def test_order_setter_empty(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND, order=['foo', '-bar'])
+        query = self._makeOne(_DATASET, _KIND, order=['foo', '-bar'])
         query.order = []
         self.assertEqual(query.order, [])
 
     def test_order_setter_string(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.order = 'field'
         self.assertEqual(query.order, ['field'])
 
     def test_order_setter_single_item_list_desc(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.order = ['-field']
         self.assertEqual(query.order, ['-field'])
 
     def test_order_setter_multiple(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.order = ['foo', '-bar']
         self.assertEqual(query.order, ['foo', '-bar'])
 
     def test_group_by_setter_empty(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND, group_by=['foo', 'bar'])
+        query = self._makeOne(_DATASET, _KIND, group_by=['foo', 'bar'])
         query.group_by = []
         self.assertEqual(query.group_by, [])
 
     def test_group_by_setter_string(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.group_by = 'field1'
         self.assertEqual(query.group_by, ['field1'])
 
     def test_group_by_setter_non_empty(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.group_by = ['field1', 'field2']
         self.assertEqual(query.group_by, ['field1', 'field2'])
 
     def test_group_by_multiple_calls(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
         _GROUP_BY1 = ['field1', 'field2']
         _GROUP_BY2 = ['field3']
-        query = self._makeOne(_KIND)
+        query = self._makeOne(_DATASET, _KIND)
         query.group_by = _GROUP_BY1
         self.assertEqual(query.group_by, _GROUP_BY1)
         query.group_by = _GROUP_BY2
         self.assertEqual(query.group_by, _GROUP_BY2)
 
-    def test_fetch_defaults(self):
+    def test_fetch_defaults_wo_implicit_connection(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
-        iterator = query.fetch()
+        query = self._makeOne(_DATASET, _KIND)
+        self.assertRaises(ValueError, query.fetch)
+
+    def test_fetch_defaults_w_implicit_connection(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+        _DATASET = 'DATASET'
+        _KIND = 'KIND'
+        connection = _Connection()
+        query = self._makeOne(_DATASET, _KIND)
+        with _Monkey(_implicit_environ, CONNECTION=connection):
+            iterator = query.fetch()
         self.assertTrue(iterator._query is query)
-        self.assertEqual(iterator._limit, 0)
+        self.assertEqual(iterator._limit, None)
         self.assertEqual(iterator._offset, 0)
 
     def test_fetch_explicit(self):
+        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(_KIND)
-        iterator = query.fetch(limit=7, offset=8)
+        connection = _Connection()
+        query = self._makeOne(_DATASET, _KIND)
+        iterator = query.fetch(limit=7, offset=8, connection=connection)
         self.assertTrue(iterator._query is query)
         self.assertEqual(iterator._limit, 7)
         self.assertEqual(iterator._offset, 8)
+
+
+class TestIterator(unittest2.TestCase):
+    _DATASET = 'DATASET'
+    _NAMESPACE = 'NAMESPACE'
+    _KIND = 'KIND'
+    _ID = 123
+    _START = b'\x00'
+    _END = b'\xFF'
+
+    def _getTargetClass(self):
+        from gcloud.datastore.query import Iterator
+        return Iterator
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def _addQueryResults(self, connection, cursor=_END, more=False):
+        from gcloud.datastore import datastore_v1_pb2 as datastore_pb
+        MORE = datastore_pb.QueryResultBatch.NOT_FINISHED
+        NO_MORE = datastore_pb.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT
+        _ID = 123
+        entity_pb = datastore_pb.Entity()
+        entity_pb.key.partition_id.dataset_id = self._DATASET
+        path_element = entity_pb.key.path_element.add()
+        path_element.kind = self._KIND
+        path_element.id = _ID
+        prop = entity_pb.property.add()
+        prop.name = 'foo'
+        prop.value.string_value = u'Foo'
+        connection._results.append(
+            ([entity_pb], cursor, MORE if more else NO_MORE))
+
+    def test_ctor_defaults(self):
+        connection = _Connection()
+        query = object()
+        iterator = self._makeOne(query, connection)
+        self.assertTrue(iterator._query is query)
+        self.assertEqual(iterator._limit, None)
+        self.assertEqual(iterator._offset, 0)
+
+    def test_ctor_explicit(self):
+        connection = _Connection()
+        query = _Query()
+        iterator = self._makeOne(query, connection, 13, 29)
+        self.assertTrue(iterator._query is query)
+        self.assertEqual(iterator._limit, 13)
+        self.assertEqual(iterator._offset, 29)
+
+    def test_next_page_no_cursors_no_more(self):
+        from base64 import b64encode
+        from gcloud.datastore.query import _pb_from_query
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection)
+        iterator = self._makeOne(query, connection)
+        entities, more_results, cursor = iterator.next_page()
+
+        self.assertEqual(cursor, b64encode(self._END))
+        self.assertFalse(more_results)
+        self.assertFalse(iterator._more_results)
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].key.path,
+                         [{'kind': self._KIND, 'id': self._ID}])
+        self.assertEqual(entities[0]['foo'], u'Foo')
+        qpb = _pb_from_query(query)
+        qpb.offset = 0
+        EXPECTED = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb,
+            'namespace': self._NAMESPACE,
+        }
+        self.assertEqual(connection._called_with, [EXPECTED])
+
+    def test_next_page_no_cursors_no_more_w_offset_and_limit(self):
+        from base64 import b64encode
+        from gcloud.datastore.query import _pb_from_query
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection)
+        iterator = self._makeOne(query, connection, 13, 29)
+        entities, more_results, cursor = iterator.next_page()
+
+        self.assertEqual(cursor, b64encode(self._END))
+        self.assertFalse(more_results)
+        self.assertFalse(iterator._more_results)
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].key.path,
+                         [{'kind': self._KIND, 'id': self._ID}])
+        self.assertEqual(entities[0]['foo'], u'Foo')
+        qpb = _pb_from_query(query)
+        qpb.limit = 13
+        qpb.offset = 29
+        EXPECTED = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb,
+            'namespace': self._NAMESPACE,
+        }
+        self.assertEqual(connection._called_with, [EXPECTED])
+
+    def test_next_page_w_cursors_w_more(self):
+        from base64 import b64decode
+        from base64 import b64encode
+        from gcloud.datastore.query import _pb_from_query
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection, cursor=self._END, more=True)
+        iterator = self._makeOne(query, connection)
+        iterator._start_cursor = self._START
+        iterator._end_cursor = self._END
+        entities, more_results, cursor = iterator.next_page()
+
+        self.assertEqual(cursor, b64encode(self._END))
+        self.assertTrue(more_results)
+        self.assertTrue(iterator._more_results)
+        self.assertEqual(iterator._end_cursor, None)
+        self.assertEqual(b64decode(iterator._start_cursor), self._END)
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].key.path,
+                         [{'kind': self._KIND, 'id': self._ID}])
+        self.assertEqual(entities[0]['foo'], u'Foo')
+        qpb = _pb_from_query(query)
+        qpb.offset = 0
+        qpb.start_cursor = b64decode(self._START)
+        qpb.end_cursor = b64decode(self._END)
+        EXPECTED = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb,
+            'namespace': self._NAMESPACE,
+        }
+        self.assertEqual(connection._called_with, [EXPECTED])
+
+    def test_next_page_w_cursors_w_bogus_more(self):
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection, cursor=self._END, more=True)
+        epb, cursor, _ = connection._results.pop()
+        connection._results.append((epb, cursor, 4))  # invalid enum
+        iterator = self._makeOne(query, connection)
+        self.assertRaises(ValueError, iterator.next_page)
+
+    def test___iter___no_more(self):
+        from gcloud.datastore.query import _pb_from_query
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection)
+        iterator = self._makeOne(query, connection)
+        entities = list(iterator)
+
+        self.assertFalse(iterator._more_results)
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].key.path,
+                         [{'kind': self._KIND, 'id': self._ID}])
+        self.assertEqual(entities[0]['foo'], u'Foo')
+        qpb = _pb_from_query(query)
+        qpb.offset = 0
+        EXPECTED = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb,
+            'namespace': self._NAMESPACE,
+        }
+        self.assertEqual(connection._called_with, [EXPECTED])
+
+    def test___iter___w_more(self):
+        from gcloud.datastore.query import _pb_from_query
+        connection = _Connection()
+        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        self._addQueryResults(connection, cursor=self._END, more=True)
+        self._addQueryResults(connection)
+        iterator = self._makeOne(query, connection)
+        entities = list(iterator)
+
+        self.assertFalse(iterator._more_results)
+        self.assertEqual(len(entities), 2)
+        for entity in entities:
+            self.assertEqual(
+                entity.key.path,
+                [{'kind': self._KIND, 'id': self._ID}])
+            self.assertEqual(entities[1]['foo'], u'Foo')
+        qpb1 = _pb_from_query(query)
+        qpb1.offset = 0
+        qpb2 = _pb_from_query(query)
+        qpb2.offset = 0
+        qpb2.start_cursor = self._END
+        EXPECTED1 = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb1,
+            'namespace': self._NAMESPACE,
+        }
+        EXPECTED2 = {
+            'dataset_id': self._DATASET,
+            'query_pb': qpb2,
+            'namespace': self._NAMESPACE,
+        }
+        self.assertEqual(len(connection._called_with), 2)
+        self.assertEqual(connection._called_with[0], EXPECTED1)
+        self.assertEqual(connection._called_with[1], EXPECTED2)
 
 
 class Test__pb_from_query(unittest2.TestCase):
@@ -418,231 +627,19 @@ class Test__pb_from_query(unittest2.TestCase):
                          ['a', 'b', 'c'])
 
 
-class TestIterator(unittest2.TestCase):
-    _DATASET = 'DATASET'
-    _NAMESPACE = 'NAMESPACE'
-    _KIND = 'KIND'
-    _ID = 123
-    _START = b'\x00'
-    _END = b'\xFF'
-
-    def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_dataset = _implicit_environ.DATASET
-        _implicit_environ.DATASET = None
-
-    def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET = self._replaced_dataset
-
-    def _getTargetClass(self):
-        from gcloud.datastore.query import Iterator
-        return Iterator
-
-    def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
-
-    def _makeDataset(self):
-        connection = _Connection()
-        dataset = _Dataset(self._DATASET, connection)
-        return dataset, connection
-
-    def _addQueryResults(self, dataset, cursor=_END, more=False):
-        from gcloud.datastore import datastore_v1_pb2 as datastore_pb
-        MORE = datastore_pb.QueryResultBatch.NOT_FINISHED
-        NO_MORE = datastore_pb.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT
-        _ID = 123
-        entity_pb = datastore_pb.Entity()
-        entity_pb.key.partition_id.dataset_id = dataset.id()
-        path_element = entity_pb.key.path_element.add()
-        path_element.kind = self._KIND
-        path_element.id = _ID
-        prop = entity_pb.property.add()
-        prop.name = 'foo'
-        prop.value.string_value = u'Foo'
-        dataset.connection()._results.append(
-            ([entity_pb], cursor, MORE if more else NO_MORE))
-
-    def test_ctor_defaults(self):
-        query = object()
-        iterator = self._makeOne(query)
-        self.assertTrue(iterator._query is query)
-        self.assertEqual(iterator._limit, None)
-        self.assertEqual(iterator._offset, 0)
-
-    def test_ctor_explicit(self):
-        query = object()
-        iterator = self._makeOne(query, 13, 29)
-        self.assertTrue(iterator._query is query)
-        self.assertEqual(iterator._limit, 13)
-        self.assertEqual(iterator._offset, 29)
-
-    def test_next_page_no_cursors_no_more(self):
-        from base64 import b64encode
-        from gcloud.datastore.query import _pb_from_query
-        self._KIND = 'KIND'
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset)
-        iterator = self._makeOne(query)
-        entities, more_results, cursor = iterator.next_page()
-
-        self.assertEqual(cursor, b64encode(self._END))
-        self.assertFalse(more_results)
-        self.assertFalse(iterator._more_results)
-        self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key.path,
-                         [{'kind': self._KIND, 'id': self._ID}])
-        self.assertEqual(entities[0]['foo'], u'Foo')
-        qpb = _pb_from_query(query)
-        qpb.offset = 0
-        EXPECTED = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb,
-            'namespace': self._NAMESPACE,
-        }
-        self.assertEqual(connection._called_with, [EXPECTED])
-
-    def test_next_page_no_cursors_no_more_w_offset_and_limit(self):
-        from base64 import b64encode
-        from gcloud.datastore.query import _pb_from_query
-        self._KIND = 'KIND'
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset)
-        iterator = self._makeOne(query, 13, 29)
-        entities, more_results, cursor = iterator.next_page()
-
-        self.assertEqual(cursor, b64encode(self._END))
-        self.assertFalse(more_results)
-        self.assertFalse(iterator._more_results)
-        self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key.path,
-                         [{'kind': self._KIND, 'id': self._ID}])
-        self.assertEqual(entities[0]['foo'], u'Foo')
-        qpb = _pb_from_query(query)
-        qpb.limit = 13
-        qpb.offset = 29
-        EXPECTED = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb,
-            'namespace': self._NAMESPACE,
-        }
-        self.assertEqual(connection._called_with, [EXPECTED])
-
-    def test_next_page_w_cursors_w_more(self):
-        from base64 import b64decode
-        from base64 import b64encode
-        from gcloud.datastore.query import _pb_from_query
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset, cursor=self._END, more=True)
-        iterator = self._makeOne(query)
-        iterator._start_cursor = self._START
-        iterator._end_cursor = self._END
-        entities, more_results, cursor = iterator.next_page()
-
-        self.assertEqual(cursor, b64encode(self._END))
-        self.assertTrue(more_results)
-        self.assertTrue(iterator._more_results)
-        self.assertEqual(iterator._end_cursor, None)
-        self.assertEqual(b64decode(iterator._start_cursor), self._END)
-        self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key.path,
-                         [{'kind': self._KIND, 'id': self._ID}])
-        self.assertEqual(entities[0]['foo'], u'Foo')
-        qpb = _pb_from_query(query)
-        qpb.offset = 0
-        qpb.start_cursor = b64decode(self._START)
-        qpb.end_cursor = b64decode(self._END)
-        EXPECTED = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb,
-            'namespace': self._NAMESPACE,
-        }
-        self.assertEqual(connection._called_with, [EXPECTED])
-
-    def test_next_page_w_cursors_w_bogus_more(self):
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset, cursor=self._END, more=True)
-        epb, cursor, _ = connection._results.pop()
-        connection._results.append((epb, cursor, 4))  # invalid enum
-        iterator = self._makeOne(query)
-        self.assertRaises(ValueError, iterator.next_page)
-
-    def test___iter___no_more(self):
-        from gcloud.datastore.query import _pb_from_query
-        self._KIND = 'KIND'
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset)
-        iterator = self._makeOne(query)
-        entities = list(iterator)
-
-        self.assertFalse(iterator._more_results)
-        self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key.path,
-                         [{'kind': self._KIND, 'id': self._ID}])
-        self.assertEqual(entities[0]['foo'], u'Foo')
-        qpb = _pb_from_query(query)
-        qpb.offset = 0
-        EXPECTED = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb,
-            'namespace': self._NAMESPACE,
-        }
-        self.assertEqual(connection._called_with, [EXPECTED])
-
-    def test___iter___w_more(self):
-        from gcloud.datastore.query import _pb_from_query
-        dataset, connection = self._makeDataset()
-        query = _Query(self._KIND, dataset, self._NAMESPACE)
-        self._addQueryResults(dataset, cursor=self._END, more=True)
-        self._addQueryResults(dataset)
-        iterator = self._makeOne(query)
-        entities = list(iterator)
-
-        self.assertFalse(iterator._more_results)
-        self.assertEqual(len(entities), 2)
-        for entity in entities:
-            self.assertEqual(
-                entity.key.path,
-                [{'kind': self._KIND, 'id': self._ID}])
-            self.assertEqual(entities[1]['foo'], u'Foo')
-        qpb1 = _pb_from_query(query)
-        qpb1.offset = 0
-        qpb2 = _pb_from_query(query)
-        qpb2.offset = 0
-        qpb2.start_cursor = self._END
-        EXPECTED1 = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb1,
-            'namespace': self._NAMESPACE,
-        }
-        EXPECTED2 = {
-            'dataset_id': self._DATASET,
-            'query_pb': qpb2,
-            'namespace': self._NAMESPACE,
-        }
-        self.assertEqual(len(connection._called_with), 2)
-        self.assertEqual(connection._called_with[0], EXPECTED1)
-        self.assertEqual(connection._called_with[1], EXPECTED2)
-
-
 class _Query(object):
 
     def __init__(self,
+                 dataset_id=None,
                  kind=None,
-                 dataset=None,
                  namespace=None,
                  ancestor=None,
                  filters=(),
                  projection=(),
                  order=(),
                  group_by=()):
+        self.dataset_id = dataset_id
         self.kind = kind
-        self.dataset = dataset
         self.namespace = namespace
         self.ancestor = ancestor
         self.filters = filters

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -25,7 +25,6 @@ class TestQuery(unittest2.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_ctor_defaults_wo_implicit_dataset_id(self):
-        _DATASET = 'DATASET'
         self.assertRaises(ValueError, self._makeOne)
 
     def test_ctor_defaults_w_implicit_dataset_id(self):

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -648,19 +648,6 @@ class _Query(object):
         self.group_by = group_by
 
 
-class _Dataset(object):
-
-    def __init__(self, id, connection):
-        self._id = id
-        self._connection = connection
-
-    def id(self):
-        return self._id
-
-    def connection(self):
-        return self._connection
-
-
 class _Connection(object):
 
     _called_with = None

--- a/regression/clear_datastore.py
+++ b/regression/clear_datastore.py
@@ -35,7 +35,8 @@ TRANSACTION_MAX_GROUPS = 5
 
 def fetch_keys(dataset, kind, fetch_max=FETCH_MAX, query=None, cursor=None):
     if query is None:
-        query = Query(kind=kind, dataset=dataset, projection=['__key__'])
+        query = Query(
+            dataset_id=dataset.id(), kind=kind, projection=['__key__'])
 
     iterator = query.fetch(limit=fetch_max, start_cursor=cursor)
 


### PR DESCRIPTION
Instead, `dataset_id` and `connection` are passed in, or derived from
the implicit environ.

Fixes #485.