### PR TITLE
Making version work in envs where get_distribution does not.

### DIFF
--- a/gcloud/__init__.py
+++ b/gcloud/__init__.py
@@ -14,6 +14,8 @@
 
 """GCloud API access in idiomatic Python."""
 
-from pkg_resources import get_distribution
-
-__version__ = get_distribution('gcloud').version
+try:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution('gcloud').version
+except (ImportError, pkg_resources.DistributionNotFound):  # pragma: NO COVER
+    __version__ = None

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -14,9 +14,9 @@
 
 """ Shared implementation of connections to API servers."""
 
-from pkg_resources import get_distribution
-
 import httplib2
+
+import gcloud
 
 
 class Connection(object):
@@ -32,7 +32,7 @@ class Connection(object):
     _EMPTY = object()
     """A pointer to represent an empty value for default arguments."""
 
-    USER_AGENT = "gcloud-python/{0}".format(get_distribution('gcloud').version)
+    USER_AGENT = "gcloud-python/{0}".format(gcloud.__version__)
     """The user agent for gcloud-python requests."""
 
     def __init__(self, credentials=None):


### PR DESCRIPTION
See http://stackoverflow.com/a/28095663/1068170 for context.

@tseaver I haven't thought deeply about this solution and I'd wager you've got some experience here.

1. Maybe there is a more preferred alternative?
1. Should we hardcode the `__version__` instead of using `None`? (It will result in `gcloud-python/None` as the user-agent.)