### PR TITLE
Making sure new docs get built on tags.

### DIFF
--- a/scripts/merge.sh
+++ b/scripts/merge.sh
@@ -23,6 +23,9 @@ if [[ "${TRAVIS_BRANCH}" == "master" ]] && \
        [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
   scripts/update_docs.sh
   scripts/update_wheels_project.sh
+elif [[ -n "${TRAVIS_TAG}" ]]; then
+  echo "Building new docs on a tag."
+  scripts/update_docs.sh
 else
   echo "Not in master on a non-pull request. Doing nothing."
 fi


### PR DESCRIPTION
A tag is not associated with a branch inherently so
TRAVIS_BRANCH == master is the wrong check.

See my previous [comment][1] for context.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/issues/472#issuecomment-74357165