### PR TITLE
Fixing flaky datastore queries in regression tests.

### DIFF
--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -155,15 +155,18 @@ class Key(object):
         """Duplicates the Key.
 
         Most attributes are simple types, so don't require copying. Other
-        attributes like ``parent`` are long-lived and so we re-use them rather
-        than creating copies.
+        attributes like ``parent`` are long-lived and so we re-use them.
 
         :rtype: :class:`gcloud.datastore.key.Key`
         :returns: A new ``Key`` instance with the same data as the current one.
         """
-        return self.__class__(*self.flat_path, parent=self.parent,
-                              dataset_id=self.dataset_id,
-                              namespace=self.namespace)
+        cloned_self = self.__class__(*self.flat_path,
+                                     dataset_id=self.dataset_id,
+                                     namespace=self.namespace)
+        # If the current parent has already been set, we re-use
+        # the same instance
+        cloned_self._parent = self._parent
+        return cloned_self
 
     def completed_key(self, id_or_name):
         """Creates new key from existing partial key by adding final ID/name.

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -152,6 +152,25 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(clone.kind, _KIND)
         self.assertEqual(clone.path, _PATH)
 
+    def test__clone_with_parent(self):
+        _DATASET = 'DATASET-ALT'
+        _NAMESPACE = 'NAMESPACE'
+        _KIND1 = 'PARENT'
+        _KIND2 = 'KIND'
+        _ID1 = 1234
+        _ID2 = 2345
+        _PATH = [{'kind': _KIND1, 'id': _ID1}, {'kind': _KIND2, 'id': _ID2}]
+
+        parent = self._makeOne(_KIND1, _ID1, namespace=_NAMESPACE,
+                               dataset_id=_DATASET)
+        key = self._makeOne(_KIND2, _ID2, parent=parent)
+        self.assertTrue(key.parent is parent)
+        clone = key._clone()
+        self.assertTrue(clone.parent is key.parent)
+        self.assertEqual(clone.dataset_id, _DATASET)
+        self.assertEqual(clone.namespace, _NAMESPACE)
+        self.assertEqual(clone.path, _PATH)
+
     def test_completed_key_on_partial_w_id(self):
         key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
         _ID = 1234


### PR DESCRIPTION
Using an ancestor in queries to ensure consistency.

See #562 for context.