### PR TITLE
Require that keys for 'put' / 'delete' match the 'dataset_id' of the batch

### DIFF
--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -60,31 +60,6 @@ def _require_connection(connection=None):
     return connection
 
 
-def _get_dataset_id_from_keys(keys):
-    """Determines dataset ID from a list of keys.
-
-    :type keys: list of :class:`gcloud.datastore.key.Key`
-    :param keys: The keys from the same dataset.
-
-    :rtype: string
-    :returns: The dataset ID of the keys.
-    :raises: :class:`ValueError` if the key dataset IDs don't agree.
-    """
-    if any(key is None for key in keys):
-        raise ValueError('None not allowed')
-
-    dataset_id = keys[0].dataset_id
-    # Rather than creating a list or set of all dataset IDs, we iterate
-    # and check. We could allow the backend to check this for us if IDs
-    # with no prefix worked (GoogleCloudPlatform/google-cloud-datastore#59)
-    # or if we made sure that a prefix s~ or e~ was on each key.
-    for key in keys[1:]:
-        if key.dataset_id != dataset_id:
-            raise ValueError('All keys in get must be from the same dataset.')
-
-    return dataset_id
-
-
 def get(keys, missing=None, deferred=None, connection=None):
     """Retrieves entities, along with their attributes.
 
@@ -111,7 +86,7 @@ def get(keys, missing=None, deferred=None, connection=None):
         return []
 
     connection = _require_connection(connection)
-    dataset_id = _get_dataset_id_from_keys(keys)
+    dataset_id, = set([key.dataset_id for key in keys])
 
     transaction = Transaction.current()
 
@@ -157,8 +132,7 @@ def put(entities, connection=None):
     in_batch = current is not None
     if not in_batch:
         keys = [entity.key for entity in entities]
-        dataset_id = _get_dataset_id_from_keys(keys)
-        current = Batch(dataset_id=dataset_id, connection=connection)
+        current = Batch(dataset_id=keys[0].dataset_id, connection=connection)
     for entity in entities:
         current.put(entity)
     if not in_batch:
@@ -183,8 +157,7 @@ def delete(keys, connection=None):
     current = Batch.current()
     in_batch = current is not None
     if not in_batch:
-        dataset_id = _get_dataset_id_from_keys(keys)
-        current = Batch(dataset_id=dataset_id, connection=connection)
+        current = Batch(dataset_id=keys[0].dataset_id, connection=connection)
     for key in keys:
         current.delete(key)
     if not in_batch:

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -103,7 +103,11 @@ def get(keys, missing=None, deferred=None, connection=None, dataset_id=None):
         return []
 
     connection = _require_connection(connection)
-    dataset_id = _require_dataset_id(dataset_id)
+    try:
+        dataset_id = _require_dataset_id(dataset_id)
+    except EnvironmentError:
+        dataset_id = keys[0].dataset_id
+
     if list(set([key.dataset_id for key in keys])) != [dataset_id]:
         raise ValueError('Keys do not match dataset ID')
 
@@ -157,7 +161,10 @@ def put(entities, connection=None, dataset_id=None):
         return
 
     connection = _require_connection(connection)
-    dataset_id = _require_dataset_id(dataset_id)
+    try:
+        dataset_id = _require_dataset_id(dataset_id)
+    except EnvironmentError:
+        dataset_id = entities[0].key.dataset_id
 
     current = Batch.current()
     in_batch = current is not None
@@ -192,7 +199,10 @@ def delete(keys, connection=None, dataset_id=None):
         return
 
     connection = _require_connection(connection)
-    dataset_id = _require_dataset_id(dataset_id)
+    try:
+        dataset_id = _require_dataset_id(dataset_id)
+    except EnvironmentError:
+        dataset_id = keys[0].dataset_id
 
     # We allow partial keys to attempt a delete, the backend will fail.
     current = Batch.current()

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -27,7 +27,7 @@ from gcloud.datastore import helpers
 def _require_dataset_id(dataset_id=None, keys=()):
     """Infer a dataset ID from the environment, if not passed explicitly.
 
-    Order or precedence:
+    Order of precedence:
 
     - Passed `dataset_id` (if not None).
     - `dataset_id` of current batch / transaction (if current exists).
@@ -38,8 +38,8 @@ def _require_dataset_id(dataset_id=None, keys=()):
     :type dataset_id: string
     :param dataset_id: Optional.
 
-    :type dataset_id: list of :class:`gcloud.datastore.key.Key`
-    :param dataset_id: Optional.
+    :type keys: list of :class:`gcloud.datastore.key.Key`
+    :param keys: Optional.
 
     :rtype: string
     :returns: A dataset ID based on the current environment.

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -36,9 +36,13 @@ def _require_dataset_id(dataset_id=None):
              and cannot be inferred from the environment.
     """
     if dataset_id is None:
-        if _implicit_environ.DATASET_ID is None:
-            raise EnvironmentError('Dataset ID could not be inferred.')
-        dataset_id = _implicit_environ.DATASET_ID
+        top = Batch.current()
+        if top is not None:
+            dataset_id = top.dataset_id
+        else:
+            if _implicit_environ.DATASET_ID is None:
+                raise EnvironmentError('Dataset ID could not be inferred.')
+            dataset_id = _implicit_environ.DATASET_ID
     return dataset_id
 
 
@@ -54,9 +58,13 @@ def _require_connection(connection=None):
              cannot be inferred from the environment.
     """
     if connection is None:
-        if _implicit_environ.CONNECTION is None:
-            raise EnvironmentError('Connection could not be inferred.')
-        connection = _implicit_environ.CONNECTION
+        top = Batch.current()
+        if top is not None:
+            connection = top.connection
+        else:
+            if _implicit_environ.CONNECTION is None:
+                raise EnvironmentError('Connection could not be inferred.')
+            connection = _implicit_environ.CONNECTION
     return connection
 
 

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -210,10 +210,14 @@ class Batch(object):
         :type entity: :class:`gcloud.datastore.entity.Entity`
         :param entity: the entity to be saved.
 
-        :raises: ValueError if entity has no key assigned.
+        :raises: ValueError if entity has no key assigned, or if the key's
+                 ``dataset_id`` does not match ours.
         """
         if entity.key is None:
             raise ValueError("Entity must have a key")
+
+        if entity.key.dataset_id != self._dataset_id:
+            raise ValueError("Key must be from same dataset as batch")
 
         _assign_entity_to_mutation(
             self.mutation, entity, self._auto_id_entities)
@@ -224,10 +228,14 @@ class Batch(object):
         :type key: :class:`gcloud.datastore.key.Key`
         :param key: the key to be deleted.
 
-        :raises: ValueError if key is not complete.
+        :raises: ValueError if key is not complete, or if the key's
+                 ``dataset_id`` does not match ours.
         """
         if key.is_partial:
             raise ValueError("Key must be complete")
+
+        if key.dataset_id != self._dataset_id:
+            raise ValueError("Key must be from same dataset as batch")
 
         key_pb = key.to_protobuf()
         helpers._add_keys_to_request(self.mutation.delete, [key_pb])

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -319,3 +319,55 @@ def _add_keys_to_request(request_field_pb, key_pbs):
     for key_pb in key_pbs:
         key_pb = _prepare_key_for_request(key_pb)
         request_field_pb.add().CopyFrom(key_pb)
+
+
+def _dataset_ids_equal(dataset_id1, dataset_id2):
+    """Compares two dataset IDs for fuzzy equality.
+
+    Each may be prefixed or unprefixed (but not null, since dataset ID
+    is required on a key). The only allowed prefixes are 's~' and 'e~'.
+
+    Two identical prefixed match
+
+      >>> 's~foo' == 's~foo'
+      >>> 'e~bar' == 'e~bar'
+
+    while non-identical prefixed don't
+
+      >>> 's~foo' != 's~bar'
+      >>> 's~foo' != 'e~foo'
+
+    As for non-prefixed, they can match other non-prefixed or
+    prefixed:
+
+      >>> 'foo' == 'foo'
+      >>> 'foo' == 's~foo'
+      >>> 'foo' == 'e~foo'
+      >>> 'foo' != 'bar'
+      >>> 'foo' != 's~bar'
+
+    (Ties are resolved since 'foo' can only be an alias for one of
+    s~foo or e~foo in the backend.)
+
+    :type dataset_id1: string
+    :param dataset_id1: A dataset ID.
+
+    :type dataset_id2: string
+    :param dataset_id2: A dataset ID.
+
+    :rtype: boolean
+    :returns: Boolean indicating if the IDs are the same.
+    """
+    if dataset_id1 == dataset_id2:
+        return True
+
+    if dataset_id1.startswith('s~') or dataset_id1.startswith('e~'):
+        # If `dataset_id1` is prefixed and not matching, then the only way
+        # they can match is if `dataset_id2` is unprefixed.
+        return dataset_id1[2:] == dataset_id2
+    elif dataset_id2.startswith('s~') or dataset_id2.startswith('e~'):
+        # Here we know `dataset_id1` is unprefixed and `dataset_id2`
+        # is prefixed.
+        return dataset_id1 == dataset_id2[2:]
+
+    return False

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -35,6 +35,18 @@ class Test__require_dataset_id(unittest2.TestCase):
             with self.assertRaises(EnvironmentError):
                 self._callFUT()
 
+    def test_implicit_unset_w_existing_batch(self):
+        ID = 'DATASET'
+        with self._monkey(None):
+            with _NoCommitBatch(dataset_id=ID, connection=object()):
+                self.assertEqual(self._callFUT(), ID)
+
+    def test_implicit_unset_w_existing_transaction(self):
+        ID = 'DATASET'
+        with self._monkey(None):
+            with _NoCommitTransaction(dataset_id=ID, connection=object()):
+                self.assertEqual(self._callFUT(), ID)
+
     def test_implicit_unset_passed_explicitly(self):
         ID = 'DATASET'
         with self._monkey(None):
@@ -72,6 +84,20 @@ class Test__require_connection(unittest2.TestCase):
         with self._monkey(None):
             with self.assertRaises(EnvironmentError):
                 self._callFUT()
+
+    def test_implicit_unset_w_existing_batch(self):
+        ID = 'DATASET'
+        CONNECTION = object()
+        with self._monkey(None):
+            with _NoCommitBatch(dataset_id=ID, connection=CONNECTION):
+                self.assertEqual(self._callFUT(), CONNECTION)
+
+    def test_implicit_unset_w_existing_transaction(self):
+        ID = 'DATASET'
+        CONNECTION = object()
+        with self._monkey(None):
+            with _NoCommitTransaction(dataset_id=ID, connection=CONNECTION):
+                self.assertEqual(self._callFUT(), CONNECTION)
 
     def test_implicit_unset_passed_explicitly(self):
         CONNECTION = object()
@@ -579,7 +605,7 @@ class _NoCommitBatch(object):
 
 class _NoCommitTransaction(object):
 
-    def __init__(self, dataset_id, connection, transaction_id):
+    def __init__(self, dataset_id, connection, transaction_id='TRANSACTION'):
         from gcloud.datastore.transaction import Transaction
         xact = self._transaction = Transaction(dataset_id, connection)
         xact._id = transaction_id

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -19,11 +19,11 @@ class Test__require_dataset_id(unittest2.TestCase):
 
     _MARKER = object()
 
-    def _callFUT(self, passed=_MARKER, keys=()):
+    def _callFUT(self, passed=_MARKER, first_key=None):
         from gcloud.datastore.api import _require_dataset_id
         if passed is self._MARKER:
-            return _require_dataset_id(keys=keys)
-        return _require_dataset_id(dataset_id=passed, keys=keys)
+            return _require_dataset_id(first_key=first_key)
+        return _require_dataset_id(dataset_id=passed, first_key=first_key)
 
     def _monkey(self, dataset_id):
         from gcloud.datastore import _implicit_environ
@@ -39,7 +39,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         from gcloud.datastore.test_batch import _Key
         ID = 'DATASET'
         with self._monkey(None):
-            self.assertEqual(self._callFUT(keys=[_Key(ID)]), ID)
+            self.assertEqual(self._callFUT(first_key=_Key(ID)), ID)
 
     def test_implicit_unset_w_existing_batch_wo_keys(self):
         ID = 'DATASET'
@@ -53,7 +53,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         OTHER = 'OTHER'
         with self._monkey(None):
             with _NoCommitBatch(dataset_id=ID, connection=object()):
-                self.assertEqual(self._callFUT(keys=[_Key(OTHER)]), ID)
+                self.assertEqual(self._callFUT(first_key=_Key(OTHER)), ID)
 
     def test_implicit_unset_w_existing_transaction_wo_keys(self):
         ID = 'DATASET'
@@ -67,7 +67,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         OTHER = 'OTHER'
         with self._monkey(None):
             with _NoCommitTransaction(dataset_id=ID, connection=object()):
-                self.assertEqual(self._callFUT(keys=[_Key(OTHER)]), ID)
+                self.assertEqual(self._callFUT(first_key=_Key(OTHER)), ID)
 
     def test_implicit_unset_passed_explicitly_wo_keys(self):
         ID = 'DATASET'
@@ -79,7 +79,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         ID = 'DATASET'
         OTHER = 'OTHER'
         with self._monkey(None):
-            self.assertEqual(self._callFUT(ID, keys=[_Key(OTHER)]), ID)
+            self.assertEqual(self._callFUT(ID, first_key=_Key(OTHER)), ID)
 
     def test_id_implicit_set_wo_keys(self):
         IMPLICIT_ID = 'IMPLICIT'
@@ -92,7 +92,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         IMPLICIT_ID = 'IMPLICIT'
         OTHER = 'OTHER'
         with self._monkey(IMPLICIT_ID):
-            self.assertEqual(self._callFUT(keys=[_Key(OTHER)]), OTHER)
+            self.assertEqual(self._callFUT(first_key=_Key(OTHER)), OTHER)
 
     def test_id_implicit_set_passed_explicitly_wo_keys(self):
         ID = 'DATASET'
@@ -106,7 +106,7 @@ class Test__require_dataset_id(unittest2.TestCase):
         IMPLICIT_ID = 'IMPLICIT'
         OTHER = 'OTHER'
         with self._monkey(IMPLICIT_ID):
-            self.assertEqual(self._callFUT(ID, keys=[_Key(OTHER)]), ID)
+            self.assertEqual(self._callFUT(ID, first_key=_Key(OTHER)), ID)
 
 
 class Test__require_connection(unittest2.TestCase):

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -90,37 +90,6 @@ class Test__require_connection(unittest2.TestCase):
             self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
 
 
-class Test__get_dataset_id_from_keys(unittest2.TestCase):
-
-    def _callFUT(self, keys):
-        from gcloud.datastore.api import _get_dataset_id_from_keys
-        return _get_dataset_id_from_keys(keys)
-
-    def _make_key(self, dataset_id):
-
-        class _Key(object):
-            def __init__(self, dataset_id):
-                self.dataset_id = dataset_id
-
-        return _Key(dataset_id)
-
-    def test_empty(self):
-        self.assertRaises(IndexError, self._callFUT, [])
-
-    def test_w_None(self):
-        self.assertRaises(ValueError, self._callFUT, [None])
-
-    def test_w_mismatch(self):
-        key1 = self._make_key('foo')
-        key2 = self._make_key('bar')
-        self.assertRaises(ValueError, self._callFUT, [key1, key2])
-
-    def test_w_match(self):
-        key1 = self._make_key('foo')
-        key2 = self._make_key('foo')
-        self.assertEqual(self._callFUT([key1, key2]), 'foo')
-
-
 class Test_get_function(unittest2.TestCase):
 
     def _callFUT(self, keys, missing=None, deferred=None, connection=None):

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -203,6 +203,41 @@ class TestBatch(unittest2.TestCase):
         deletes = list(batch.mutation.delete)
         self.assertEqual(len(deletes), 0)
 
+    def test_put_entity_w_completed_key_prefixed_dataset_id(self):
+        _DATASET = 'DATASET'
+        _PROPERTIES = {
+            'foo': 'bar',
+            'baz': 'qux',
+            'spam': [1, 2, 3],
+            'frotz': [],  # will be ignored
+            }
+        connection = _Connection()
+        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        entity = _Entity(_PROPERTIES)
+        entity.exclude_from_indexes = ('baz', 'spam')
+        key = entity.key = _Key('s~' + _DATASET)
+
+        batch.put(entity)
+
+        insert_auto_ids = list(batch.mutation.insert_auto_id)
+        self.assertEqual(len(insert_auto_ids), 0)
+        upserts = list(batch.mutation.upsert)
+        self.assertEqual(len(upserts), 1)
+
+        upsert = upserts[0]
+        self.assertEqual(upsert.key, key._key)
+        props = dict([(prop.name, prop.value) for prop in upsert.property])
+        self.assertTrue(props['foo'].indexed)
+        self.assertFalse(props['baz'].indexed)
+        self.assertTrue(props['spam'].indexed)
+        self.assertFalse(props['spam'].list_value[0].indexed)
+        self.assertFalse(props['spam'].list_value[1].indexed)
+        self.assertFalse(props['spam'].list_value[2].indexed)
+        self.assertFalse('frotz' in props)
+
+        deletes = list(batch.mutation.delete)
+        self.assertEqual(len(deletes), 0)
+
     def test_delete_w_partial_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
@@ -225,6 +260,22 @@ class TestBatch(unittest2.TestCase):
         connection = _Connection()
         batch = self._makeOne(dataset_id=_DATASET, connection=connection)
         key = _Key(_DATASET)
+
+        batch.delete(key)
+
+        insert_auto_ids = list(batch.mutation.insert_auto_id)
+        self.assertEqual(len(insert_auto_ids), 0)
+        upserts = list(batch.mutation.upsert)
+        self.assertEqual(len(upserts), 0)
+        deletes = list(batch.mutation.delete)
+        self.assertEqual(len(deletes), 1)
+        self.assertEqual(deletes[0], key._key)
+
+    def test_delete_w_completed_key_w_prefixed_dataset_id(self):
+        _DATASET = 'DATASET'
+        connection = _Connection()
+        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        key = _Key('s~' + _DATASET)
 
         batch.delete(key)
 

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -116,7 +116,7 @@ class TestBatch(unittest2.TestCase):
         connection = _Connection()
         batch = self._makeOne(dataset_id=_DATASET, connection=connection)
         entity = _Entity()
-        key = entity.key = _Key(_Entity)
+        key = entity.key = _Key(_DATASET)
         key._id = None
 
         batch.add_auto_id_entity(entity)
@@ -128,7 +128,7 @@ class TestBatch(unittest2.TestCase):
         connection = _Connection()
         batch = self._makeOne(dataset_id=_DATASET, connection=connection)
         entity = _Entity()
-        entity.key = _Key(_Entity)
+        entity.key = _Key(_DATASET)
 
         self.assertRaises(ValueError, batch.add_auto_id_entity, entity)
 
@@ -138,6 +138,15 @@ class TestBatch(unittest2.TestCase):
         batch = self._makeOne(dataset_id=_DATASET, connection=connection)
 
         self.assertRaises(ValueError, batch.put, _Entity())
+
+    def test_put_entity_w_key_wrong_dataset_id(self):
+        _DATASET = 'DATASET'
+        connection = _Connection()
+        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        entity = _Entity()
+        entity.key = _Key('OTHER')
+
+        self.assertRaises(ValueError, batch.put, entity)
 
     def test_put_entity_w_partial_key(self):
         _DATASET = 'DATASET'
@@ -200,6 +209,14 @@ class TestBatch(unittest2.TestCase):
         batch = self._makeOne(dataset_id=_DATASET, connection=connection)
         key = _Key(_DATASET)
         key._id = None
+
+        self.assertRaises(ValueError, batch.delete, key)
+
+    def test_delete_w_key_wrong_dataset_id(self):
+        _DATASET = 'DATASET'
+        connection = _Connection()
+        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        key = _Key('OTHER')
 
         self.assertRaises(ValueError, batch.delete, key)
 

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -517,3 +517,27 @@ class Test__prepare_key_for_request(unittest2.TestCase):
         key = datastore_pb.Key()
         new_key = self._callFUT(key)
         self.assertTrue(new_key is key)
+
+
+class Test__dataset_ids_equal(unittest2.TestCase):
+
+    def _callFUT(self, dataset_id1, dataset_id2):
+        from gcloud.datastore.helpers import _dataset_ids_equal
+        return _dataset_ids_equal(dataset_id1, dataset_id2)
+
+    def test_identical_prefixed(self):
+        self.assertTrue(self._callFUT('s~foo', 's~foo'))
+        self.assertTrue(self._callFUT('e~bar', 'e~bar'))
+
+    def test_different_prefixed(self):
+        self.assertFalse(self._callFUT('s~foo', 's~bar'))
+        self.assertFalse(self._callFUT('s~foo', 'e~foo'))
+
+    def test_all_unprefixed(self):
+        self.assertTrue(self._callFUT('foo', 'foo'))
+        self.assertFalse(self._callFUT('foo', 'bar'))
+
+    def test_unprefixed_with_prefixed(self):
+        self.assertTrue(self._callFUT('foo', 's~foo'))
+        self.assertTrue(self._callFUT('foo', 'e~foo'))
+        self.assertFalse(self._callFUT('foo', 's~bar'))


### PR DESCRIPTION
Fixes #447.