### PR TITLE
Removing hard dependency on PyOpenSSL.

### DIFF
--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -108,11 +108,11 @@ class _ACLEntity(object):
         if not self.identifier:
             return str(self.type)
         else:
-            return '{self.type}-{self.identifier}'.format(self=self)
+            return '{acl.type}-{acl.identifier}'.format(acl=self)
 
     def __repr__(self):
-        return '<ACL Entity: {self} ({roles})>'.format(
-            self=self, roles=', '.join(self.roles))
+        return '<ACL Entity: {acl} ({roles})>'.format(
+            acl=self, roles=', '.join(self.roles))
 
     def get_roles(self):
         """Get the list of roles permitted by this entity.

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -23,8 +23,8 @@ import urllib
 from Crypto.Hash import SHA256
 from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_v1_5
-from OpenSSL import crypto
 from oauth2client import client
+from oauth2client import crypt
 from oauth2client import service_account
 import pytz
 
@@ -57,11 +57,8 @@ def _get_pem_key(credentials):
     """
     if isinstance(credentials, client.SignedJwtAssertionCredentials):
         # Take our PKCS12 (.p12) key and make it into a RSA key we can use.
-        pkcs12 = crypto.load_pkcs12(
-            base64.b64decode(credentials.private_key),
-            'notasecret')
-        pem_text = crypto.dump_privatekey(
-            crypto.FILETYPE_PEM, pkcs12.get_privatekey())
+        pem_text = crypt.pkcs12_key_as_pem(credentials.private_key,
+                                           credentials.private_key_password)
     elif isinstance(credentials, service_account._ServiceAccountCredentials):
         pem_text = credentials._private_key_pkcs8_text
     else:

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,9 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 REQUIREMENTS = [
     'httplib2',
-    'oauth2client',
+    'oauth2client >= 1.4.6',
     'protobuf >= 2.5.0',
     'pycrypto',
-    'pyopenssl',
     'pytz',
     'six',
 ]


### PR DESCRIPTION
Requires `oauth2client>=1.4.6` (@tseaver should I put this in `setup.py`?)

Also had to update storage/acl.py due to a change in
PyLint that didn't like `self` as a kwarg to a str instance
method

Fixes #537