### PR TITLE
Attempt retry hook for flaky regression test cases.

### DIFF
--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -20,6 +20,7 @@ from gcloud import datastore
 # This assumes the command is being run via tox hence the
 # repository root is the current directory.
 from regression import populate_datastore
+from regression.regression_utils import RetryTestsMetaclass
 
 
 datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
@@ -27,6 +28,8 @@ datastore.set_defaults()
 
 
 class TestDatastore(unittest2.TestCase):
+
+    __metaclass__ = RetryTestsMetaclass
 
     def setUp(self):
         self.case_entities_to_delete = []

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -80,7 +80,8 @@ class TestDatastoreSave(TestDatastore):
 
     def _generic_test_post(self, name=None, key_id=None):
         entity = self._get_post(id_or_name=(name or key_id))
-        datastore.put([entity])
+        with datastore.Transaction():
+            datastore.put([entity])
 
         # Register entity to be deleted.
         self.case_entities_to_delete.append(entity)
@@ -149,7 +150,8 @@ class TestDatastoreSaveKeys(TestDatastore):
         entity['fullName'] = u'Full name'
         entity['linkedTo'] = key  # Self reference.
 
-        datastore.put([entity])
+        with datastore.Transaction():
+            datastore.put([entity])
         self.case_entities_to_delete.append(entity)
 
         query = datastore.Query(kind='Person')

--- a/regression/regression_utils.py
+++ b/regression/regression_utils.py
@@ -18,6 +18,7 @@ import sys
 import types
 
 from gcloud import storage
+from gcloud.storage.exceptions import NotFound
 
 
 # From shell environ. May be None.
@@ -35,7 +36,7 @@ Please check the Contributing guide for instructions.
 class RetryTestsMetaclass(type):
 
     NUM_RETRIES = 2
-    FLAKY_ERROR_CLASSES = (AssertionError,)
+    FLAKY_ERROR_CLASSES = (AssertionError, NotFound)
 
     @staticmethod
     def _wrap_class_attr(class_attr):

--- a/regression/regression_utils.py
+++ b/regression/regression_utils.py
@@ -36,7 +36,7 @@ Please check the Contributing guide for instructions.
 class RetryTestsMetaclass(type):
 
     NUM_RETRIES = 2
-    FLAKY_ERROR_CLASSES = (AssertionError, NotFound)
+    FLAKY_ERROR_CLASSES = (NotFound,)
 
     @staticmethod
     def _wrap_class_attr(class_attr):

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -47,6 +47,8 @@ def tearDownModule():
 
 class TestStorage(unittest2.TestCase):
 
+    __metaclass__ = regression_utils.RetryTestsMetaclass
+
     @classmethod
     def setUpClass(cls):
         cls.connection = regression_utils.get_storage_connection()


### PR DESCRIPTION
Fixes #531.

To "test" that this works, feel free to add a test case like:

```python
    x = 0

    def test_retry(self):
        # Feel free to vary 3 higher and higher, should always be
        # NUM_RETRIES in the final error message.
        if self.x < 3:
            self.x += 1
            self.assertEqual(self.x, object())  # Fails
        else:
            self.assertTrue(True)
```