### PR TITLE
Adding support for GCD dev server in datastore package.

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -19,6 +19,10 @@ from pkg_resources import get_distribution
 import httplib2
 
 
+API_BASE_URL = 'https://www.googleapis.com'
+"""The base of the API call URL."""
+
+
 class Connection(object):
     """A generic connection to Google Cloud Platform.
 
@@ -53,9 +57,6 @@ class Connection(object):
     :type http: :class:`httplib2.Http` or class that defines ``request()``.
     :param http: An optional HTTP object to make requests.
     """
-
-    API_BASE_URL = 'https://www.googleapis.com'
-    """The base of the API call URL."""
 
     USER_AGENT = "gcloud-python/{0}".format(get_distribution('gcloud').version)
     """The user agent for gcloud-python requests."""

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -67,6 +67,7 @@ SCOPE = ('https://www.googleapis.com/auth/datastore',
 """The scopes required for authenticating as a Cloud Datastore consumer."""
 
 _DATASET_ENV_VAR_NAME = 'GCLOUD_DATASET_ID'
+_GCD_DATASET_ENV_VAR_NAME = 'DATASTORE_DATASET'
 
 
 def set_default_dataset_id(dataset_id=None):
@@ -85,6 +86,9 @@ def set_default_dataset_id(dataset_id=None):
     """
     if dataset_id is None:
         dataset_id = os.getenv(_DATASET_ENV_VAR_NAME)
+
+    if dataset_id is None:
+        dataset_id = os.getenv(_GCD_DATASET_ENV_VAR_NAME)
 
     if dataset_id is None:
         dataset_id = _implicit_environ.app_engine_id()

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -14,10 +14,15 @@
 
 """Connections to gcloud datastore API servers."""
 
+import os
+
 from gcloud import connection
 from gcloud.exceptions import make_exception
 from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
 from gcloud.datastore import helpers
+
+
+_GCD_HOST_ENV_VAR_NAME = 'DATASTORE_HOST'
 
 
 class Connection(connection.Connection):
@@ -29,6 +34,10 @@ class Connection(connection.Connection):
     :type credentials: :class:`oauth2client.client.OAuth2Credentials`
     :param credentials: The OAuth2 Credentials to use for this connection.
     """
+
+    API_BASE_URL = os.getenv(_GCD_HOST_ENV_VAR_NAME,
+                             connection.Connection.API_BASE_URL)
+    """The base of the API call URL."""
 
     API_VERSION = 'v1beta2'
     """The version of the API, used in building the API call's URL."""

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -359,7 +359,7 @@ class Test_get_function(unittest2.TestCase):
 
         # Make URI to check for requests.
         URI = '/'.join([
-            conn.API_BASE_URL,
+            conn.api_base_url,
             'datastore',
             conn.API_VERSION,
             'datasets',

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -18,13 +18,13 @@ import json
 
 from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
 
-from gcloud.connection import Connection as _Base
+from gcloud import connection as base_connection
 from gcloud.exceptions import make_exception
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.iterator import Iterator
 
 
-class Connection(_Base):
+class Connection(base_connection.Connection):
     """A connection to Google Cloud Storage via the JSON REST API.
 
     This defines :meth:`Connection.api_request` for making a generic JSON
@@ -65,6 +65,9 @@ class Connection(_Base):
       >>>   print bucket
       <Bucket: my-bucket-name>
     """
+
+    API_BASE_URL = base_connection.API_BASE_URL
+    """The base of the API call URL."""
 
     API_VERSION = 'v1'
     """The version of the API, used in building the API call's URL."""


### PR DESCRIPTION
Enabling
- set_default_dataset_id() support for DATASTORE_DATASET environment
  variable name
- gcloud.datastore.Connection.API_BASE_URL override for
  DATASTORE_HOST environment variable name

Fixes #650.