### PR TITLE
Adding umbrella datastore.set_defaults().

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ with the Cloud Datastore using this Client Library.
 .. code:: python
 
     from gcloud import datastore
-    datastore.set_default_connection()
-    datastore.set_default_dataset_id()
+    datastore.set_defaults()
     # Then do other things...
     from gcloud.datastore.entity import Entity
     from gcloud.datastore.key import Key

--- a/docs/_components/datastore-getting-started.rst
+++ b/docs/_components/datastore-getting-started.rst
@@ -38,8 +38,7 @@ Add some data to your dataset
 Open a Python console and...
 
   >>> from gcloud import datastore
-  >>> datastore.set_default_connection()
-  >>> datastore.set_default_dataset_id('<your-dataset-id>')
+  >>> datastore.set_defaults()
   >>> from gcloud.datastore.query import Query
   >>> list(Query(kind='Person').fetch())
   []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,8 +29,7 @@ Cloud Datastore
 .. code-block:: python
 
   from gcloud import datastore
-  datastore.set_default_connection()
-  datastore.set_default_dataset_id('<dataset-id>')
+  datastore.set_defaults()
 
   from gcloud.datastore.entity import Entity
   from gcloud.datastore.key import Key

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -21,8 +21,7 @@ You'll typically use these to get started with the API:
 >>> from gcloud.datastore.key import Key
 >>> from gcloud.datastore.query import Query
 
->>> datastore.set_default_connection()
->>> datastore.set_default_dataset_id()
+>>> datastore.set_defaults()
 
 >>> key = Key('EntityKind', 1234)
 >>> entity = Entity(key)
@@ -93,6 +92,26 @@ def set_default_connection(connection=None):
     """
     connection = connection or get_connection()
     _implicit_environ.CONNECTION = connection
+
+
+def set_defaults(dataset_id=None, connection=None):
+    """Set defaults either explicitly or implicitly as fall-back.
+
+    Uses the arguments to call the individual default methods
+    - set_default_dataset_id
+    - set_default_connection
+
+    In the future we will likely enable methods like
+    - set_default_namespace
+
+    :type dataset_id: string
+    :param dataset_id: Optional. The dataset ID to use as default.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: A connection provided to be the default.
+    """
+    set_default_dataset_id(dataset_id=dataset_id)
+    set_default_connection(connection=connection)
 
 
 def get_connection():

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -170,7 +170,7 @@ class Connection(connection.Connection):
 
         >>> from gcloud import datastore
         >>> from gcloud.datastore.key import Key
-        >>> datastore.set_default_connection()
+        >>> datastore.set_defaults()
         >>> key = Key('MyKind', 1234, dataset_id='dataset-id')
         >>> datastore.get(key)
         <Entity object>
@@ -263,8 +263,7 @@ class Connection(connection.Connection):
         >>> from gcloud import datastore
         >>> from gcloud.datastore.query import Query
 
-        >>> datastore.set_default_connection()
-        >>> datastore.set_default_dataset_id()
+        >>> datastore.set_defaults()
 
         >>> query = Query(kind='MyKind')
         >>> query.add_filter('property', '=', 'val')

--- a/gcloud/datastore/demo/__init__.py
+++ b/gcloud/datastore/demo/__init__.py
@@ -23,5 +23,4 @@ DATASET_ID = os.getenv('GCLOUD_TESTS_DATASET_ID')
 
 
 def initialize():
-    datastore.set_default_connection()
-    datastore.set_default_dataset_id(DATASET_ID)
+    datastore.set_defaults(dataset_id=DATASET_ID)

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -116,6 +116,37 @@ class Test_set_default_connection(unittest2.TestCase):
         self.assertEqual(_implicit_environ.CONNECTION, fake_cnxn)
 
 
+class Test_set_defaults(unittest2.TestCase):
+
+    def _callFUT(self, dataset_id=None, connection=None):
+        from gcloud.datastore import set_defaults
+        return set_defaults(dataset_id=dataset_id, connection=connection)
+
+    def test_it(self):
+        from gcloud._testing import _Monkey
+        from gcloud import datastore
+
+        DATASET_ID = object()
+        CONNECTION = object()
+
+        SET_DATASET_CALLED = []
+
+        def call_set_dataset(dataset_id=None):
+            SET_DATASET_CALLED.append(dataset_id)
+
+        SET_CONNECTION_CALLED = []
+
+        def call_set_connection(connection=None):
+            SET_CONNECTION_CALLED.append(connection)
+
+        with _Monkey(datastore, set_default_dataset_id=call_set_dataset,
+                     set_default_connection=call_set_connection):
+            self._callFUT(dataset_id=DATASET_ID, connection=CONNECTION)
+
+        self.assertEqual(SET_DATASET_CALLED, [DATASET_ID])
+        self.assertEqual(SET_CONNECTION_CALLED, [CONNECTION])
+
+
 class Test_get_connection(unittest2.TestCase):
 
     def _callFUT(self):

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -30,8 +30,7 @@ class Transaction(Batch):
       >>> from gcloud import datastore
       >>> from gcloud.datastore.transaction import Transaction
 
-      >>> datastore.set_default_connection()
-      >>> datastore.set_default_dataset_id()
+      >>> datastore.set_defaults()
 
       >>> with Transaction()
       ...     entity1.save()

--- a/regression/clear_datastore.py
+++ b/regression/clear_datastore.py
@@ -23,8 +23,7 @@ from six.moves import input
 
 
 datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_default_dataset_id()
-datastore.set_default_connection()
+datastore.set_defaults()
 
 
 FETCH_MAX = 20

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -27,8 +27,7 @@ from regression import populate_datastore
 
 
 datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_default_dataset_id()
-datastore.set_default_connection()
+datastore.set_defaults()
 
 
 class TestDatastore(unittest2.TestCase):

--- a/regression/populate_datastore.py
+++ b/regression/populate_datastore.py
@@ -23,8 +23,7 @@ from gcloud.datastore.transaction import Transaction
 
 
 datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_default_dataset_id()
-datastore.set_default_connection()
+datastore.set_defaults()
 
 
 ANCESTOR = ('Book', 'GoT')


### PR DESCRIPTION
This will be the most common auth / setup path for typical users.

It may make sense at some point to create a config class in [`datastore/_implicit_environ.py`][1] to allow lots of config at once / swappable setting for multi-tenant applications.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/blob/0525530ad7a76e408ca2e842b883d49c353ed56d/gcloud/datastore/_implicit_environ.py