### PR TITLE
Using httplib instead of httplib2 to get GCE metadata.

### DIFF
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -69,15 +69,12 @@ def compute_engine_id():
     headers = {'Metadata-Flavor': 'Google'}
     connection = httplib.HTTPConnection(host, timeout=0.1)
 
-    content = None
     try:
         connection.request('GET', uri_path, headers=headers)
         response = connection.getresponse()
         if response.status == 200:
-            content = response.read()
+            return response.read()
     except socket.error:  # socket.timeout or socket.error(64, 'Host is down')
         pass
     finally:
         connection.close()
-
-    return content


### PR DESCRIPTION
Fixes #575.

Feel free to run the bash script I [included][1] in the bug to torture test the fix.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/issues/575#issuecomment-71943675