### PR TITLE
#514: add `datastore.put` API, remove `Entity.save'

### DIFF
--- a/docs/_components/datastore-getting-started.rst
+++ b/docs/_components/datastore-getting-started.rst
@@ -44,7 +44,7 @@ Open a Python console and...
   >>> entity = datastore.Entity(key=datastore.Key('Person'))
   >>> entity['name'] = 'Your name'
   >>> entity['age'] = 25
-  >>> entity.save()
+  >>> datastore.put([entity])
   >>> list(Query(kind='Person').fetch())
   [<Entity{...} {'name': 'Your name', 'age': 25}>]
 

--- a/docs/_components/datastore-quickstart.rst
+++ b/docs/_components/datastore-quickstart.rst
@@ -58,7 +58,7 @@ you can create entities and save them::
   >>> entity = datastore.Entity(key=datastore.Key('Person'))
   >>> entity['name'] = 'Your name'
   >>> entity['age'] = 25
-  >>> entity.save()
+  >>> datastore.put([entity])
   >>> list(datastore.Query(kind='Person').fetch())
   [<Entity{...} {'name': 'Your name', 'age': 25}>]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Cloud Datastore
   entity = datastore.Entity(key=datastore.Key('Person'))
   entity['name'] = 'Your name'
   entity['age'] = 25
-  entity.save()
+  datastore.put([entity])
 
 Cloud Storage
 ~~~~~~~~~~~~~

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -53,6 +53,7 @@ from gcloud.datastore import _implicit_environ
 from gcloud.datastore.api import allocate_ids
 from gcloud.datastore.api import delete
 from gcloud.datastore.api import get
+from gcloud.datastore.api import put
 from gcloud.datastore.batch import Batch
 from gcloud.datastore.connection import Connection
 from gcloud.datastore.entity import Entity

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -70,6 +70,9 @@ def _get_dataset_id_from_keys(keys):
     :returns: The dataset ID of the keys.
     :raises: :class:`ValueError` if the key dataset IDs don't agree.
     """
+    if any(key is None for key in keys):
+        raise ValueError('None not allowed')
+
     dataset_id = keys[0].dataset_id
     # Rather than creating a list or set of all dataset IDs, we iterate
     # and check. We could allow the backend to check this for us if IDs

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -133,6 +133,32 @@ def get(keys, missing=None, deferred=None, connection=None):
     return entities
 
 
+def put(entities, connection=None):
+    """Save the entities in the Cloud Datastore.
+
+    :type entities: list of :class:`gcloud.datastore.entity.Entity`
+    :param entities: The entities to be saved to the datastore.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: Optional connection used to connect to datastore.
+    """
+    if not entities:
+        return
+
+    connection = connection or _implicit_environ.CONNECTION
+
+    current = _BATCHES.top
+    in_batch = current is not None
+    if not in_batch:
+        keys = [entity.key for entity in entities]
+        dataset_id = _get_dataset_id_from_keys(keys)
+        current = Batch(dataset_id=dataset_id, connection=connection)
+    for entity in entities:
+        current.put(entity)
+    if not in_batch:
+        current.commit()
+
+
 def delete(keys, connection=None):
     """Delete the keys in the Cloud Datastore.
 

--- a/gcloud/datastore/demo/demo.py
+++ b/gcloud/datastore/demo/demo.py
@@ -28,7 +28,7 @@ toy = datastore.Entity(key)
 toy.update({'name': 'Toy'})
 
 # Now let's save it to our datastore:
-toy.save()
+datastore.put([toy])
 
 # If we look it up by its key, we should find it...
 print(datastore.get([toy.key]))
@@ -55,7 +55,7 @@ for id, name, age in SAMPLE_DATA:
     entity = datastore.Entity(key)
     entity['name'] = name
     entity['age'] = age
-    entity.save()
+    datastore.put([entity])
 # We'll start by look at all Thing entities:
 query = datastore.Query(kind='Thing')
 
@@ -76,18 +76,18 @@ datastore.delete(sample_keys)
 
 # You can also work inside a transaction.
 # (Check the official docs for explanations of what's happening here.)
-with datastore.Transaction():
+with datastore.Transaction() as xact:
     print('Creating and saving an entity...')
     key = datastore.Key('Thing', 'foo')
     thing = datastore.Entity(key)
     thing['age'] = 10
-    thing.save()
+    xact.put(thing)
 
     print('Creating and saving another entity...')
     key2 = datastore.Key('Thing', 'bar')
     thing2 = datastore.Entity(key2)
     thing2['age'] = 15
-    thing2.save()
+    xact.put(thing2)
 
     print('Committing the transaction...')
 
@@ -95,11 +95,11 @@ with datastore.Transaction():
 datastore.delete([key, key2])
 
 # To rollback a transaction, just call .rollback()
-with datastore.Transaction() as t:
+with datastore.Transaction() as xact:
     key = datastore.Key('Thing', 'another')
     thing = datastore.Entity(key)
-    thing.save()
-    t.rollback()
+    xact.put(thing)
+    xact.rollback()
 
 # Let's check if the entity was actually created:
 created = datastore.get([key])
@@ -107,10 +107,10 @@ print('yes' if created else 'no')
 
 # Remember, a key won't be complete until the transaction is commited.
 # That is, while inside the transaction block, thing.key will be incomplete.
-with datastore.Transaction():
+with datastore.Transaction() as xact:
     key = datastore.Key('Thing')  # partial
     thing = datastore.Entity(key)
-    thing.save()
+    xact.put(thing)
     print(thing.key)  # This will still be partial
 
 print(thing.key)  # This will be complete

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -65,7 +65,7 @@ class Entity(dict):
 
     :type key: :class:`gcloud.datastore.key.Key`
     :param key: Optional key to be set on entity. Required for
-                :fund:`gcloud.datastore.put()`
+                :func:`gcloud.datastore.put()`
 
     :type exclude_from_indexes: tuple of string
     :param exclude_from_indexes: Names of fields whose values are not to be

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -15,10 +15,6 @@
 """Class for representing a single entity in the Cloud Datastore."""
 
 
-class NoKey(RuntimeError):
-    """Exception raised by Entity methods which require a key."""
-
-
 class Entity(dict):
     """Entities are akin to rows in a relational database
 

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -14,8 +14,6 @@
 
 """Class for representing a single entity in the Cloud Datastore."""
 
-from gcloud.datastore import _implicit_environ
-
 
 class NoKey(RuntimeError):
     """Exception raised by Entity methods which require a key."""
@@ -70,8 +68,8 @@ class Entity(dict):
        any decoding / encoding step.
 
     :type key: :class:`gcloud.datastore.key.Key`
-    :param key: Optional key to be set on entity. Required for :meth:`save()`
-                or :meth:`reload()`.
+    :param key: Optional key to be set on entity. Required for
+                :fund:`gcloud.datastore.put()`
 
     :type exclude_from_indexes: tuple of string
     :param exclude_from_indexes: Names of fields whose values are not to be
@@ -103,55 +101,6 @@ class Entity(dict):
         :rtype: sequence of field names
         """
         return frozenset(self._exclude_from_indexes)
-
-    @property
-    def _must_key(self):
-        """Return our key, or raise NoKey if not set.
-
-        :rtype: :class:`gcloud.datastore.key.Key`.
-        :returns: The entity's key.
-        :raises: :class:`NoKey` if no key is set.
-        """
-        if self.key is None:
-            raise NoKey()
-        return self.key
-
-    def save(self, connection=None):
-        """Save the entity in the Cloud Datastore.
-
-        .. note::
-           Any existing properties for the entity will be replaced by those
-           currently set on this instance.  Already-stored properties which do
-           not correspond to keys set on this instance will be removed from
-           the datastore.
-
-        .. note::
-           Property values which are "text" (``unicode`` in Python2, ``str`` in
-           Python3) map to 'string_value' in the datastore;  values which are
-           "bytes" (``str`` in Python2, ``bytes`` in Python3) map to
-           'blob_value'.
-
-        :type connection: :class:`gcloud.datastore.connection.Connection`
-        :param connection: Optional connection used to connect to datastore.
-        """
-        connection = connection or _implicit_environ.CONNECTION
-
-        key = self._must_key
-        assigned, new_id = connection.save_entity(
-            dataset_id=key.dataset_id,
-            key_pb=key.to_protobuf(),
-            properties=dict(self),
-            exclude_from_indexes=self.exclude_from_indexes)
-
-        # If we are in a transaction and the current entity needs an
-        # automatically assigned ID, tell the transaction where to put that.
-        transaction = connection.transaction()
-        if transaction and key.is_partial:
-            transaction.add_auto_id_entity(self)
-
-        if assigned:
-            # Update the key (which may have been altered).
-            self.key = self.key.completed_key(new_id)
 
     def __repr__(self):
         if self.key:

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -90,6 +90,29 @@ class Test__require_connection(unittest2.TestCase):
             self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
 
 
+class Test__get_dataset_id_from_keys(unittest2.TestCase):
+
+    def _callFUT(self, keys):
+        from gcloud.datastore.api import _get_dataset_id_from_keys
+        return _get_dataset_id_from_keys(keys)
+
+    def test_empty(self):
+        self.assertRaises(IndexError, self._callFUT, [])
+
+    def test_w_None(self):
+        self.assertRaises(ValueError, self._callFUT, [None])
+
+    def test_w_mismatch(self):
+        foo = _Key('foo')
+        bar = _Key('bar')
+        self.assertRaises(ValueError, self._callFUT, [foo, bar])
+
+    def test_w_match(self):
+        foo1 = _Key('foo')
+        foo2 = _Key('foo')
+        self.assertEqual(self._callFUT([foo1, foo2]), 'foo')
+
+
 class Test_get_function(unittest2.TestCase):
 
     def _callFUT(self, keys, missing=None, deferred=None, connection=None):
@@ -552,3 +575,8 @@ class Test_allocate_ids_function(unittest2.TestCase):
             COMPLETE_KEY = Key('KIND', 1234)
             self.assertRaises(ValueError, self._callFUT,
                               COMPLETE_KEY, 2)
+
+
+class _Key(object):
+    def __init__(self, dataset_id):
+        self.dataset_id = dataset_id

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -30,30 +30,30 @@ class Test__require_dataset_id(unittest2.TestCase):
         from gcloud._testing import _Monkey
         return _Monkey(_implicit_environ, DATASET_ID=dataset_id)
 
-    def test__require_dataset_implicit_unset(self):
+    def test_implicit_unset(self):
         with self._monkey(None):
             with self.assertRaises(EnvironmentError):
                 self._callFUT()
 
-    def test__require_dataset_implicit_unset_passed_explicitly(self):
+    def test_implicit_unset_passed_explicitly(self):
         ID = 'DATASET'
         with self._monkey(None):
             self.assertEqual(self._callFUT(ID), ID)
 
-    def test__require_dataset_id_implicit_set(self):
+    def test_id_implicit_set(self):
         IMPLICIT_ID = 'IMPLICIT'
         with self._monkey(IMPLICIT_ID):
             stored_id = self._callFUT()
         self.assertTrue(stored_id is IMPLICIT_ID)
 
-    def test__require_dataset_id_implicit_set_passed_explicitly(self):
+    def test_id_implicit_set_passed_explicitly(self):
         ID = 'DATASET'
         IMPLICIT_ID = 'IMPLICIT'
         with self._monkey(IMPLICIT_ID):
             self.assertEqual(self._callFUT(ID), ID)
 
 
-class Test_require_connection(unittest2.TestCase):
+class Test__require_connection(unittest2.TestCase):
 
     _MARKER = object()
 
@@ -68,22 +68,22 @@ class Test_require_connection(unittest2.TestCase):
         from gcloud._testing import _Monkey
         return _Monkey(_implicit_environ, CONNECTION=connection)
 
-    def test__require_connection_implicit_unset(self):
+    def test_implicit_unset(self):
         with self._monkey(None):
             with self.assertRaises(EnvironmentError):
                 self._callFUT()
 
-    def test__require_connection_implicit_unset_passed_explicitly(self):
+    def test_implicit_unset_passed_explicitly(self):
         CONNECTION = object()
         with self._monkey(None):
             self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
 
-    def test__require_connection_implicit_set(self):
+    def test_implicit_set(self):
         IMPLICIT_CONNECTION = object()
         with self._monkey(IMPLICIT_CONNECTION):
             self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
 
-    def test__require_connection_implicit_set_passed_explicitly(self):
+    def test_implicit_set_passed_explicitly(self):
         IMPLICIT_CONNECTION = object()
         CONNECTION = object()
         with self._monkey(IMPLICIT_CONNECTION):
@@ -97,11 +97,11 @@ class Test_get_function(unittest2.TestCase):
         return get(keys, missing=missing, deferred=deferred,
                    connection=connection)
 
-    def test_get_no_keys(self):
+    def test_no_keys(self):
         results = self._callFUT([])
         self.assertEqual(results, [])
 
-    def test_get_miss(self):
+    def test_miss(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
 
@@ -111,7 +111,7 @@ class Test_get_function(unittest2.TestCase):
         results = self._callFUT([key], connection=connection)
         self.assertEqual(results, [])
 
-    def test_get_miss_w_missing(self):
+    def test_miss_w_missing(self):
         from gcloud.datastore import datastore_v1_pb2 as datastore_pb
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
@@ -138,7 +138,7 @@ class Test_get_function(unittest2.TestCase):
         self.assertEqual([missed.key.to_protobuf() for missed in missing],
                          [key.to_protobuf()])
 
-    def test_get_miss_w_deferred(self):
+    def test_miss_w_deferred(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
 
@@ -172,7 +172,7 @@ class Test_get_function(unittest2.TestCase):
 
         return entity_pb
 
-    def test_get_hit(self):
+    def test_hit(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
 
@@ -199,7 +199,7 @@ class Test_get_function(unittest2.TestCase):
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
-    def test_get_hit_multiple_keys_same_dataset(self):
+    def test_hit_multiple_keys_same_dataset(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
 
@@ -226,7 +226,7 @@ class Test_get_function(unittest2.TestCase):
         self.assertEqual(retrieved2.key.path, key2.path)
         self.assertEqual(dict(retrieved2), {})
 
-    def test_get_hit_multiple_keys_different_dataset(self):
+    def test_hit_multiple_keys_different_dataset(self):
         from gcloud.datastore.key import Key
 
         DATASET_ID1 = 'DATASET'
@@ -240,7 +240,7 @@ class Test_get_function(unittest2.TestCase):
         with self.assertRaises(ValueError):
             self._callFUT([key1, key2], connection=object())
 
-    def test_get_implicit(self):
+    def test_implicit(self):
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
@@ -284,7 +284,7 @@ class Test_delete_function(unittest2.TestCase):
         from gcloud.datastore.api import delete
         return delete(keys, connection=connection)
 
-    def test_delete_no_batch(self):
+    def test_no_batch(self):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Key
 
@@ -296,7 +296,7 @@ class Test_delete_function(unittest2.TestCase):
         result = self._callFUT([key], connection=connection)
         self.assertEqual(result, None)
 
-    def test_delete_existing_batch(self):
+    def test_existing_batch(self):
         from gcloud._testing import _Monkey
         from gcloud.datastore import api
         from gcloud.datastore.batch import _Batches
@@ -324,7 +324,7 @@ class Test_delete_function(unittest2.TestCase):
         self.assertEqual(len(deletes), 1)
         self.assertEqual(deletes[0], key._key)
 
-    def test_delete_implicit_connection(self):
+    def test_implicit_connection(self):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore import api
@@ -354,14 +354,14 @@ class Test_delete_function(unittest2.TestCase):
         self.assertEqual(len(deletes), 1)
         self.assertEqual(deletes[0], key._key)
 
-    def test_delete_no_keys(self):
+    def test_no_keys(self):
         from gcloud.datastore import _implicit_environ
 
         self.assertEqual(_implicit_environ.CONNECTION, None)
         result = self._callFUT([])
         self.assertEqual(result, None)
 
-    def test_delete_no_connection(self):
+    def test_no_connection(self):
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore.test_batch import _Key
 
@@ -380,7 +380,7 @@ class Test_allocate_ids_function(unittest2.TestCase):
         from gcloud.datastore.api import allocate_ids
         return allocate_ids(incomplete_key, num_ids, connection=connection)
 
-    def test_allocate_ids(self):
+    def test_w_explicit_connection(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
 
@@ -397,7 +397,7 @@ class Test_allocate_ids_function(unittest2.TestCase):
         self.assertEqual(CONNECTION._called_dataset_id, DATASET_ID)
         self.assertEqual(len(CONNECTION._called_key_pbs), NUM_IDS)
 
-    def test_allocate_ids_implicit(self):
+    def test_w_implicit_connection(self):
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
@@ -413,7 +413,7 @@ class Test_allocate_ids_function(unittest2.TestCase):
         # Check the IDs returned.
         self.assertEqual([key.id for key in result], range(NUM_IDS))
 
-    def test_allocate_ids_with_complete(self):
+    def test_with_already_completed_key(self):
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -295,6 +295,10 @@ class Test_delete_function(unittest2.TestCase):
 
         result = self._callFUT([key], connection=connection)
         self.assertEqual(result, None)
+        self.assertEqual(len(connection._committed), 1)
+        dataset_id, mutation = connection._committed[0]
+        self.assertEqual(dataset_id, _DATASET)
+        self.assertEqual(list(mutation.delete), [key.to_protobuf()])
 
     def test_existing_batch(self):
         from gcloud._testing import _Monkey
@@ -323,6 +327,7 @@ class Test_delete_function(unittest2.TestCase):
         deletes = list(CURR_BATCH.mutation.delete)
         self.assertEqual(len(deletes), 1)
         self.assertEqual(deletes[0], key._key)
+        self.assertEqual(len(connection._committed), 0)
 
     def test_implicit_connection(self):
         from gcloud._testing import _Monkey
@@ -353,6 +358,7 @@ class Test_delete_function(unittest2.TestCase):
         deletes = list(CURR_BATCH.mutation.delete)
         self.assertEqual(len(deletes), 1)
         self.assertEqual(deletes[0], key._key)
+        self.assertEqual(len(connection._committed), 0)
 
     def test_no_keys(self):
         from gcloud.datastore import _implicit_environ

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -96,6 +96,14 @@ class Test__get_dataset_id_from_keys(unittest2.TestCase):
         from gcloud.datastore.api import _get_dataset_id_from_keys
         return _get_dataset_id_from_keys(keys)
 
+    def _make_key(self, dataset_id):
+
+        class _Key(object):
+            def __init__(self, dataset_id):
+                self.dataset_id = dataset_id
+
+        return _Key(dataset_id)
+
     def test_empty(self):
         self.assertRaises(IndexError, self._callFUT, [])
 
@@ -103,14 +111,14 @@ class Test__get_dataset_id_from_keys(unittest2.TestCase):
         self.assertRaises(ValueError, self._callFUT, [None])
 
     def test_w_mismatch(self):
-        foo = _Key('foo')
-        bar = _Key('bar')
-        self.assertRaises(ValueError, self._callFUT, [foo, bar])
+        key1 = self._make_key('foo')
+        key2 = self._make_key('bar')
+        self.assertRaises(ValueError, self._callFUT, [key1, key2])
 
     def test_w_match(self):
-        foo1 = _Key('foo')
-        foo2 = _Key('foo')
-        self.assertEqual(self._callFUT([foo1, foo2]), 'foo')
+        key1 = self._make_key('foo')
+        key2 = self._make_key('foo')
+        self.assertEqual(self._callFUT([key1, key2]), 'foo')
 
 
 class Test_get_function(unittest2.TestCase):
@@ -575,8 +583,3 @@ class Test_allocate_ids_function(unittest2.TestCase):
             COMPLETE_KEY = Key('KIND', 1234)
             self.assertRaises(ValueError, self._callFUT,
                               COMPLETE_KEY, 2)
-
-
-class _Key(object):
-    def __init__(self, dataset_id):
-        self.dataset_id = dataset_id

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -53,79 +53,6 @@ class TestEntity(unittest2.TestCase):
         self.assertEqual(sorted(entity.exclude_from_indexes),
                          sorted(_EXCLUDE_FROM_INDEXES))
 
-    def test__must_key_no_key(self):
-        from gcloud.datastore.entity import NoKey
-
-        entity = self._makeOne()
-        self.assertRaises(NoKey, getattr, entity, '_must_key')
-
-    def test_save_no_key(self):
-        from gcloud.datastore.entity import NoKey
-
-        entity = self._makeOne()
-        entity['foo'] = 'Foo'
-        self.assertRaises(NoKey, entity.save)
-
-    def test_save_wo_transaction_wo_auto_id_wo_returned_key(self):
-        connection = _Connection()
-        key = _Key()
-        entity = self._makeOne(key=key)
-        entity['foo'] = 'Foo'
-        entity.save(connection=connection)
-        self.assertEqual(entity['foo'], 'Foo')
-        self.assertEqual(connection._saved,
-                         (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
-        self.assertEqual(key._path, None)
-
-    def test_save_w_transaction_wo_partial_key(self):
-        connection = _Connection()
-        transaction = connection._transaction = _Transaction()
-        key = _Key()
-        entity = self._makeOne(key=key)
-        entity['foo'] = 'Foo'
-        entity.save(connection=connection)
-        self.assertEqual(entity['foo'], 'Foo')
-        self.assertEqual(connection._saved,
-                         (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
-        self.assertEqual(transaction._added, ())
-        self.assertEqual(key._path, None)
-
-    def test_save_w_transaction_w_partial_key(self):
-        connection = _Connection()
-        transaction = connection._transaction = _Transaction()
-        key = _Key()
-        key._partial = True
-        entity = self._makeOne(key=key)
-        entity['foo'] = 'Foo'
-        entity.save(connection=connection)
-        self.assertEqual(entity['foo'], 'Foo')
-        self.assertEqual(connection._saved,
-                         (_DATASET_ID, 'KEY', {'foo': 'Foo'}, ()))
-        self.assertEqual(transaction._added, (entity,))
-        self.assertEqual(key._path, None)
-
-    def test_save_w_returned_key_exclude_from_indexes(self):
-        from gcloud.datastore import datastore_v1_pb2 as datastore_pb
-        from gcloud.datastore.key import Key
-
-        key_pb = datastore_pb.Key()
-        key_pb.partition_id.dataset_id = _DATASET_ID
-        key_pb.path_element.add(kind=_KIND, id=_ID)
-        connection = _Connection()
-        connection._save_result = (True, _ID)
-        key = Key('KIND', dataset_id=_DATASET_ID)
-        entity = self._makeOne(key=key, exclude_from_indexes=['foo'])
-        entity['foo'] = 'Foo'
-        entity.save(connection=connection)
-        self.assertEqual(entity['foo'], 'Foo')
-        self.assertEqual(connection._saved[0], _DATASET_ID)
-        self.assertEqual(connection._saved[1], key.to_protobuf())
-        self.assertEqual(connection._saved[2], {'foo': 'Foo'})
-        self.assertEqual(connection._saved[3], ('foo',))
-        self.assertEqual(len(connection._saved), 4)
-
-        self.assertEqual(entity.key._path, [{'kind': _KIND, 'id': _ID}])
-
     def test___repr___no_key_empty(self):
         entity = self._makeOne()
         self.assertEqual(repr(entity), '<Entity {}>')
@@ -149,38 +76,6 @@ class _Key(object):
     def __init__(self, dataset_id=_DATASET_ID):
         self.dataset_id = dataset_id
 
-    def to_protobuf(self):
-        return self._key
-
-    @property
-    def is_partial(self):
-        return self._partial
-
     @property
     def path(self):
         return self._path
-
-
-class _Connection(object):
-    _transaction = _saved = _deleted = None
-    _save_result = (False, None)
-
-    def transaction(self):
-        return self._transaction
-
-    def save_entity(self, dataset_id, key_pb, properties,
-                    exclude_from_indexes=()):
-        self._saved = (dataset_id, key_pb, properties,
-                       tuple(exclude_from_indexes))
-        return self._save_result
-
-
-class _Transaction(object):
-    _added = ()
-
-    def __nonzero__(self):
-        return True
-    __bool__ = __nonzero__
-
-    def add_auto_id_entity(self, entity):
-        self._added += (entity,)

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -32,16 +32,16 @@ class Transaction(Batch):
 
       >>> datastore.set_defaults()
 
-      >>> with Transaction()
-      ...     entity1.save()
-      ...     entity2.save()
+      >>> with Transaction() as xact:
+      ...     datastore.put(entity1)
+      ...     datastore.put(entity2)
 
     Because it derives from :class:`Batch`, :class`Transaction` also provides
     :meth:`put` and :meth:`delete` methods::
 
-      >>> with Transaction()
-      ...     transaction.put(entity1)
-      ...     transaction.delete(entity2.key)
+      >>> with Transaction() as xact:
+      ...     xact.put(entity1)
+      ...     xact.delete(entity2.key)
 
     By default, the transaction is rolled back if the transaction block
     exits with an error::
@@ -59,7 +59,7 @@ class Transaction(Batch):
 
          >>> with Transaction():
          ...     entity = Entity(key=Key('Thing'))
-         ...     entity.save()
+         ...     datastore.put([entity])
 
        ``entity`` won't have a complete Key until the transaction is
        committed.
@@ -69,7 +69,7 @@ class Transaction(Batch):
 
          >>> with Transaction():
          ...     entity = Entity(key=Key('Thing'))
-         ...     entity.save()
+         ...     datastore.put([entity])
          ...     assert entity.key.is_partial  # There is no ID on this key.
          >>> assert not entity.key.is_partial  # There *is* an ID.
 
@@ -89,33 +89,12 @@ class Transaction(Batch):
       >>> transaction.begin()
 
       >>> entity = Entity(key=Key('Thing'))
-      >>> entity.save()
+      >>> datastore.put([entity])
 
       >>> if error:
       ...     transaction.rollback()
       ... else:
       ...     transaction.commit()
-
-    For now, this library will enforce a rule of one transaction per
-    connection.  That is, If you want to work with two transactions at
-    the same time (for whatever reason), that must happen over two
-    separate :class:`gcloud.datastore.connection.Connection` s.
-
-    For example, this is perfectly valid::
-
-      >>> with Transaction():
-      ...     entity = Entity(key=Key('Thing'))
-      ...     entity.save()
-
-    However, this **wouldn't** be acceptable::
-
-      >>> with Transaction():
-      ...     Entity(key=Key('Thing')).save()
-      ...     with Transaction():
-      ...         Entity(key=Key('Thing')).save()
-
-    Technically, it looks like the Protobuf API supports this type of
-    pattern, however it makes the code particularly messy.
 
     :type dataset_id: string
     :param dataset_id: The ID of the dataset.

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -89,7 +89,7 @@ class Transaction(Batch):
       >>> transaction.begin()
 
       >>> entity = Entity(key=Key('Thing'))
-      >>> datastore.put([entity])
+      >>> transaction.put([entity])
 
       >>> if error:
       ...     transaction.rollback()

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -77,7 +77,7 @@ class TestDatastoreSave(TestDatastore):
 
     def _generic_test_post(self, name=None, key_id=None):
         entity = self._get_post(id_or_name=(name or key_id))
-        entity.save()
+        datastore.put([entity])
 
         # Register entity to be deleted.
         self.case_entities_to_delete.append(entity)
@@ -108,9 +108,9 @@ class TestDatastoreSave(TestDatastore):
         self._generic_test_post()
 
     def test_save_multiple(self):
-        with datastore.Transaction():
+        with datastore.Transaction() as xact:
             entity1 = self._get_post()
-            entity1.save()
+            xact.put(entity1)
             # Register entity to be deleted.
             self.case_entities_to_delete.append(entity1)
 
@@ -124,7 +124,7 @@ class TestDatastoreSave(TestDatastore):
                 'rating': 4.5,
             }
             entity2 = self._get_post(post_content=second_post_content)
-            entity2.save()
+            xact.put(entity2)
             # Register entity to be deleted.
             self.case_entities_to_delete.append(entity2)
 
@@ -146,7 +146,7 @@ class TestDatastoreSaveKeys(TestDatastore):
         entity['fullName'] = u'Full name'
         entity['linkedTo'] = key  # Self reference.
 
-        entity.save()
+        datastore.put([entity])
         self.case_entities_to_delete.append(entity)
 
         query = datastore.Query(kind='Person')
@@ -340,10 +340,10 @@ class TestDatastoreTransaction(TestDatastore):
         entity = datastore.Entity(key=datastore.Key('Company', 'Google'))
         entity['url'] = u'www.google.com'
 
-        with datastore.Transaction():
+        with datastore.Transaction() as xact:
             results = datastore.get([entity.key])
             if len(results) == 0:
-                entity.save()
+                xact.put(entity)
                 self.case_entities_to_delete.append(entity)
 
         # This will always return after the transaction.

--- a/regression/populate_datastore.py
+++ b/regression/populate_datastore.py
@@ -82,14 +82,14 @@ CHARACTERS = [
 
 
 def add_characters():
-    with datastore.Transaction():
+    with datastore.Transaction() as xact:
         for key_path, character in zip(KEY_PATHS, CHARACTERS):
             if key_path[-1] != character['name']:
                 raise ValueError(('Character and key don\'t agree',
                                   key_path, character))
             entity = datastore.Entity(key=datastore.Key(*key_path))
             entity.update(character)
-            entity.save()
+            xact.put(entity)
             print('Adding Character %s %s' % (character['name'],
                                               character['family']))
 


### PR DESCRIPTION
Similar to the `delete` API added in #522.