### PR TITLE
DISCUSSION PR: Add __environ__ to gcloud package to augment user agent

### DIFF
--- a/gcloud/__init__.py
+++ b/gcloud/__init__.py
@@ -16,4 +16,89 @@
 
 from pkg_resources import get_distribution
 
+import six
+import socket
+
+try:
+    from google import appengine
+except ImportError:
+    appengine = None
+
+
 __version__ = get_distribution('gcloud').version
+
+
+HTTPConnection = six.moves.http_client.HTTPConnection
+
+
+class _UserAgentReifyProperty(object):
+    """Helper for extra environment information."""
+
+    _curr_environ = None
+    _user_agent = None
+
+    def __init__(self, wrapped):
+        self._property_name = wrapped.__name__
+        self._curr_environ = self.environ_at_init()
+
+    @staticmethod
+    def environ_at_init():
+        """Checks environment variables during instance initialization.
+
+        Intended to infer as much as possible from the environment without
+        running code.
+
+        :rtype: string or ``NoneType``
+        :returns: Either ``'-GAE'`` if on App Engine else ``None``
+        """
+        if appengine is not None:
+            return '-GAE'
+
+    def environ_post_init(self):
+        """Checks environment variables after instance initialization.
+
+        This is meant for checks which can't be performed instantaneously.
+
+        :rtype: string
+        :returns: Either ``'-GCE'`` if on Compute Engine else an empty string.
+        """
+        gce_environ = self.check_compute_engine()
+        if gce_environ is not None:
+            return gce_environ
+
+        return ''
+
+    @staticmethod
+    def check_compute_engine():
+        """Checks if the current environment is Compute Engine.
+
+        :rtype: string or ``NoneType``
+        :returns: The string ``'-GCE'`` if on Compute Engine else ``None``.
+        """
+        host = '169.254.169.254'
+        uri_path = '/computeMetadata/v1/project/project-id'
+        headers = {'Metadata-Flavor': 'Google'}
+        connection = HTTPConnection(host, timeout=0.1)
+        try:
+            connection.request('GET', uri_path, headers=headers)
+            response = connection.getresponse()
+            if response.status == 200:
+                return '-GCE'
+        except socket.error:  # Expect timeout or host is down
+            pass
+        finally:
+            connection.close()
+
+    def __get__(self, inst, objtype=None):
+        if inst is None:
+            return self
+
+        if self._curr_environ is None:
+            self._curr_environ = self.environ_post_init()
+
+        if self._user_agent is None:
+            self._user_agent = "gcloud-python/{0}{1}".format(
+                __version__, self._curr_environ)
+
+        setattr(inst, self._property_name, self._user_agent)
+        return self._user_agent

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -14,9 +14,9 @@
 
 """ Shared implementation of connections to API servers."""
 
-from pkg_resources import get_distribution
-
 import httplib2
+
+import gcloud
 
 
 class Connection(object):
@@ -29,12 +29,6 @@ class Connection(object):
     API_BASE_URL = 'https://www.googleapis.com'
     """The base of the API call URL."""
 
-    _EMPTY = object()
-    """A pointer to represent an empty value for default arguments."""
-
-    USER_AGENT = "gcloud-python/{0}".format(get_distribution('gcloud').version)
-    """The user agent for gcloud-python requests."""
-
     def __init__(self, credentials=None):
         """Constructor for Connection.
 
@@ -44,6 +38,11 @@ class Connection(object):
         """
         self._http = None
         self._credentials = credentials
+
+    @gcloud._UserAgentReifyProperty  # pragma: NO COVER
+    def user_agent(self):
+        """The user agent for gcloud-python requests."""
+        # The decorator will handle the value.
 
     @property
     def credentials(self):

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -59,7 +59,7 @@ class Connection(connection.Connection):
         headers = {
             'Content-Type': 'application/x-protobuf',
             'Content-Length': str(len(data)),
-            'User-Agent': self.USER_AGENT,
+            'User-Agent': self.user_agent,
         }
         headers, content = self.http.request(
             uri=self.build_api_url(dataset_id=dataset_id, method=method),

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -300,7 +300,7 @@ class Test_get_function(unittest2.TestCase):
         self.assertEqual(called_with['headers']['Content-Type'],
                          'application/x-protobuf')
         self.assertEqual(called_with['headers']['User-Agent'],
-                         conn.USER_AGENT)
+                         conn.user_agent)
 
     def test_w_deferred_from_backend_but_not_passed(self):
         from gcloud.datastore import _datastore_v1_pb2 as datastore_pb

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -44,7 +44,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(called_with['headers']['Content-Type'],
                          'application/x-protobuf')
         self.assertEqual(called_with['headers']['User-Agent'],
-                         conn.USER_AGENT)
+                         conn.user_agent)
 
     def test_ctor_defaults(self):
         conn = self._makeOne()
@@ -409,7 +409,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         self.assertEqual(cw['headers']['Content-Type'],
                          'application/x-protobuf')
-        self.assertEqual(cw['headers']['User-Agent'], conn.USER_AGENT)
+        self.assertEqual(cw['headers']['User-Agent'], conn.user_agent)
         rq_class = datastore_pb.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -36,7 +36,10 @@ class TestConnection(unittest2.TestCase):
         return pb
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        conn = self._getTargetClass()(*args, **kw)
+        # Set the user agent so the user_agent is not lazily loaded.
+        setattr(conn, 'user_agent', 'gcloud-python/test')
+        return conn
 
     def _verifyProtobufCall(self, called_with, URI, conn):
         self.assertEqual(called_with['uri'], URI)

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -300,7 +300,7 @@ class Blob(_PropertyMixin):
         headers = {
             'Accept': 'application/json',
             'Accept-Encoding': 'gzip, deflate',
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
 
         upload = transfer.Upload(file_obj,

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -169,7 +169,7 @@ class Connection(_Base):
         if content_type:
             headers['Content-Type'] = content_type
 
-        headers['User-Agent'] = self.USER_AGENT
+        headers['User-Agent'] = self.user_agent
 
         return self.http.request(uri=url, method=method, headers=headers,
                                  body=data)

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -904,11 +904,11 @@ class _Responder(object):
 class _Connection(_Responder):
 
     API_BASE_URL = 'http://example.com'
-    USER_AGENT = 'testing 1.2.3'
     credentials = object()
 
     def __init__(self, *responses):
         super(_Connection, self).__init__(*responses)
+        self.user_agent = 'testing 1.2.3'
         self._signed = []
         self.http = _HTTP(*responses)
 

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -22,7 +22,10 @@ class TestConnection(unittest2.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        conn = self._getTargetClass()(*args, **kw)
+        # Set the user agent so the user_agent is not lazily loaded.
+        setattr(conn, 'user_agent', 'gcloud-python/test')
+        return conn
 
     def test_ctor_defaults(self):
         PROJECT = 'project'

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -194,7 +194,7 @@ class TestConnection(unittest2.TestCase):
         expected_headers = {
             'Accept-Encoding': 'gzip',
             'Content-Length': 0,
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
@@ -214,7 +214,7 @@ class TestConnection(unittest2.TestCase):
             'Accept-Encoding': 'gzip',
             'Content-Length': 0,
             'Content-Type': 'application/json',
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
@@ -234,7 +234,7 @@ class TestConnection(unittest2.TestCase):
             'Accept-Encoding': 'gzip',
             'Content-Length': 0,
             'X-Foo': 'foo',
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
@@ -258,7 +258,7 @@ class TestConnection(unittest2.TestCase):
         expected_headers = {
             'Accept-Encoding': 'gzip',
             'Content-Length': 0,
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
@@ -305,7 +305,7 @@ class TestConnection(unittest2.TestCase):
         expected_headers = {
             'Accept-Encoding': 'gzip',
             'Content-Length': 0,
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
@@ -333,7 +333,7 @@ class TestConnection(unittest2.TestCase):
             'Accept-Encoding': 'gzip',
             'Content-Length': len(DATAJ),
             'Content-Type': 'application/json',
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': conn.user_agent,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 

--- a/gcloud/test___init__.py
+++ b/gcloud/test___init__.py
@@ -1,0 +1,187 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+
+class Test__UserAgentReifyProperty(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud import _UserAgentReifyProperty
+        return _UserAgentReifyProperty
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_ctor_defaults(self):
+        ua_prop = self._makeOne(NamedObject())
+        self.assertEqual(ua_prop._property_name, NamedObject.NAME_VAL)
+        self.assertEqual(ua_prop._curr_environ, None)
+        self.assertEqual(ua_prop._user_agent, None)
+
+    def test_ctor_appengine_loaded(self):
+        import gcloud
+        from gcloud._testing import _Monkey
+
+        NON_NULL = object()
+        with _Monkey(gcloud, appengine=NON_NULL):
+            ua_prop = self._makeOne(NamedObject())
+        self.assertEqual(ua_prop._property_name, NamedObject.NAME_VAL)
+        self.assertEqual(ua_prop._curr_environ, '-GAE')
+        self.assertEqual(ua_prop._user_agent, None)
+
+    def _check_compute_engine_helper(self, status, result):
+        import gcloud
+        from gcloud._testing import _Monkey
+
+        if status == 'RAISE':
+            CONNECTION = _TimeoutHTTPConnection()
+        else:
+            CONNECTION = _HTTPConnection(status)
+
+        CONNECTION.created = 0
+
+        def _factory(host, timeout):
+            CONNECTION.created += 1
+            CONNECTION.host = host
+            CONNECTION.timeout = timeout
+            return CONNECTION
+
+        klass = self._getTargetClass()
+        with _Monkey(gcloud, HTTPConnection=_factory):
+            gce_str = klass.check_compute_engine()
+        self.assertEqual(gce_str, result)
+
+        self.assertEqual(CONNECTION.created, 1)
+        self.assertEqual(CONNECTION.host, '169.254.169.254')
+        self.assertEqual(CONNECTION.timeout, 0.1)
+        self.assertEqual(
+            CONNECTION._called_args,
+            [('GET', '/computeMetadata/v1/project/project-id')])
+        expected_kwargs = {
+            'headers': {
+                'Metadata-Flavor': 'Google',
+            },
+        }
+        self.assertEqual(CONNECTION._called_kwargs, [expected_kwargs])
+        self.assertEqual(CONNECTION._close_count, 1)
+
+    def test_check_compute_engine_fail(self):
+        self._check_compute_engine_helper(404, None)
+
+    def test_check_compute_engine_raise(self):
+        self._check_compute_engine_helper('RAISE', None)
+
+    def test_check_compute_engine_success(self):
+        self._check_compute_engine_helper(200, '-GCE')
+
+    def test_class_property_on_connection(self):
+        from gcloud.connection import Connection
+
+        klass = self._getTargetClass()
+        self.assertTrue(isinstance(Connection.user_agent, klass))
+
+    def test_instance_property_on_connection_default(self):
+        import gcloud
+        from gcloud.connection import Connection
+
+        cnxn = Connection()
+        expected_ua = 'gcloud-python/{0}'.format(gcloud.__version__)
+        self.assertEqual(cnxn.user_agent, expected_ua)
+
+    def test_instance_property_connection_with_appengine(self):
+        import gcloud
+        from gcloud._testing import _Monkey
+        from gcloud.connection import Connection
+
+        NON_NULL = object()
+        with _Monkey(gcloud, appengine=NON_NULL):
+            local_prop = self._makeOne(NamedObject('user_agent'))
+            with _Monkey(Connection, user_agent=local_prop):
+                cnxn = Connection()
+                value = cnxn.user_agent
+
+        expected_ua = 'gcloud-python/{0}-GAE'.format(gcloud.__version__)
+        self.assertEqual(value, expected_ua)
+
+    def test_instance_property_connection_with_compute_engine(self):
+        import gcloud
+        from gcloud._testing import _Monkey
+        from gcloud.connection import Connection
+
+        CONNECTION = _HTTPConnection(200)
+        CONNECTION.created = 0
+
+        def _factory(host, timeout):
+            CONNECTION.created += 1
+            CONNECTION.host = host
+            CONNECTION.timeout = timeout
+            return CONNECTION
+
+        with _Monkey(gcloud, HTTPConnection=_factory):
+            local_prop = self._makeOne(NamedObject('user_agent'))
+            with _Monkey(Connection, user_agent=local_prop):
+                cnxn = Connection()
+                value = cnxn.user_agent
+
+        expected_ua = 'gcloud-python/{0}-GCE'.format(gcloud.__version__)
+        self.assertEqual(value, expected_ua)
+
+
+class NamedObject(object):
+
+    NAME_VAL = object()
+
+    def __init__(self, name=None):
+        self.__name__ = name or self.NAME_VAL
+
+
+class _HTTPResponse(object):
+
+    def __init__(self, status):
+        self.status = status
+
+
+class _BaseHTTPConnection(object):
+
+    host = timeout = None
+
+    def __init__(self):
+        self._close_count = 0
+        self._called_args = []
+        self._called_kwargs = []
+
+    def request(self, method, uri, **kwargs):
+        self._called_args.append((method, uri))
+        self._called_kwargs.append(kwargs)
+
+    def close(self):
+        self._close_count += 1
+
+
+class _HTTPConnection(_BaseHTTPConnection):
+
+    def __init__(self, status):
+        super(_HTTPConnection, self).__init__()
+        self.status = status
+
+    def getresponse(self):
+        return _HTTPResponse(self.status)
+
+
+class _TimeoutHTTPConnection(_BaseHTTPConnection):
+
+    def getresponse(self):
+        import socket
+        raise socket.timeout('timed out')

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -56,10 +56,3 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(creds)
         self.assertTrue(conn.http is authorized)
         self.assertTrue(isinstance(creds._called_with, Http))
-
-    def test_user_agent_format(self):
-        from pkg_resources import get_distribution
-        expected_ua = 'gcloud-python/{0}'.format(
-            get_distribution('gcloud').version)
-        conn = self._makeOne()
-        self.assertEqual(conn.USER_AGENT, expected_ua)


### PR DESCRIPTION
See #566.

This should not be merged (uses lots of `pragma: NO COVER`), it is just a quick and dirty way to go about it.

The App Engine import is innocuous, but the Compute Engine metadata server HTTP should not happen every single time `gcloud` is imported (or any sub-package / sub-module). This is the thing I want to discuss.