### PR TITLE
Moving MD5 hash method from regression to storage helpers.

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -17,6 +17,9 @@
 These are *not* part of the API.
 """
 
+from Crypto.Hash import MD5
+import base64
+
 
 class _PropertyMixin(object):
     """Abstract mixin for cloud storage classes with associated propertties.
@@ -187,3 +190,14 @@ def _scalar_property(fieldname):
         self._patch_properties({fieldname: value})
 
     return property(_getter, _setter)
+
+
+def _base64_md5hash(bytes_to_sign):
+    """Get MD5 hash of bytes (as base64).
+
+    :type bytes_to_sign: bytes
+    :param bytes_to_sign: Bytes used to compute an MD5 hash (as base64).
+    """
+    hash = MD5.new(data=bytes_to_sign)
+    digest_bytes = hash.digest()
+    return base64.b64encode(digest_bytes)

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -192,12 +192,28 @@ def _scalar_property(fieldname):
     return property(_getter, _setter)
 
 
-def _base64_md5hash(bytes_to_sign):
+def _write_buffer_to_hash(buffer_object, hash_obj, digest_block_size=8192):
+    """Read blocks from a buffer and update a hash with them.
+
+    :type buffer_object: bytes buffer
+    :param buffer_object: Buffer containing bytes used to update a hash object.
+    """
+    block = buffer_object.read(digest_block_size)
+
+    while len(block) > 0:
+        hash_obj.update(block)
+        # Update the block for the next iteration.
+        block = buffer_object.read(digest_block_size)
+
+
+def _base64_md5hash(buffer_object):
     """Get MD5 hash of bytes (as base64).
 
-    :type bytes_to_sign: bytes
-    :param bytes_to_sign: Bytes used to compute an MD5 hash (as base64).
+    :type buffer_object: bytes buffer
+    :param buffer_object: Buffer containing bytes used to compute an MD5
+                          hash (as base64).
     """
-    hash = MD5.new(data=bytes_to_sign)
-    digest_bytes = hash.digest()
+    hash_obj = MD5.new()
+    _write_buffer_to_hash(buffer_object, hash_obj)
+    digest_bytes = hash_obj.digest()
     return base64.b64encode(digest_bytes)

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from Crypto.Hash import MD5
-import base64
 import httplib2
 import tempfile
 import time
@@ -21,6 +19,7 @@ import unittest2
 
 from gcloud import exceptions
 from gcloud import storage
+from gcloud.storage._helpers import _base64_md5hash
 from gcloud.storage import _implicit_environ
 
 
@@ -96,18 +95,12 @@ class TestStorageFiles(unittest2.TestCase):
         }
     }
 
-    @staticmethod
-    def _get_base64_md5hash(filename):
-        with open(filename, 'rb') as file_obj:
-            hash = MD5.new(data=file_obj.read())
-        digest_bytes = hash.digest()
-        return base64.b64encode(digest_bytes)
-
     @classmethod
     def setUpClass(cls):
         super(TestStorageFiles, cls).setUpClass()
         for file_data in cls.FILES.values():
-            file_data['hash'] = cls._get_base64_md5hash(file_data['path'])
+            with open(file_data['path'], 'rb') as file_obj:
+                file_data['hash'] = _base64_md5hash(file_obj.read())
         cls.bucket = SHARED_BUCKETS['test_bucket']
 
     def setUp(self):

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -100,7 +100,7 @@ class TestStorageFiles(unittest2.TestCase):
         super(TestStorageFiles, cls).setUpClass()
         for file_data in cls.FILES.values():
             with open(file_data['path'], 'rb') as file_obj:
-                file_data['hash'] = _base64_md5hash(file_obj.read())
+                file_data['hash'] = _base64_md5hash(file_obj)
         cls.bucket = SHARED_BUCKETS['test_bucket']
 
     def setUp(self):


### PR DESCRIPTION
May make sense to swap out for `hashlib.md5` (though they seem to
be equivalent).

In preparation for #547.