### PR TITLE
Fixed #634 - Formatting on admonitions looked off.

### DIFF
--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -596,17 +596,26 @@ h2, h3 {
 /* Docs Content
    ========================================================================== */
 
-.admonition-title {
-  background-color: #e5ecf9;
-  padding: 8px;
-}
-
 .admonition {
   background-color: #f8f8f8;
 }
 
+.admonition p.admonition-title {
+  background-color: #e5ecf9;
+  font-weight: bold;
+  padding: 8px;
+}
+
 .admonition pre {
   background-color: #eeeeee !important;
+}
+
+.admonition p {
+  padding: 0 8px;
+}
+
+.admonition .last {
+  padding-bottom: 8px;
 }
 
 .docs-header {


### PR DESCRIPTION
Before:
![note-before](https://cloud.githubusercontent.com/assets/112928/6187511/5c529c3e-b355-11e4-9c99-a1a199708a5e.png)

After:
![note-after](https://cloud.githubusercontent.com/assets/112928/6187513/607f8f38-b355-11e4-8b49-1282c7933e96.png)
