### PR TITLE
Adding lazy loading support for dataset ID.

### DIFF
--- a/gcloud/datastore/_testing.py
+++ b/gcloud/datastore/_testing.py
@@ -24,9 +24,9 @@ def _monkey_defaults(*args, **kwargs):
     return _Monkey(_implicit_environ, _DEFAULTS=mock_defaults)
 
 
-def _setup_defaults(test_case):
+def _setup_defaults(test_case, *args, **kwargs):
     test_case._replaced_defaults = _implicit_environ._DEFAULTS
-    _implicit_environ._DEFAULTS = _DefaultsContainer()
+    _implicit_environ._DEFAULTS = _DefaultsContainer(*args, **kwargs)
 
 
 def _tear_down_defaults(test_case):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -321,6 +321,29 @@ class Test_set_default_dataset_id(unittest2.TestCase):
         self.assertEqual(connection.timeout, None)
 
 
+class Test__lazy_property_deco(unittest2.TestCase):
+
+    def _callFUT(self, deferred_callable):
+        from gcloud.datastore._implicit_environ import _lazy_property_deco
+        return _lazy_property_deco(deferred_callable)
+
+    def test_on_function(self):
+        def test_func():
+            pass  # pragma: NO COVER never gets called
+
+        lazy_prop = self._callFUT(test_func)
+        self.assertTrue(lazy_prop._deferred_callable is test_func)
+        self.assertEqual(lazy_prop._name, 'test_func')
+
+    def test_on_staticmethod(self):
+        def test_func():
+            pass  # pragma: NO COVER never gets called
+
+        lazy_prop = self._callFUT(staticmethod(test_func))
+        self.assertTrue(lazy_prop._deferred_callable is test_func)
+        self.assertEqual(lazy_prop._name, 'test_func')
+
+
 class Test_lazy_loaded_dataset_id(unittest2.TestCase):
 
     def setUp(self):

--- a/pylintrc_default
+++ b/pylintrc_default
@@ -73,6 +73,10 @@ ignore =
 #                  identical implementation but different docstrings.
 # - star-args:  standard Python idioms for varargs:
 #                  ancestor = Query().filter(*order_props)
+# - method-hidden: Decorating a method in a class (e.g. in _DefaultsContainer)
+#                      @_lazy_property_deco
+#                      def dataset_id():
+#                          ...
 disable =
     maybe-no-member,
     no-member,
@@ -80,6 +84,7 @@ disable =
     redefined-builtin,
     similarities,
     star-args,
+    method-hidden,
 
 
 [REPORTS]

--- a/regression/clear_datastore.py
+++ b/regression/clear_datastore.py
@@ -17,9 +17,10 @@
 from six.moves import input
 
 from gcloud import datastore
+from gcloud.datastore import _implicit_environ
 
 
-datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
+_implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
 datastore.set_defaults()
 
 

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -17,12 +17,13 @@ import pytz
 import unittest2
 
 from gcloud import datastore
+from gcloud.datastore import _implicit_environ
 # This assumes the command is being run via tox hence the
 # repository root is the current directory.
 from regression import populate_datastore
 
 
-datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
+_implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
 datastore.set_defaults()
 
 

--- a/regression/populate_datastore.py
+++ b/regression/populate_datastore.py
@@ -17,9 +17,10 @@
 from six.moves import zip
 
 from gcloud import datastore
+from gcloud.datastore import _implicit_environ
 
 
-datastore._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
+_implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
 datastore.set_defaults()
 
 


### PR DESCRIPTION
**NOTE**: Has #666 as diffbase.

Still need to support connection (and eventually do the same
in storage).

Again verified only the lazy loading tests used implicit
behavior via

```diff
diff --git a/gcloud/datastore/_implicit_environ.py b/gcloud/datastore/_implicit_environ.py
index 6e61636..6d67be6 100644
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -177,6 +177,10 @@ class _LazyProperty(object):
         self._method = method

     def __get__(self, obj, objtype):
+        class FooError(Exception):
+            pass
+        raise FooError
+
         if obj is None or objtype is not _DefaultsContainer:
             return self
```
