### PR TITLE
Remove Key.get() and Entity.reload()

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -107,8 +107,8 @@ def get_connection():
     >>> connection = datastore.get_connection()
     >>> key1 = Key('Kind', 1234, dataset_id='dataset1')
     >>> key2 = Key('Kind', 1234, dataset_id='dataset2')
-    >>> entity1 = key1.get(connection=connection)
-    >>> entity2 = key2.get(connection=connection)
+    >>> entity1 = datastore.get(key1, connection=connection)
+    >>> entity2 = datastore.get(key2, connection=connection)
 
     :rtype: :class:`gcloud.datastore.connection.Connection`
     :returns: A connection defined with the proper credentials.

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -166,14 +166,13 @@ class Connection(connection.Connection):
         This method deals only with protobufs
         (:class:`gcloud.datastore.datastore_v1_pb2.Key` and
         :class:`gcloud.datastore.datastore_v1_pb2.Entity`) and is used
-        under the hood for methods like
-        :meth:`gcloud.datastore.key.Key.get`:
+        under the hood in :func:`gcloud.datastore.get`:
 
         >>> from gcloud import datastore
         >>> from gcloud.datastore.key import Key
         >>> datastore.set_default_connection()
         >>> key = Key('MyKind', 1234, dataset_id='dataset-id')
-        >>> key.get()
+        >>> datastore.get(key)
         <Entity object>
 
         Using the ``connection`` class directly:

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -40,9 +40,9 @@ class Entity(dict):
     This means you could take an existing entity and change the key
     to duplicate the object.
 
-    Use :meth:`gcloud.datastore.key.Key.get` to retrieve an existing entity.
+    Use :func:`gcloud.datastore.get` to retrieve an existing entity.
 
-      >>> key.get()
+      >>> datastore.get(key)
       <Entity[{'kind': 'EntityKind', id: 1234}] {'property': 'value'}>
 
     You can the set values on the entity just like you would on any
@@ -115,29 +115,6 @@ class Entity(dict):
         if self.key is None:
             raise NoKey()
         return self.key
-
-    def reload(self, connection=None):
-        """Reloads the contents of this entity from the datastore.
-
-        This method takes the :class:`gcloud.datastore.key.Key`, loads all
-        properties from the Cloud Datastore, and sets the updated properties on
-        the current object.
-
-        .. warning::
-          This will override any existing properties if a different value
-          exists remotely, however it will *not* override any properties that
-          exist only locally.
-
-        :type connection: :class:`gcloud.datastore.connection.Connection`
-        :param connection: Optional connection used to connect to datastore.
-        """
-        connection = connection or _implicit_environ.CONNECTION
-
-        key = self._must_key
-        entity = key.get(connection=connection)
-
-        if entity:
-            self.update(entity)
 
     def save(self, connection=None):
         """Save the entity in the Cloud Datastore.

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -217,29 +217,6 @@ class Key(object):
 
         return key
 
-    def get(self, connection=None):
-        """Retrieve entity corresponding to the current key.
-
-        :type connection: :class:`gcloud.datastore.connection.Connection`
-        :param connection: Optional connection used to connect to datastore.
-
-        :rtype: :class:`gcloud.datastore.entity.Entity` or :class:`NoneType`
-        :returns: The requested entity, or ``None`` if there was no
-                  match found.
-        """
-        # Temporary cylic import, needs to be removed.
-        from gcloud.datastore import api
-
-        # We allow partial keys to attempt a get, the backend will fail.
-        connection = connection or _implicit_environ.CONNECTION
-        entities = api.get([self], connection=connection)
-
-        if entities:
-            result = entities[0]
-            # We assume that the backend has not changed the key.
-            result.key = self
-            return result
-
     def delete(self, connection=None):
         """Delete the key in the Cloud Datastore.
 

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -59,32 +59,6 @@ class TestEntity(unittest2.TestCase):
         entity = self._makeOne()
         self.assertRaises(NoKey, getattr, entity, '_must_key')
 
-    def test_reload_no_key(self):
-        from gcloud.datastore.entity import NoKey
-
-        entity = self._makeOne()
-        entity['foo'] = 'Foo'
-        self.assertRaises(NoKey, entity.reload)
-
-    def test_reload_miss(self):
-        key = _Key()
-        key._stored = None  # Explicit miss.
-        entity = self._makeOne(key=key)
-        entity['foo'] = 'Foo'
-        # Does not raise, does not update on miss.
-        entity.reload()
-        self.assertEqual(entity['foo'], 'Foo')
-
-    def test_reload_hit(self):
-        key = _Key()
-        NEW_VAL = 'Baz'
-        key._stored = {'foo': NEW_VAL}
-        entity = self._makeOne(key=key)
-        entity['foo'] = 'Foo'
-        entity.reload()
-        self.assertEqual(entity['foo'], NEW_VAL)
-        self.assertEqual(entity.keys(), ['foo'])
-
     def test_save_no_key(self):
         from gcloud.datastore.entity import NoKey
 
@@ -185,10 +159,6 @@ class _Key(object):
     @property
     def path(self):
         return self._path
-
-    def get(self, connection=None):
-        self._connection_used = connection
-        return self._stored
 
 
 class _Connection(object):

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -232,62 +232,6 @@ class TestKey(unittest2.TestCase):
         pb = key.to_protobuf()
         self.assertFalse(pb.path_element[0].HasField('kind'))
 
-    def test_get_explicit_connection_miss(self):
-        from gcloud.datastore.test_connection import _Connection
-
-        cnxn_lookup_result = []
-        cnxn = _Connection(*cnxn_lookup_result)
-        key = self._makeOne('KIND', 1234, dataset_id=self._DEFAULT_DATASET)
-        entity = key.get(connection=cnxn)
-        self.assertEqual(entity, None)
-
-    def test_get_implicit_connection_miss(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
-        from gcloud.datastore.test_connection import _Connection
-
-        cnxn_lookup_result = []
-        cnxn = _Connection(*cnxn_lookup_result)
-        key = self._makeOne('KIND', 1234, dataset_id=self._DEFAULT_DATASET)
-        with _Monkey(_implicit_environ, CONNECTION=cnxn):
-            entity = key.get()
-        self.assertEqual(entity, None)
-
-    def test_get_explicit_connection_hit(self):
-        from gcloud.datastore import datastore_v1_pb2
-        from gcloud.datastore.test_connection import _Connection
-
-        KIND = 'KIND'
-        ID = 1234
-
-        # Make a bogus entity PB to be returned from fake Connection.
-        entity_pb = datastore_v1_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = self._DEFAULT_DATASET
-        path_element = entity_pb.key.path_element.add()
-        path_element.kind = KIND
-        path_element.id = ID
-        prop = entity_pb.property.add()
-        prop.name = 'foo'
-        prop.value.string_value = 'Foo'
-
-        # Make fake connection.
-        cnxn_lookup_result = [entity_pb]
-        cnxn = _Connection(*cnxn_lookup_result)
-
-        # Create key and look-up.
-        key = self._makeOne(KIND, ID, dataset_id=self._DEFAULT_DATASET)
-        entity = key.get(connection=cnxn)
-        self.assertEqual(entity.items(), [('foo', 'Foo')])
-        self.assertTrue(entity.key is key)
-
-    def test_get_no_connection(self):
-        from gcloud.datastore import _implicit_environ
-
-        self.assertEqual(_implicit_environ.CONNECTION, None)
-        key = self._makeOne('KIND', 1234, dataset_id=self._DEFAULT_DATASET)
-        with self.assertRaises(EnvironmentError):
-            key.get()
-
     def test_delete_explicit_connection(self):
         from gcloud.datastore.test_connection import _Connection
 

--- a/pylintrc_default
+++ b/pylintrc_default
@@ -73,8 +73,6 @@ ignore =
 #                  identical implementation but different docstrings.
 # - star-args:  standard Python idioms for varargs:
 #                  ancestor = Query().filter(*order_props)
-# - cyclic-import:  temporary workaround to support Key.get until Dataset
-#                   is removed in #477.
 disable =
     maybe-no-member,
     no-member,
@@ -82,7 +80,6 @@ disable =
     redefined-builtin,
     similarities,
     star-args,
-    cyclic-import,
 
 
 [REPORTS]


### PR DESCRIPTION
Has #521 as diffbase.

Removed `Entity.reload()` because it relied on the existence of `Key.get()`. Replacing it would have required another cyclic import.
    
See #490 RE: removing `Entity.reload()`.

Fixes #517.