### PR TITLE
Documenting dunder (e.g. __iter__) methods without docstrings.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -12,7 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Create / interact with gcloud storage buckets."""
+"""Create / interact with gcloud storage buckets.
+
+If you want to check whether a blob exists, you can use the ``in`` operator
+in Python::
+
+  >>> print 'kitten.jpg' in bucket
+  True
+  >>> print 'does-not-exist' in bucket
+  False
+
+If you want to get all the blobs in the bucket, you can use
+:func:`get_all_blobs <gcloud.storage.bucket.Bucket.get_all_blobs>`::
+
+  >>> blobs = bucket.get_all_blobs()
+
+You can also use the bucket as an iterator::
+
+  >>> for blob in bucket:
+  ...   print blob
+"""
 
 import os
 import six


### PR DESCRIPTION
Fixes #60.

Much of the discussion in #60 focuses on dunder-methods which no longer exist. This documents the remaining ones that don't have docstrings, hence don't show up in our API docs.