### PR TITLE
Making sure delete does not fail in regression tests.

### DIFF
--- a/regression/storage.py
+++ b/regression/storage.py
@@ -39,10 +39,20 @@ def setUpModule():
         SHARED_BUCKETS['test_bucket'] = connection.create_bucket(bucket_name)
 
 
+def safe_delete(bucket):
+    for key in bucket:
+        try:
+            key.delete()
+        except storage.exceptions.NotFound:
+            print('Delete failed with 404: %r' % (key,))
+
+    # Passing force=False does not try to delete the contained files.
+    bucket.delete(force=False)
+
+
 def tearDownModule():
     for bucket in SHARED_BUCKETS.values():
-        # Passing force=True also deletes all files.
-        bucket.delete(force=True)
+        safe_delete(bucket)
 
 
 class TestStorage(unittest2.TestCase):


### PR DESCRIPTION
Adds a `safe_delete()` which respects objects which are still listed for a bucket but have already been deleted. (This is because the object list is eventually consistent and we delete some objects in our regression tests.)

Fixes #531. See #535 for context.

Fix based on [comment][1] from @thobrla.

This is a "temporary" stop-gap and the safe delete can likely be folded into `Connection.delete_bucket()`. For now, we want to eliminate flaky regression test failures.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/pull/535#issuecomment-71078224