### PR TITLE
Making json.loads() optional in gcloud.exceptions.make_exception.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -67,7 +67,7 @@ class Connection(connection.Connection):
 
         status = headers['status']
         if status != '200':
-            raise make_exception(headers, content)
+            raise make_exception(headers, content, use_json=False)
 
         return content
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -106,10 +106,10 @@ class TestConnection(unittest2.TestCase):
         METHOD = 'METHOD'
         DATA = 'DATA'
         conn = self._makeOne()
-        conn._http = Http({'status': '400'}, '{"message": "Bad Request"}')
+        conn._http = Http({'status': '400'}, 'Entity value is indexed.')
         with self.assertRaises(BadRequest) as e:
             conn._request(DATASET_ID, METHOD, DATA)
-        expected_message = ('400 Bad Request')
+        expected_message = '400 Entity value is indexed.'
         self.assertEqual(str(e.exception), expected_message)
 
     def test__rpc(self):


### PR DESCRIPTION
Fixes #626.