### PR TITLE
Storage: updating Connection docstring; turning make_request private.

### DIFF
--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -100,7 +100,7 @@ class TestConnection(unittest2.TestCase):
         ])
         self.assertEqual(conn.build_api_url('/foo', upload=True), URI)
 
-    def test_make_request_no_data_no_content_type_no_headers(self):
+    def test__make_request_no_data_no_content_type_no_headers(self):
         PROJECT = 'project'
         conn = self._makeOne(PROJECT)
         URI = 'http://example.com/test'
@@ -108,7 +108,7 @@ class TestConnection(unittest2.TestCase):
             {'status': '200', 'content-type': 'text/plain'},
             '',
         )
-        headers, content = conn.make_request('GET', URI)
+        headers, content = conn._make_request('GET', URI)
         self.assertEqual(headers['status'], '200')
         self.assertEqual(headers['content-type'], 'text/plain')
         self.assertEqual(content, '')
@@ -122,7 +122,7 @@ class TestConnection(unittest2.TestCase):
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
-    def test_make_request_w_data_no_extra_headers(self):
+    def test__make_request_w_data_no_extra_headers(self):
         PROJECT = 'project'
         conn = self._makeOne(PROJECT)
         URI = 'http://example.com/test'
@@ -130,7 +130,7 @@ class TestConnection(unittest2.TestCase):
             {'status': '200', 'content-type': 'text/plain'},
             '',
         )
-        conn.make_request('GET', URI, {}, 'application/json')
+        conn._make_request('GET', URI, {}, 'application/json')
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
         self.assertEqual(http._called_with['body'], {})
@@ -142,7 +142,7 @@ class TestConnection(unittest2.TestCase):
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
-    def test_make_request_w_extra_headers(self):
+    def test__make_request_w_extra_headers(self):
         PROJECT = 'project'
         conn = self._makeOne(PROJECT)
         URI = 'http://example.com/test'
@@ -150,7 +150,7 @@ class TestConnection(unittest2.TestCase):
             {'status': '200', 'content-type': 'text/plain'},
             '',
         )
-        conn.make_request('GET', URI, headers={'X-Foo': 'foo'})
+        conn._make_request('GET', URI, headers={'X-Foo': 'foo'})
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
         self.assertEqual(http._called_with['body'], None)


### PR DESCRIPTION
Making it clear in the docstring that the Connection itself only handles `storage.bucket...` API methods and that the other classes handle the other 30 (give or take) methods of the API.

@tseaver This documents our decision from earlier today (about the responsibilities of `Connection`).

Also note
- We don't directly support `storage.buckets.update` anywhere (but `Connection.api_request` would allow it)
- We don't support `storage.buckets.patch` on `Connection`. Only via `Bucket` (through `_PropertyMixin._patch_properties()`).
- Both `Bucket._reload_properties()` (via `_PropertyMixin`) and `Connection.get_bucket` implement `storage.buckets.get`.

For your reference: [discovery document][1].

[1]: https://gist.github.com/dhermes/86b1dc89ebd8afd7a506#file-storage-v1-rest-json