### PR TITLE
Adding get_for_service_account_json function in credentials.

### DIFF
--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -73,13 +73,16 @@ def get_credentials():
     return client.GoogleCredentials.get_application_default()
 
 
-def get_for_service_account_json(private_key_path, scope=None):
+def get_for_service_account_json(json_credentials_path, scope=None):
     """Gets the credentials for a service account with JSON key.
 
-    :type private_key_path: string
-    :param private_key_path: The path to a private key file (this file was
-                             given to you when you created the service
-                             account). This file must be in JSON key format.
+    :type json_credentials_path: string
+    :param json_credentials_path: The path to a private key file (this file was
+                                  given to you when you created the service
+                                  account). This file must contain a JSON
+                                  object with a private key and other
+                                  credentials information (downloaded from the
+                                  Google APIs console).
 
     :type scope: string or tuple of string
     :param scope: The scope against which to authenticate. (Different services
@@ -93,7 +96,7 @@ def get_for_service_account_json(private_key_path, scope=None):
               credentials object.
     """
     credentials = _get_application_default_credential_from_file(
-        private_key_path)
+        json_credentials_path)
     if scope is not None:
         credentials = credentials.create_scoped(scope)
     return credentials

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -24,6 +24,7 @@ from Crypto.Hash import SHA256
 from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_v1_5
 from oauth2client import client
+from oauth2client.client import _get_application_default_credential_from_file
 from oauth2client import crypt
 from oauth2client import service_account
 import pytz
@@ -72,8 +73,34 @@ def get_credentials():
     return client.GoogleCredentials.get_application_default()
 
 
+def get_for_service_account_json(private_key_path, scope=None):
+    """Gets the credentials for a service account with JSON key.
+
+    :type private_key_path: string
+    :param private_key_path: The path to a private key file (this file was
+                             given to you when you created the service
+                             account). This file must be in JSON key format.
+
+    :type scope: string or tuple of string
+    :param scope: The scope against which to authenticate. (Different services
+                  require different scopes, check the documentation for which
+                  scope is required for the different levels of access to any
+                  particular API.)
+
+    :rtype: :class:`oauth2client.client.GoogleCredentials`,
+            :class:`oauth2client.service_account._ServiceAccountCredentials`
+    :returns: New service account or Google (for a user JSON key file)
+              credentials object.
+    """
+    credentials = _get_application_default_credential_from_file(
+        private_key_path)
+    if scope is not None:
+        credentials = credentials.create_scoped(scope)
+    return credentials
+
+
 def get_for_service_account_p12(client_email, private_key_path, scope=None):
-    """Gets the credentials for a service account.
+    """Gets the credentials for a service account with PKCS12 / p12 key.
 
     .. note::
       This method is not used by default, instead :func:`get_credentials`

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -61,6 +61,54 @@ class TestCredentials(unittest2.TestCase):
         self.assertEqual(client._called_with, expected_called_with)
 
 
+class Test_get_for_service_account_json(unittest2.TestCase):
+
+    def _callFUT(self, private_key_path, scope=None):
+        from gcloud.credentials import get_for_service_account_json
+        return get_for_service_account_json(private_key_path, scope=scope)
+
+    def test_it(self):
+        from gcloud._testing import _Monkey
+        from gcloud import credentials as MUT
+
+        CREDS = _Credentials()
+        _filenames = []
+
+        def get_creds(filename):
+            _filenames.append(filename)
+            return CREDS
+
+        FILENAME = object()
+
+        renames = {'_get_application_default_credential_from_file': get_creds}
+        with _Monkey(MUT, **renames):
+            self._callFUT(FILENAME)
+
+        self.assertEqual(_filenames, [FILENAME])
+        self.assertFalse(hasattr(CREDS, '_scopes'))
+
+    def test_it_with_scope(self):
+        from gcloud._testing import _Monkey
+        from gcloud import credentials as MUT
+
+        CREDS = _Credentials()
+        _filenames = []
+
+        def get_creds(filename):
+            _filenames.append(filename)
+            return CREDS
+
+        FILENAME = object()
+        SCOPE = object()
+
+        renames = {'_get_application_default_credential_from_file': get_creds}
+        with _Monkey(MUT, **renames):
+            self._callFUT(FILENAME, scope=SCOPE)
+
+        self.assertEqual(_filenames, [FILENAME])
+        self.assertEqual(CREDS._scopes, SCOPE)
+
+
 class Test_generate_signed_url(unittest2.TestCase):
 
     def _callFUT(self, *args, **kwargs):

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -63,9 +63,9 @@ class TestCredentials(unittest2.TestCase):
 
 class Test_get_for_service_account_json(unittest2.TestCase):
 
-    def _callFUT(self, private_key_path, scope=None):
+    def _callFUT(self, json_credentials_path, scope=None):
         from gcloud.credentials import get_for_service_account_json
-        return get_for_service_account_json(private_key_path, scope=scope)
+        return get_for_service_account_json(json_credentials_path, scope=scope)
 
     def test_it(self):
         from gcloud._testing import _Monkey


### PR DESCRIPTION
Fixes #638.

@jgeewax PTAL

I thought about wrapping JSON key and PKCS12 key into one method but the JSON key is actual a JSON payload with everything needed, e.g.

```JSON
{
  "private_key_id": "0996.....",
  "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdgIBADA.....\n-----END PRIVATE KEY-----\n",
  "client_email": "32578400.......@developer.gserviceaccount.com",
  "client_id": "32578400.........apps.googleusercontent.com",
  "type": "service_account"
}
```

whereas a P12 key is just the bytes in `private_key` (and created for PKCS12 rather than PEM).

I don't think it's worth trying to smash together the two API surfaces:

```python
get_for_service_account_json(private_key_path, scope=None)
get_for_service_account_p12(client_email, private_key_path, scope=None)
```