### PR TITLE
Adding datastore _DEFAULTS stubs in all tests that use it.

### DIFF
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -38,7 +38,8 @@ class _DefaultsContainer(object):
     :param dataset_id: Persistent implied dataset ID from environment.
     """
 
-    def __init__(self, connection=None, dataset_id=None):
+    def __init__(self, connection=None, dataset_id=None, implicit=False):
+        self.implicit = implicit
         self.connection = connection
         self.dataset_id = dataset_id
 
@@ -107,4 +108,4 @@ def get_default_dataset_id():
     return _DEFAULTS.dataset_id
 
 
-_DEFAULTS = _DefaultsContainer()
+_DEFAULTS = _DefaultsContainer(implicit=True)

--- a/gcloud/datastore/_testing.py
+++ b/gcloud/datastore/_testing.py
@@ -1,0 +1,33 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared datastore testing utilities."""
+
+from gcloud._testing import _Monkey
+from gcloud.datastore import _implicit_environ
+from gcloud.datastore._implicit_environ import _DefaultsContainer
+
+
+def _monkey_defaults(*args, **kwargs):
+    mock_defaults = _DefaultsContainer(*args, **kwargs)
+    return _Monkey(_implicit_environ, _DEFAULTS=mock_defaults)
+
+
+def _setup_defaults(test_case):
+    test_case._replaced_defaults = _implicit_environ._DEFAULTS
+    _implicit_environ._DEFAULTS = _DefaultsContainer()
+
+
+def _tear_down_defaults(test_case):
+    _implicit_environ._DEFAULTS = test_case._replaced_defaults

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -18,14 +18,12 @@ import unittest2
 class Test_set_default_dataset_id(unittest2.TestCase):
 
     def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_defaults = _implicit_environ._DEFAULTS
-        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
-            None, None)
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
 
     def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ._DEFAULTS = self._replaced_defaults
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _callFUT(self, dataset_id=None):
         from gcloud.datastore import set_default_dataset_id
@@ -276,14 +274,12 @@ class Test_set_default_dataset_id(unittest2.TestCase):
 class Test_set_default_connection(unittest2.TestCase):
 
     def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_defaults = _implicit_environ._DEFAULTS
-        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
-            None, None)
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
 
     def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ._DEFAULTS = self._replaced_defaults
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _callFUT(self, connection=None):
         from gcloud.datastore import set_default_connection

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -17,6 +17,14 @@ import unittest2
 
 class Test_get_default_connection(unittest2.TestCase):
 
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
+
     def _callFUT(self):
         from gcloud.datastore._implicit_environ import get_default_connection
         return get_default_connection()
@@ -25,16 +33,22 @@ class Test_get_default_connection(unittest2.TestCase):
         self.assertEqual(self._callFUT(), None)
 
     def test_preset(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
 
         SENTINEL = object()
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(SENTINEL, None)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults(connection=SENTINEL):
             self.assertEqual(self._callFUT(), SENTINEL)
 
 
 class Test_get_default_dataset_id(unittest2.TestCase):
+
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _callFUT(self):
         from gcloud.datastore._implicit_environ import get_default_dataset_id
@@ -44,10 +58,8 @@ class Test_get_default_dataset_id(unittest2.TestCase):
         self.assertEqual(self._callFUT(), None)
 
     def test_preset(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
 
         SENTINEL = object()
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, SENTINEL)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults(dataset_id=SENTINEL):
             self.assertEqual(self._callFUT(), SENTINEL)

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -27,11 +27,9 @@ class TestBatch(unittest2.TestCase):
                                       connection=connection)
 
     def test_ctor_missing_required(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
 
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, None)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults():
             self.assertRaises(ValueError, self._makeOne)
             self.assertRaises(ValueError, self._makeOne, dataset_id=object())
             self.assertRaises(ValueError, self._makeOne, connection=object())
@@ -48,15 +46,12 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(batch._auto_id_entities, [])
 
     def test_ctor_implicit(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
         from gcloud.datastore._datastore_v1_pb2 import Mutation
         _DATASET = 'DATASET'
         CONNECTION = _Connection()
 
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(CONNECTION,
-                                                             _DATASET)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults(connection=CONNECTION, dataset_id=_DATASET):
             batch = self._makeOne()
 
         self.assertEqual(batch.dataset_id, _DATASET)

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -22,14 +22,12 @@ _ID = 1234
 class TestEntity(unittest2.TestCase):
 
     def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_defaults = _implicit_environ._DEFAULTS
-        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
-            None, None)
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
 
     def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ._DEFAULTS = self._replaced_defaults
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _getTargetClass(self):
         from gcloud.datastore.entity import Entity

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -18,14 +18,12 @@ import unittest2
 class Test_entity_from_protobuf(unittest2.TestCase):
 
     def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_defaults = _implicit_environ._DEFAULTS
-        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
-            None, None)
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
 
     def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ._DEFAULTS = self._replaced_defaults
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import entity_from_protobuf
@@ -149,6 +147,14 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
 
 class Test_key_from_protobuf(unittest2.TestCase):
+
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import key_from_protobuf

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -20,14 +20,12 @@ class TestKey(unittest2.TestCase):
     _DEFAULT_DATASET = 'DATASET'
 
     def setUp(self):
-        from gcloud.datastore import _implicit_environ
-        self._replaced_defaults = _implicit_environ._DEFAULTS
-        _implicit_environ._DEFAULTS = _implicit_environ._DefaultsContainer(
-            None, None)
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
 
     def tearDown(self):
-        from gcloud.datastore import _implicit_environ
-        _implicit_environ._DEFAULTS = self._replaced_defaults
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
 
     def _getTargetClass(self):
         from gcloud.datastore.key import Key
@@ -37,10 +35,8 @@ class TestKey(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def _monkeyDatasetID(self, dataset_id=_DEFAULT_DATASET):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, dataset_id)
-        return _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS)
+        from gcloud.datastore._testing import _monkey_defaults
+        return _monkey_defaults(dataset_id=dataset_id)
 
     def test_ctor_empty(self):
         self.assertRaises(ValueError, self._makeOne)

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -17,6 +17,14 @@ import unittest2
 
 class TestQuery(unittest2.TestCase):
 
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
+
     def _getTargetClass(self):
         from gcloud.datastore.query import Query
         return Query
@@ -28,12 +36,10 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(ValueError, self._makeOne)
 
     def test_ctor_defaults_w_implicit_dataset_id(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
-        _DATASET = 'DATASET'
+        from gcloud.datastore._testing import _monkey_defaults
 
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(None, _DATASET)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        _DATASET = 'DATASET'
+        with _monkey_defaults(dataset_id=_DATASET):
             query = self._makeOne()
         self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, None)
@@ -315,15 +321,14 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(ValueError, query.fetch)
 
     def test_fetch_defaults_w_implicit_connection(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
+
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         connection = _Connection()
         query = self._makeOne(_DATASET, _KIND)
 
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(connection, None)
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults(connection=connection):
             iterator = query.fetch()
         self.assertTrue(iterator._query is query)
         self.assertEqual(iterator._limit, None)

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -17,6 +17,14 @@ import unittest2
 
 class TestTransaction(unittest2.TestCase):
 
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
+
     def _getTargetClass(self):
         from gcloud.datastore.transaction import Transaction
 
@@ -52,15 +60,11 @@ class TestTransaction(unittest2.TestCase):
         self.assertEqual(len(xact._auto_id_entities), 0)
 
     def test_ctor_with_env(self):
-        from gcloud._testing import _Monkey
-        from gcloud.datastore import _implicit_environ
+        from gcloud.datastore._testing import _monkey_defaults
 
         CONNECTION = _Connection()
         DATASET_ID = 'DATASET'
-        MOCK_DEFAULTS = _implicit_environ._DefaultsContainer(CONNECTION,
-                                                             DATASET_ID)
-
-        with _Monkey(_implicit_environ, _DEFAULTS=MOCK_DEFAULTS):
+        with _monkey_defaults(connection=CONNECTION, dataset_id=DATASET_ID):
             xact = self._makeOne()
 
         self.assertEqual(xact.id, None)


### PR DESCRIPTION
**NOTE**: Has #664 as diffbase

Introduces
- concept of `implicit` for `_DefaultsContainer`.
- testing module for datastore for patching

Verified all test cases that would accidentally rely on _DEFAULTS implicit
behavior by using a custom `_DefaultsContainer` that raises when the
instance is implicit.

Main delta for the custom properties:

```diff
diff --git a/gcloud/datastore/_implicit_environ.py b/gcloud/datastore/_implicit_environ.py
index 3afc954..1d38562 100644
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -38,9 +38,37 @@ class _DefaultsContainer(object):
 :param dataset_id: Persistent implied dataset ID from environment.
 """

-    def __init__(self, connection=None, dataset_id=None):
-        self.connection = connection
-        self.dataset_id = dataset_id
+    class FooError(Exception):
+        pass
+
+    @property
+    def dataset_id(self):
+        if self.implicit:
+            raise self.FooError
+        return self._dataset_id
+
+    @dataset_id.setter
+    def dataset_id(self, value):
+        if self.implicit:
+            raise self.FooError
+        self._dataset_id = value
+
+    @property
+    def connection(self):
+        if self.implicit:
+            raise self.FooError
+        return self._connection
+
+    @connection.setter
+    def connection(self, value):
+        if self.implicit:
+            raise self.FooError
+        self._connection = value
+
+    def __init__(self, connection=None, dataset_id=None, implicit=False):
+        self.implicit = implicit
+        self._connection = connection
+        self._dataset_id = dataset_id

 def app_engine_id():
```