### PR TITLE
Restore 'Dataset' class.

### DIFF
--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -43,21 +43,24 @@ class Dataset(object):
 
         Passes our ``dataset_id``.
         """
-        return get(keys, missing, deferred, self.connection, self.dataset_id)
+        return get(keys, missing=missing, deferred=deferred,
+                   connection=self.connection, dataset_id=self.dataset_id)
 
     def put(self, entities):
         """Proxy to :func:`gcloud.datastore.api.put`.
 
         Passes our ``dataset_id``.
         """
-        return put(entities, self.connection, dataset_id=self.dataset_id)
+        return put(entities, connection=self.connection,
+                   dataset_id=self.dataset_id)
 
     def delete(self, keys):
         """Proxy to :func:`gcloud.datastore.api.delete`.
 
         Passes our ``dataset_id``.
         """
-        return delete(keys, self.connection, dataset_id=self.dataset_id)
+        return delete(keys, connection=self.connection,
+                      dataset_id=self.dataset_id)
 
     def key(self, *path_args, **kwargs):
         """Proxy to :func:`gcloud.datastore.key.Key`.

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -24,7 +24,7 @@ from gcloud.datastore.transaction import Transaction
 
 class Dataset(object):
     """Convenience wrapper for invoking APIs/factories w/ a dataset ID.
-    
+
     :type dataset_id: string
     :param dataset_id: (required) dataset ID to pass to proxied API methods.
 

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -87,17 +87,12 @@ class Dataset(object):
         return Transaction(dataset_id=self.dataset_id,
                            connection=self.connection)
 
-    def query(self,
-              kind=None,
-              namespace=None,
-              ancestor=None,
-              filters=(),
-              projection=(),
-              order=(),
-              group_by=()):
+    def query(self, **kwargs):
         """Proxy to :func:`gcloud.datastore.query.Query`.
 
         Passes our ``dataset_id``.
         """
-        return Query(self.dataset_id, kind, namespace, ancestor, filters,
-                     projection, order, group_by)
+        if 'dataset_id' in kwargs:
+            raise TypeError('Cannot pass dataset_id')
+        kwargs['dataset_id'] = self.dataset_id
+        return Query(**kwargs)

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -63,7 +63,7 @@ class Dataset(object):
                       dataset_id=self.dataset_id)
 
     def key(self, *path_args, **kwargs):
-        """Proxy to :func:`gcloud.datastore.key.Key`.
+        """Proxy to :class:`gcloud.datastore.key.Key`.
 
         Passes our ``dataset_id``.
         """
@@ -73,14 +73,14 @@ class Dataset(object):
         return Key(*path_args, **kwargs)
 
     def batch(self):
-        """Proxy to :func:`gcloud.datastore.batch.Batch`.
+        """Proxy to :class:`gcloud.datastore.batch.Batch`.
 
         Passes our ``dataset_id``.
         """
         return Batch(dataset_id=self.dataset_id, connection=self.connection)
 
     def transaction(self):
-        """Proxy to :func:`gcloud.datastore.transaction.Transaction`.
+        """Proxy to :class:`gcloud.datastore.transaction.Transaction`.
 
         Passes our ``dataset_id``.
         """
@@ -88,7 +88,7 @@ class Dataset(object):
                            connection=self.connection)
 
     def query(self, **kwargs):
-        """Proxy to :func:`gcloud.datastore.query.Query`.
+        """Proxy to :class:`gcloud.datastore.query.Query`.
 
         Passes our ``dataset_id``.
         """

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -23,7 +23,14 @@ from gcloud.datastore.transaction import Transaction
 
 
 class Dataset(object):
-    """Convenience wrapper for invoking APIs/factories w/ a dataset ID."""
+    """Convenience wrapper for invoking APIs/factories w/ a dataset ID.
+    
+    :type dataset_id: string
+    :param dataset_id: (required) dataset ID to pass to proxied API methods.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`, or None
+    :param connection: (optional) connection to pass to proxied API methods
+    """
 
     def __init__(self, dataset_id, connection=None):
         if dataset_id is None:

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -25,31 +25,32 @@ from gcloud.datastore.transaction import Transaction
 class Dataset(object):
     """Convenience wrapper for invoking APIs/factories w/ a dataset ID."""
 
-    def __init__(self, dataset_id):
+    def __init__(self, dataset_id, connection=None):
         if dataset_id is None:
             raise ValueError('dataset_id required')
         self.dataset_id = dataset_id
+        self.connection = connection
 
-    def get(self, keys, missing=None, deferred=None, connection=None):
+    def get(self, keys, missing=None, deferred=None):
         """Proxy to :func:`gcloud.datastore.api.get`.
 
         Passes our ``dataset_id``.
         """
-        return get(keys, missing, deferred, connection, self.dataset_id)
+        return get(keys, missing, deferred, self.connection, self.dataset_id)
 
-    def put(self, entities, connection=None):
+    def put(self, entities):
         """Proxy to :func:`gcloud.datastore.api.put`.
 
         Passes our ``dataset_id``.
         """
-        return put(entities, connection, dataset_id=self.dataset_id)
+        return put(entities, self.connection, dataset_id=self.dataset_id)
 
-    def delete(self, keys, connection=None):
+    def delete(self, keys):
         """Proxy to :func:`gcloud.datastore.api.delete`.
 
         Passes our ``dataset_id``.
         """
-        return delete(keys, connection, dataset_id=self.dataset_id)
+        return delete(keys, self.connection, dataset_id=self.dataset_id)
 
     def key(self, *path_args, **kwargs):
         """Proxy to :func:`gcloud.datastore.key.Key`.
@@ -62,19 +63,20 @@ class Dataset(object):
         kwargs['dataset_id'] = self.dataset_id
         return Key(*path_args, **kwargs)
 
-    def batch(self, connection=None):
+    def batch(self):
         """Proxy to :func:`gcloud.datastore.batch.Batch`.
 
         Passes our ``dataset_id``.
         """
-        return Batch(dataset_id=self.dataset_id, connection=connection)
+        return Batch(dataset_id=self.dataset_id, connection=self.connection)
 
-    def transaction(self, connection=None):
+    def transaction(self):
         """Proxy to :func:`gcloud.datastore.transaction.Transaction`.
 
         Passes our ``dataset_id``.
         """
-        return Transaction(dataset_id=self.dataset_id, connection=connection)
+        return Transaction(dataset_id=self.dataset_id,
+                           connection=self.connection)
 
     def query(self,
               kind=None,

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -67,9 +67,8 @@ class Dataset(object):
 
         Passes our ``dataset_id``.
         """
-        dataset_id = kwargs.pop('dataset_id', None)
-        if dataset_id not in (None, self.dataset_id):
-            raise ValueError('Conflicting dataset_id')
+        if 'dataset_id' in kwargs:
+            raise TypeError('Cannot pass dataset_id')
         kwargs['dataset_id'] = self.dataset_id
         return Key(*path_args, **kwargs)
 

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -1,0 +1,91 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Convenience wrapper for invoking APIs/factories w/ a dataset ID."""
+
+from gcloud.datastore.api import delete
+from gcloud.datastore.api import get
+from gcloud.datastore.api import put
+from gcloud.datastore.batch import Batch
+from gcloud.datastore.key import Key
+from gcloud.datastore.query import Query
+from gcloud.datastore.transaction import Transaction
+
+
+class Dataset(object):
+
+    def __init__(self, dataset_id):
+        if dataset_id is None:
+            raise ValueError('dataset_id required')
+        self.dataset_id = dataset_id
+
+    def get(self, keys, missing=None, deferred=None, connection=None):
+        """Proxy to :func:`gcloud.datastore.api.get`.
+
+        Passes our ``dataset_id``.
+        """
+        return get(keys, missing, deferred, connection, self.dataset_id)
+
+    def put(self, entities, connection=None):
+        """Proxy to :func:`gcloud.datastore.api.put`.
+
+        Passes our ``dataset_id``.
+        """
+        return put(entities, connection, dataset_id=self.dataset_id)
+
+    def delete(self, keys, connection=None):
+        """Proxy to :func:`gcloud.datastore.api.delete`.
+
+        Passes our ``dataset_id``.
+        """
+        return delete(keys, connection, dataset_id=self.dataset_id)
+
+    def key(self, *path_args, **kwargs):
+        """Proxy to :func:`gcloud.datastore.key.Key`.
+
+        Passes our ``dataset_id``.
+        """
+        dataset_id = kwargs.pop('dataset_id', None)
+        if dataset_id not in (None, self.dataset_id):
+            raise ValueError('Conflicting dataset_id')
+        kwargs['dataset_id'] = self.dataset_id
+        return Key(*path_args, **kwargs)
+
+    def batch(self, connection=None):
+        """Proxy to :func:`gcloud.datastore.batch.Batch`.
+
+        Passes our ``dataset_id``.
+        """
+        return Batch(dataset_id=self.dataset_id, connection=connection)
+
+    def transaction(self, connection=None):
+        """Proxy to :func:`gcloud.datastore.transaction.Transaction`.
+
+        Passes our ``dataset_id``.
+        """
+        return Transaction(dataset_id=self.dataset_id, connection=connection)
+
+    def query(self,
+              kind=None,
+              namespace=None,
+              ancestor=None,
+              filters=(),
+              projection=(),
+              order=(),
+              group_by=()):
+        """Proxy to :func:`gcloud.datastore.query.Query`.
+
+        Passes our ``dataset_id``.
+        """
+        return Query(self.dataset_id, kind, namespace, ancestor, filters,
+                     projection, order, group_by)

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -23,6 +23,7 @@ from gcloud.datastore.transaction import Transaction
 
 
 class Dataset(object):
+    """Convenience wrapper for invoking APIs/factories w/ a dataset ID."""
 
     def __init__(self, dataset_id):
         if dataset_id is None:

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -157,26 +157,12 @@ class TestDataset(unittest2.TestCase):
         self.assertTrue(_called_with[0][1]['connection'] is conn)
         self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
-    def test_key_w_conflicting_dataset_id(self):
+    def test_key_w_dataset_id(self):
         KIND = 'KIND'
         ID = 1234
         dataset = self._makeOne()
-        self.assertRaises(ValueError,
-                          dataset.key, KIND, ID, dataset_id='OTHER')
-
-    def test_key_w_matching_dataset_id(self):
-        from gcloud.datastore import dataset as MUT
-        from gcloud._testing import _Monkey
-        KIND = 'KIND'
-        ID = 1234
-        dataset = self._makeOne()
-
-        with _Monkey(MUT, Key=_Dummy):
-            key = dataset.key(KIND, ID, dataset_id=self.DATASET_ID)
-
-        self.assertTrue(isinstance(key, _Dummy))
-        self.assertEqual(key.args, (KIND, ID))
-        self.assertEqual(key.kwargs, {'dataset_id': self.DATASET_ID})
+        self.assertRaises(TypeError,
+                          dataset.key, KIND, ID, dataset_id=self.DATASET_ID)
 
     def test_key_wo_dataset_id(self):
         from gcloud.datastore import dataset as MUT

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -232,6 +232,12 @@ class TestDataset(unittest2.TestCase):
         self.assertEqual(xact.kwargs,
                          {'dataset_id': self.DATASET_ID, 'connection': conn})
 
+    def test_query_w_dataset_id(self):
+        KIND = 'KIND'
+        dataset = self._makeOne()
+        self.assertRaises(TypeError,
+                          dataset.query, kind=KIND, dataset_id=self.DATASET_ID)
+
     def test_query_w_defaults(self):
         from gcloud.datastore import dataset as MUT
         from gcloud._testing import _Monkey
@@ -241,9 +247,8 @@ class TestDataset(unittest2.TestCase):
             query = dataset.query()
 
         self.assertTrue(isinstance(query, _Dummy))
-        args = (self.DATASET_ID, None, None, None, (), (), (), ())
-        self.assertEqual(query.args, args)
-        self.assertEqual(query.kwargs, {})
+        self.assertEqual(query.args, ())
+        self.assertEqual(query.kwargs, {'dataset_id': self.DATASET_ID})
 
     def test_query_explicit(self):
         from gcloud.datastore import dataset as MUT
@@ -258,14 +263,29 @@ class TestDataset(unittest2.TestCase):
         dataset = self._makeOne()
 
         with _Monkey(MUT, Query=_Dummy):
-            query = dataset.query(KIND, NAMESPACE, ANCESTOR, FILTERS,
-                                  PROJECTION, ORDER, GROUP_BY)
+            query = dataset.query(
+                kind=KIND,
+                namespace=NAMESPACE,
+                ancestor=ANCESTOR,
+                filters=FILTERS,
+                projection=PROJECTION,
+                order=ORDER,
+                group_by=GROUP_BY,
+                )
 
         self.assertTrue(isinstance(query, _Dummy))
-        args = (self.DATASET_ID, KIND, NAMESPACE, ANCESTOR, FILTERS,
-                PROJECTION, ORDER, GROUP_BY)
-        self.assertEqual(query.args, args)
-        self.assertEqual(query.kwargs, {})
+        kwargs = {
+            'dataset_id': self.DATASET_ID,
+            'kind': KIND,
+            'namespace': NAMESPACE,
+            'ancestor': ANCESTOR,
+            'filters': FILTERS,
+            'projection': PROJECTION,
+            'order': ORDER,
+            'group_by': GROUP_BY,
+        }
+        self.assertEqual(query.args, ())
+        self.assertEqual(query.kwargs, kwargs)
 
 
 class _Dummy(object):

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -1,0 +1,272 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+
+class TestDataset(unittest2.TestCase):
+
+    DATASET_ID = 'DATASET'
+
+    def _getTargetClass(self):
+        from gcloud.datastore.dataset import Dataset
+        return Dataset
+
+    def _makeOne(self, dataset_id=DATASET_ID):
+        return self._getTargetClass()(dataset_id=dataset_id)
+
+    def test_ctor_w_None(self):
+        self.assertRaises(ValueError, self._makeOne, None)
+
+    def test_ctor_w_dataset_id(self):
+        dataset = self._makeOne()
+        self.assertEqual(dataset.dataset_id, self.DATASET_ID)
+
+    def test_get_defaults(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _get(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        key = object()
+
+        with _Monkey(MUT, get=_get):
+            dataset.get([key])
+
+        args = ([key], None, None, None, self.DATASET_ID)
+        self.assertEqual(_called_with, [(args, {})])
+
+    def test_get_explicit(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _get(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        key, missing, deferred, conn = object(), [], [], object()
+
+        with _Monkey(MUT, get=_get):
+            dataset.get([key], missing, deferred, conn)
+
+        args = ([key], missing, deferred, conn, self.DATASET_ID)
+        self.assertEqual(_called_with, [(args, {})])
+
+    def test_put_wo_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _put(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        entity = object()
+
+        with _Monkey(MUT, put=_put):
+            dataset.put([entity])
+
+        self.assertEqual(_called_with,
+                         [(([entity], None), {'dataset_id': self.DATASET_ID})])
+
+    def test_put_w_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _put(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        entity, conn = object(), object()
+
+        with _Monkey(MUT, put=_put):
+            dataset.put([entity], conn)
+
+        self.assertEqual(_called_with,
+                         [(([entity], conn), {'dataset_id': self.DATASET_ID})])
+
+    def test_delete_wo_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _delete(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        key = object()
+
+        with _Monkey(MUT, delete=_delete):
+            dataset.delete([key])
+
+        self.assertEqual(_called_with,
+                         [(([key], None), {'dataset_id': self.DATASET_ID})])
+
+    def test_delete_w_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _delete(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        key, conn = object(), object()
+        with _Monkey(MUT, delete=_delete):
+            dataset.delete([key], conn)
+
+        self.assertEqual(_called_with,
+                         [(([key], conn), {'dataset_id': self.DATASET_ID})])
+
+    def test_key_w_conflicting_dataset_id(self):
+        KIND = 'KIND'
+        ID = 1234
+        dataset = self._makeOne()
+        self.assertRaises(ValueError,
+                          dataset.key, KIND, ID, dataset_id='OTHER')
+
+    def test_key_w_matching_dataset_id(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        KIND = 'KIND'
+        ID = 1234
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Key=_Dummy):
+            key = dataset.key(KIND, ID, dataset_id=self.DATASET_ID)
+
+        self.assertTrue(isinstance(key, _Dummy))
+        self.assertEqual(key.args, (KIND, ID))
+        self.assertEqual(key.kwargs, {'dataset_id': self.DATASET_ID})
+
+    def test_key_wo_dataset_id(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        KIND = 'KIND'
+        ID = 1234
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Key=_Dummy):
+            key = dataset.key(KIND, ID)
+
+        self.assertTrue(isinstance(key, _Dummy))
+        self.assertEqual(key.args, (KIND, ID))
+        self.assertEqual(key.kwargs, {'dataset_id': self.DATASET_ID})
+
+    def test_batch_wo_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Batch=_Dummy):
+            batch = dataset.batch()
+
+        self.assertTrue(isinstance(batch, _Dummy))
+        self.assertEqual(batch.args, ())
+        self.assertEqual(batch.kwargs,
+                         {'dataset_id': self.DATASET_ID, 'connection': None})
+
+    def test_batch_w_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        dataset = self._makeOne()
+        conn = object()
+
+        with _Monkey(MUT, Batch=_Dummy):
+            batch = dataset.batch(conn)
+
+        self.assertTrue(isinstance(batch, _Dummy))
+        self.assertEqual(batch.args, ())
+        self.assertEqual(batch.kwargs,
+                         {'dataset_id': self.DATASET_ID, 'connection': conn})
+
+    def test_transaction_wo_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Transaction=_Dummy):
+            xact = dataset.transaction()
+
+        self.assertTrue(isinstance(xact, _Dummy))
+        self.assertEqual(xact.args, ())
+        self.assertEqual(xact.kwargs,
+                         {'dataset_id': self.DATASET_ID, 'connection': None})
+
+    def test_transaction_w_connection(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        dataset = self._makeOne()
+        conn = object()
+
+        with _Monkey(MUT, Transaction=_Dummy):
+            xact = dataset.transaction(conn)
+
+        self.assertTrue(isinstance(xact, _Dummy))
+        self.assertEqual(xact.args, ())
+        self.assertEqual(xact.kwargs,
+                         {'dataset_id': self.DATASET_ID, 'connection': conn})
+
+    def test_query_w_defaults(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Query=_Dummy):
+            query = dataset.query()
+
+        self.assertTrue(isinstance(query, _Dummy))
+        args = (self.DATASET_ID, None, None, None, (), (), (), ())
+        self.assertEqual(query.args, args)
+        self.assertEqual(query.kwargs, {})
+
+    def test_query_explicit(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+        KIND = 'KIND'
+        NAMESPACE = 'NAMESPACE'
+        ANCESTOR = object()
+        FILTERS = [('PROPERTY', '==', 'VALUE')]
+        PROJECTION = ['__key__']
+        ORDER = ['PROPERTY']
+        GROUP_BY = ['GROUPBY']
+        dataset = self._makeOne()
+
+        with _Monkey(MUT, Query=_Dummy):
+            query = dataset.query(KIND, NAMESPACE, ANCESTOR, FILTERS,
+                                  PROJECTION, ORDER, GROUP_BY)
+
+        self.assertTrue(isinstance(query, _Dummy))
+        args = (self.DATASET_ID, KIND, NAMESPACE, ANCESTOR, FILTERS,
+                PROJECTION, ORDER, GROUP_BY)
+        self.assertEqual(query.args, args)
+        self.assertEqual(query.kwargs, {})
+
+
+class _Dummy(object):
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -54,8 +54,11 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, get=_get):
             dataset.get([key])
 
-        args = ([key], None, None, None, self.DATASET_ID)
-        self.assertEqual(_called_with, [(args, {})])
+        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertTrue(_called_with[0][1]['missing'] is None)
+        self.assertTrue(_called_with[0][1]['deferred'] is None)
+        self.assertTrue(_called_with[0][1]['connection'] is None)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_get_explicit(self):
         from gcloud.datastore import dataset as MUT
@@ -73,8 +76,11 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, get=_get):
             dataset.get([key], missing, deferred)
 
-        args = ([key], missing, deferred, conn, self.DATASET_ID)
-        self.assertEqual(_called_with, [(args, {})])
+        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertTrue(_called_with[0][1]['missing'] is missing)
+        self.assertTrue(_called_with[0][1]['deferred'] is deferred)
+        self.assertTrue(_called_with[0][1]['connection'] is conn)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_put_wo_connection(self):
         from gcloud.datastore import dataset as MUT
@@ -91,8 +97,9 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, put=_put):
             dataset.put([entity])
 
-        self.assertEqual(_called_with,
-                         [(([entity], None), {'dataset_id': self.DATASET_ID})])
+        self.assertEqual(_called_with[0][0], ([entity],))
+        self.assertTrue(_called_with[0][1]['connection'] is None)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_put_w_connection(self):
         from gcloud.datastore import dataset as MUT
@@ -109,8 +116,9 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, put=_put):
             dataset.put([entity])
 
-        self.assertEqual(_called_with,
-                         [(([entity], conn), {'dataset_id': self.DATASET_ID})])
+        self.assertEqual(_called_with[0][0], ([entity],))
+        self.assertTrue(_called_with[0][1]['connection'] is conn)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_delete_wo_connection(self):
         from gcloud.datastore import dataset as MUT
@@ -127,8 +135,9 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, delete=_delete):
             dataset.delete([key])
 
-        self.assertEqual(_called_with,
-                         [(([key], None), {'dataset_id': self.DATASET_ID})])
+        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertTrue(_called_with[0][1]['connection'] is None)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_delete_w_connection(self):
         from gcloud.datastore import dataset as MUT
@@ -144,8 +153,9 @@ class TestDataset(unittest2.TestCase):
         with _Monkey(MUT, delete=_delete):
             dataset.delete([key])
 
-        self.assertEqual(_called_with,
-                         [(([key], conn), {'dataset_id': self.DATASET_ID})])
+        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertTrue(_called_with[0][1]['connection'] is conn)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
 
     def test_key_w_conflicting_dataset_id(self):
         KIND = 'KIND'


### PR DESCRIPTION
Wrapper around 'datastore.api.{get,put,delete}', plus the 'Key',
'Batch', 'Transaction', and 'Query' factories.

Per @jgeewax in #659.