### PR TITLE
Upgrading version to 0.4.1.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
 
 setup(
     name='gcloud',
-    version='0.4.0',
+    version='0.4.1',
     description='API Client library for Google Cloud',
     author='JJ Geewax',
     author_email='jj@geewax.org',


### PR DESCRIPTION
This is for a Friday minor release cycle.

@tseaver I'll handle pushing the tag as well. Preference for tag names? Current is:

```
0.3.0
v0.4.0
```