### PR TITLE
Putting back lint speedups for pull requests.

### DIFF
--- a/run_pylint.py
+++ b/run_pylint.py
@@ -125,9 +125,12 @@ def get_files_for_linting():
     a remote branch to diff against.
     """
     diff_base = None
-    # Temporary turning Travis diffbase off since pylint will fail on a
-    # deleted file that shows up in a diff.
-    if os.getenv('TRAVIS') is None:
+    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+            os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
+        # In the case of a pull request into master, we want to
+        # diff against HEAD in master.
+        diff_base = 'origin/master'
+    elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')
         branch = os.getenv('GCLOUD_BRANCH_FOR_LINT')


### PR DESCRIPTION
This was removed in e998859d8dba24a97be97ead6edc759c77a22375 since
it broke pylint by removing a module.