### PR TITLE
Replacing _implicit_environ module globals with a container.

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -99,7 +99,7 @@ def set_default_dataset_id(dataset_id=None):
         dataset_id = _implicit_environ.compute_engine_id()
 
     if dataset_id is not None:
-        _implicit_environ.DATASET_ID = dataset_id
+        _implicit_environ._DEFAULTS.dataset_id = dataset_id
     else:
         raise EnvironmentError('No dataset ID could be inferred.')
 
@@ -111,7 +111,7 @@ def set_default_connection(connection=None):
     :param connection: A connection provided to be the default.
     """
     connection = connection or get_connection()
-    _implicit_environ.CONNECTION = connection
+    _implicit_environ._DEFAULTS.connection = connection
 
 
 def set_defaults(dataset_id=None, connection=None):

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -28,11 +28,19 @@ except ImportError:
     app_identity = None
 
 
-DATASET_ID = None
-"""Module global to allow persistent implied dataset ID from enviroment."""
+class _DefaultsContainer(object):
+    """Container for defaults.
 
-CONNECTION = None
-"""Module global to allow persistent implied connection from enviroment."""
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: Persistent implied connection from environment.
+
+    :type dataset_id: string
+    :param dataset_id: Persistent implied dataset ID from environment.
+    """
+
+    def __init__(self, connection=None, dataset_id=None):
+        self.connection = connection
+        self.dataset_id = dataset_id
 
 
 def app_engine_id():
@@ -87,7 +95,7 @@ def get_default_connection():
     :rtype: :class:`gcloud.datastore.connection.Connection` or ``NoneType``
     :returns: The default connection if one has been set.
     """
-    return CONNECTION
+    return _DEFAULTS.connection
 
 
 def get_default_dataset_id():
@@ -96,4 +104,7 @@ def get_default_dataset_id():
     :rtype: string or ``NoneType``
     :returns: The default dataset ID if one has been set.
     """
-    return DATASET_ID
+    return _DEFAULTS.dataset_id
+
+
+_DEFAULTS = _DefaultsContainer()

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -19,12 +19,13 @@ class Test_set_default_dataset_id(unittest2.TestCase):
 
     def setUp(self):
         from gcloud.datastore import _implicit_environ
-        self._replaced_dataset_id = _implicit_environ.DATASET_ID
-        _implicit_environ.DATASET_ID = None
+        self._replaced_defaults = _implicit_environ._DEFAULTS
+        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
+            None, None)
 
     def tearDown(self):
         from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET_ID = self._replaced_dataset_id
+        _implicit_environ._DEFAULTS = self._replaced_defaults
 
     def _callFUT(self, dataset_id=None):
         from gcloud.datastore import set_default_dataset_id
@@ -60,7 +61,7 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self.assertRaises(EnvironmentError, self._callFUT)
 
-        self.assertEqual(_implicit_environ.DATASET_ID, None)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(), None)
 
     def test_set_from_env_var(self):
         from gcloud.datastore import _implicit_environ
@@ -70,7 +71,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, IMPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         IMPLICIT_DATASET_ID)
 
     def test_set_explicit_w_env_var_set(self):
         from gcloud.datastore import _implicit_environ
@@ -80,7 +82,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT(EXPLICIT_DATASET_ID)
 
-        self.assertEqual(_implicit_environ.DATASET_ID, EXPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         EXPLICIT_DATASET_ID)
 
     def test_set_explicit_no_env_var_set(self):
         from gcloud.datastore import _implicit_environ
@@ -91,7 +94,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT(EXPLICIT_DATASET_ID)
 
-        self.assertEqual(_implicit_environ.DATASET_ID, EXPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         EXPLICIT_DATASET_ID)
 
     def test_set_explicit_None_wo_env_var_set(self):
         from gcloud.datastore import _implicit_environ
@@ -100,7 +104,7 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self.assertRaises(EnvironmentError, self._callFUT, None)
 
-        self.assertEqual(_implicit_environ.DATASET_ID, None)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(), None)
 
     def test_set_explicit_None_w_env_var_set(self):
         from gcloud.datastore import _implicit_environ
@@ -110,7 +114,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT(None)
 
-        self.assertEqual(_implicit_environ.DATASET_ID, IMPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         IMPLICIT_DATASET_ID)
 
     def test_set_from_gcd_env_var(self):
         from gcloud.datastore import _GCD_DATASET_ENV_VAR_NAME
@@ -123,7 +128,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, GCD_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         GCD_DATASET_ID)
 
     def test_set_gcd_and_production_env_vars(self):
         from gcloud.datastore import _DATASET_ENV_VAR_NAME
@@ -141,8 +147,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit():
                 self._callFUT()
 
-        self.assertNotEqual(_implicit_environ.DATASET_ID, GCD_DATASET_ID)
-        self.assertEqual(_implicit_environ.DATASET_ID, IMPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         IMPLICIT_DATASET_ID)
 
     def test_set_gcd_env_vars_and_appengine(self):
         from gcloud.datastore import _GCD_DATASET_ENV_VAR_NAME
@@ -158,8 +164,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit(app_identity=APP_IDENTITY):
                 self._callFUT()
 
-        self.assertNotEqual(_implicit_environ.DATASET_ID, APP_ENGINE_ID)
-        self.assertEqual(_implicit_environ.DATASET_ID, GCD_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         GCD_DATASET_ID)
 
     def test_set_implicit_from_appengine(self):
         from gcloud.datastore import _implicit_environ
@@ -171,7 +177,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit(app_identity=APP_IDENTITY):
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, APP_ENGINE_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         APP_ENGINE_ID)
 
     def test_set_implicit_both_env_and_appengine(self):
         from gcloud.datastore import _implicit_environ
@@ -183,7 +190,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
             with self._monkeyImplicit(app_identity=APP_IDENTITY):
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, IMPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         IMPLICIT_DATASET_ID)
 
     def _implicit_compute_engine_helper(self, status):
         from gcloud.datastore import _implicit_environ
@@ -206,7 +214,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
                 else:
                     self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, EXPECTED_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         EXPECTED_ID)
         self.assertEqual(connection.host, '169.254.169.254')
         self.assertEqual(connection.timeout, 0.1)
         self.assertEqual(
@@ -241,7 +250,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
                                       app_identity=APP_IDENTITY):
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, APP_ENGINE_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         APP_ENGINE_ID)
         self.assertEqual(connection.host, None)
         self.assertEqual(connection.timeout, None)
 
@@ -257,7 +267,8 @@ class Test_set_default_dataset_id(unittest2.TestCase):
                                       app_identity=APP_IDENTITY):
                 self._callFUT()
 
-        self.assertEqual(_implicit_environ.DATASET_ID, IMPLICIT_DATASET_ID)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(),
+                         IMPLICIT_DATASET_ID)
         self.assertEqual(connection.host, None)
         self.assertEqual(connection.timeout, None)
 
@@ -266,12 +277,13 @@ class Test_set_default_connection(unittest2.TestCase):
 
     def setUp(self):
         from gcloud.datastore import _implicit_environ
-        self._replaced_connection = _implicit_environ.CONNECTION
-        _implicit_environ.CONNECTION = None
+        self._replaced_defaults = _implicit_environ._DEFAULTS
+        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
+            None, None)
 
     def tearDown(self):
         from gcloud.datastore import _implicit_environ
-        _implicit_environ.CONNECTION = self._replaced_connection
+        _implicit_environ._DEFAULTS = self._replaced_defaults
 
     def _callFUT(self, connection=None):
         from gcloud.datastore import set_default_connection
@@ -280,23 +292,23 @@ class Test_set_default_connection(unittest2.TestCase):
     def test_set_explicit(self):
         from gcloud.datastore import _implicit_environ
 
-        self.assertEqual(_implicit_environ.CONNECTION, None)
+        self.assertEqual(_implicit_environ.get_default_connection(), None)
         fake_cnxn = object()
         self._callFUT(connection=fake_cnxn)
-        self.assertEqual(_implicit_environ.CONNECTION, fake_cnxn)
+        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
 
     def test_set_implicit(self):
         from gcloud._testing import _Monkey
         from gcloud import datastore
         from gcloud.datastore import _implicit_environ
 
-        self.assertEqual(_implicit_environ.CONNECTION, None)
+        self.assertEqual(_implicit_environ.get_default_connection(), None)
 
         fake_cnxn = object()
         with _Monkey(datastore, get_connection=lambda: fake_cnxn):
             self._callFUT()
 
-        self.assertEqual(_implicit_environ.CONNECTION, fake_cnxn)
+        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
 
 
 class Test_set_defaults(unittest2.TestCase):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -29,7 +29,8 @@ class Test_get_default_connection(unittest2.TestCase):
         from gcloud.datastore import _implicit_environ
 
         SENTINEL = object()
-        with _Monkey(_implicit_environ, CONNECTION=SENTINEL):
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(SENTINEL, None)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             self.assertEqual(self._callFUT(), SENTINEL)
 
 
@@ -47,5 +48,6 @@ class Test_get_default_dataset_id(unittest2.TestCase):
         from gcloud.datastore import _implicit_environ
 
         SENTINEL = object()
-        with _Monkey(_implicit_environ, DATASET_ID=SENTINEL):
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, SENTINEL)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             self.assertEqual(self._callFUT(), SENTINEL)

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -30,9 +30,8 @@ class TestBatch(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
 
-        with _Monkey(_implicit_environ,
-                     DATASET_ID=None,
-                     CONNECTION=None):
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, None)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             self.assertRaises(ValueError, self._makeOne)
             self.assertRaises(ValueError, self._makeOne, dataset_id=object())
             self.assertRaises(ValueError, self._makeOne, connection=object())
@@ -52,15 +51,15 @@ class TestBatch(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
         from gcloud.datastore._datastore_v1_pb2 import Mutation
-        DATASET_ID = 'DATASET'
+        _DATASET = 'DATASET'
         CONNECTION = _Connection()
 
-        with _Monkey(_implicit_environ,
-                     DATASET_ID=DATASET_ID,
-                     CONNECTION=CONNECTION):
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(CONNECTION,
+                                                             _DATASET)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             batch = self._makeOne()
 
-        self.assertEqual(batch.dataset_id, DATASET_ID)
+        self.assertEqual(batch.dataset_id, _DATASET)
         self.assertEqual(batch.connection, CONNECTION)
         self.assertTrue(isinstance(batch.mutation, Mutation))
         self.assertEqual(batch._auto_id_entities, [])

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -23,12 +23,13 @@ class TestEntity(unittest2.TestCase):
 
     def setUp(self):
         from gcloud.datastore import _implicit_environ
-        self._replaced_dataset_id = _implicit_environ.DATASET_ID
-        _implicit_environ.DATASET_ID = None
+        self._replaced_defaults = _implicit_environ._DEFAULTS
+        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
+            None, None)
 
     def tearDown(self):
         from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET_ID = self._replaced_dataset_id
+        _implicit_environ._DEFAULTS = self._replaced_defaults
 
     def _getTargetClass(self):
         from gcloud.datastore.entity import Entity

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -19,12 +19,13 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
     def setUp(self):
         from gcloud.datastore import _implicit_environ
-        self._replaced_dataset_id = _implicit_environ.DATASET_ID
-        _implicit_environ.DATASET_ID = None
+        self._replaced_defaults = _implicit_environ._DEFAULTS
+        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
+            None, None)
 
     def tearDown(self):
         from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET_ID = self._replaced_dataset_id
+        _implicit_environ._DEFAULTS = self._replaced_defaults
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import entity_from_protobuf

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -20,14 +20,14 @@ class TestKey(unittest2.TestCase):
     _DEFAULT_DATASET = 'DATASET'
 
     def setUp(self):
-
         from gcloud.datastore import _implicit_environ
-        self._replaced_dataset_id = _implicit_environ.DATASET_ID
-        _implicit_environ.DATASET_ID = None
+        self._replaced_defaults = _implicit_environ._DEFAULTS
+        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
+            None, None)
 
     def tearDown(self):
         from gcloud.datastore import _implicit_environ
-        _implicit_environ.DATASET_ID = self._replaced_dataset_id
+        _implicit_environ._DEFAULTS = self._replaced_defaults
 
     def _getTargetClass(self):
         from gcloud.datastore.key import Key
@@ -39,7 +39,8 @@ class TestKey(unittest2.TestCase):
     def _monkeyDatasetID(self, dataset_id=_DEFAULT_DATASET):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
-        return _Monkey(_implicit_environ, DATASET_ID=dataset_id)
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, dataset_id)
+        return _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS)
 
     def test_ctor_empty(self):
         self.assertRaises(ValueError, self._makeOne)

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -31,7 +31,9 @@ class TestQuery(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
         _DATASET = 'DATASET'
-        with _Monkey(_implicit_environ, DATASET_ID=_DATASET):
+
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, _DATASET)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             query = self._makeOne()
         self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, None)
@@ -319,7 +321,9 @@ class TestQuery(unittest2.TestCase):
         _KIND = 'KIND'
         connection = _Connection()
         query = self._makeOne(_DATASET, _KIND)
-        with _Monkey(_implicit_environ, CONNECTION=connection):
+
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(connection, None)
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             iterator = query.fetch()
         self.assertTrue(iterator._query is query)
         self.assertEqual(iterator._limit, None)

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -29,7 +29,7 @@ class TestTransaction(unittest2.TestCase):
     def test_ctor_missing_required(self):
         from gcloud.datastore import _implicit_environ
 
-        self.assertEqual(_implicit_environ.DATASET_ID, None)
+        self.assertEqual(_implicit_environ.get_default_dataset_id(), None)
 
         with self.assertRaises(ValueError):
             self._makeOne()
@@ -55,11 +55,12 @@ class TestTransaction(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
 
-        DATASET_ID = 'DATASET'
         CONNECTION = _Connection()
+        DATASET_ID = 'DATASET'
+        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(CONNECTION,
+                                                             DATASET_ID)
 
-        with _Monkey(_implicit_environ, DATASET_ID=DATASET_ID,
-                     CONNECTION=CONNECTION):
+        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
             xact = self._makeOne()
 
         self.assertEqual(xact.id, None)


### PR DESCRIPTION
This is so that a container instance can have lazily loaded properties.

**NOTE**: Has #663 as a diffbase