### PR TITLE
Removing dataset_id from allocate_ids and get_entities

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -205,7 +205,7 @@ def get_entities(keys, missing=None, deferred=None,
     return entities
 
 
-def allocate_ids(incomplete_key, num_ids, connection=None, dataset_id=None):
+def allocate_ids(incomplete_key, num_ids, connection=None):
     """Allocates a list of IDs from a partial key.
 
     :type incomplete_key: A :class:`gcloud.datastore.key.Key`
@@ -217,15 +217,11 @@ def allocate_ids(incomplete_key, num_ids, connection=None, dataset_id=None):
     :type connection: :class:`gcloud.datastore.connection.Connection`
     :param connection: Optional. The connection used to connect to datastore.
 
-    :type dataset_id: string
-    :param dataset_id: Optional. The ID of the dataset.
-
     :rtype: list of :class:`gcloud.datastore.key.Key`
     :returns: The (complete) keys allocated with ``incomplete_key`` as root.
     :raises: :class:`ValueError` if ``incomplete_key`` is not a partial key.
     """
     connection = _require_connection(connection)
-    dataset_id = _require_dataset_id(dataset_id)
 
     if not incomplete_key.is_partial:
         raise ValueError(('Key is not partial.', incomplete_key))
@@ -233,7 +229,8 @@ def allocate_ids(incomplete_key, num_ids, connection=None, dataset_id=None):
     incomplete_key_pb = incomplete_key.to_protobuf()
     incomplete_key_pbs = [incomplete_key_pb] * num_ids
 
-    allocated_key_pbs = connection.allocate_ids(dataset_id, incomplete_key_pbs)
+    allocated_key_pbs = connection.allocate_ids(incomplete_key.dataset_id,
+                                                incomplete_key_pbs)
     allocated_ids = [allocated_key_pb.path_element[-1].id
                      for allocated_key_pb in allocated_key_pbs]
     return [incomplete_key.completed_key(allocated_id)

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -232,8 +232,7 @@ class Key(object):
 
         # We allow partial keys to attempt a get, the backend will fail.
         connection = connection or _implicit_environ.CONNECTION
-        entities = datastore.get_entities(
-            [self], connection=connection, dataset_id=self.dataset_id)
+        entities = datastore.get_entities([self], connection=connection)
 
         if entities:
             result = entities[0]

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -358,11 +358,9 @@ class Test_get_entities_function(unittest2.TestCase):
 
 class Test_allocate_ids_function(unittest2.TestCase):
 
-    def _callFUT(self, incomplete_key, num_ids,
-                 connection=None, dataset_id=None):
+    def _callFUT(self, incomplete_key, num_ids, connection=None):
         from gcloud.datastore import allocate_ids
-        return allocate_ids(incomplete_key, num_ids, connection=connection,
-                            dataset_id=dataset_id)
+        return allocate_ids(incomplete_key, num_ids, connection=connection)
 
     def test_allocate_ids(self):
         from gcloud.datastore.key import Key
@@ -372,8 +370,7 @@ class Test_allocate_ids_function(unittest2.TestCase):
         INCOMPLETE_KEY = Key('KIND', dataset_id=DATASET_ID)
         CONNECTION = _Connection()
         NUM_IDS = 2
-        result = self._callFUT(INCOMPLETE_KEY, NUM_IDS,
-                               connection=CONNECTION, dataset_id=DATASET_ID)
+        result = self._callFUT(INCOMPLETE_KEY, NUM_IDS, connection=CONNECTION)
 
         # Check the IDs returned match.
         self.assertEqual([key.id for key in result], range(NUM_IDS))


### PR DESCRIPTION
Since we require `Key` to have a dataset ID, these methods should not be allowed to ignore this value.

For `allocate_ids` this is cut and dry but for `get_entities` we may want to allow the user to provide `dataset_id` since there are potentially **many** keys to check. (Performance sensitive.)

--------

@pcostell 

In the `get_entities` change, we check that the `dataset_id` of every `Key` in a list is identical.

This can cause all kinds of trouble, just in comparing prefixed and un-prefixed alone. Do you think this check can be avoided? Due to GoogleCloudPlatform/google-cloud-datastore#59 it's not possible to just set the dataset ID on the `Key` protobuf and let the backend do the checking for us.

OTOH, creating the protobufs for each `Key` will be the same O(n) work that checking the dataset IDs will, so maybe the performance cost is negligible?