### PR TITLE
Restore pylint speedup for PRs

### DIFF
--- a/run_pylint.py
+++ b/run_pylint.py
@@ -125,8 +125,12 @@ def get_files_for_linting():
     a remote branch to diff against.
     """
     diff_base = None
-    # Temporarily turning off origin/master check since file removed.
-    if os.getenv('TRAVIS') is None:
+    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+            os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
+        # In the case of a pull request into master, we want to
+        # diff against HEAD in master.
+        diff_base = 'origin/master'
+    elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')
         branch = os.getenv('GCLOUD_BRANCH_FOR_LINT')

--- a/run_pylint.py
+++ b/run_pylint.py
@@ -180,6 +180,12 @@ def get_python_files():
 
 def lint_fileset(filenames, rcfile, description):
     """Lints a group of files using a given rcfile."""
+    # Only lint filenames that exist. For example, 'git diff --name-only'
+    # could spit out deleted / renamed files. Another alternative could
+    # be to use 'git diff --name-status' and filter out files with a
+    # status of 'D'.
+    filenames = [filename for filename in filenames
+                 if os.path.exists(filename)]
     if filenames:
         rc_flag = '--rcfile=%s' % (rcfile,)
         pylint_shell_command = ['pylint', rc_flag] + filenames


### PR DESCRIPTION
Was removed in #542.

Also modifying `lint_fileset` so that removing / renaming files does not give `run_pylint` fits.