### PR TITLE
Adding lazy loading support for datastore connection.

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -46,8 +46,9 @@ The main concepts with this API are:
   when race conditions may occur.
 """
 
-from gcloud import credentials
 from gcloud.datastore import _implicit_environ
+from gcloud.datastore._implicit_environ import SCOPE
+from gcloud.datastore._implicit_environ import get_connection
 from gcloud.datastore._implicit_environ import get_default_connection
 from gcloud.datastore._implicit_environ import get_default_dataset_id
 from gcloud.datastore._implicit_environ import set_default_dataset_id
@@ -61,11 +62,6 @@ from gcloud.datastore.entity import Entity
 from gcloud.datastore.key import Key
 from gcloud.datastore.query import Query
 from gcloud.datastore.transaction import Transaction
-
-
-SCOPE = ('https://www.googleapis.com/auth/datastore',
-         'https://www.googleapis.com/auth/userinfo.email')
-"""The scopes required for authenticating as a Cloud Datastore consumer."""
 
 
 def set_default_connection(connection=None):
@@ -96,25 +92,3 @@ def set_defaults(dataset_id=None, connection=None):
     """
     set_default_dataset_id(dataset_id=dataset_id)
     set_default_connection(connection=connection)
-
-
-def get_connection():
-    """Shortcut method to establish a connection to the Cloud Datastore.
-
-    Use this if you are going to access several datasets
-    with the same set of credentials (unlikely):
-
-    >>> from gcloud import datastore
-
-    >>> connection = datastore.get_connection()
-    >>> key1 = datastore.Key('Kind', 1234, dataset_id='dataset1')
-    >>> key2 = datastore.Key('Kind', 1234, dataset_id='dataset2')
-    >>> entity1 = datastore.get(key1, connection=connection)
-    >>> entity2 = datastore.get(key2, connection=connection)
-
-    :rtype: :class:`gcloud.datastore.connection.Connection`
-    :returns: A connection defined with the proper credentials.
-    """
-    implicit_credentials = credentials.get_credentials()
-    scoped_credentials = implicit_credentials.create_scoped(SCOPE)
-    return Connection(credentials=scoped_credentials)

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -46,11 +46,11 @@ The main concepts with this API are:
   when race conditions may occur.
 """
 
-from gcloud.datastore import _implicit_environ
 from gcloud.datastore._implicit_environ import SCOPE
 from gcloud.datastore._implicit_environ import get_connection
 from gcloud.datastore._implicit_environ import get_default_connection
 from gcloud.datastore._implicit_environ import get_default_dataset_id
+from gcloud.datastore._implicit_environ import set_default_connection
 from gcloud.datastore._implicit_environ import set_default_dataset_id
 from gcloud.datastore.api import allocate_ids
 from gcloud.datastore.api import delete
@@ -62,16 +62,6 @@ from gcloud.datastore.entity import Entity
 from gcloud.datastore.key import Key
 from gcloud.datastore.query import Query
 from gcloud.datastore.transaction import Transaction
-
-
-def set_default_connection(connection=None):
-    """Set default connection either explicitly or implicitly as fall-back.
-
-    :type connection: :class:`gcloud.datastore.connection.Connection`
-    :param connection: A connection provided to be the default.
-    """
-    connection = connection or get_connection()
-    _implicit_environ._DEFAULTS.connection = connection
 
 
 def set_defaults(dataset_id=None, connection=None):

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -28,6 +28,13 @@ try:
 except ImportError:
     app_identity = None
 
+from gcloud import credentials
+from gcloud.datastore.connection import Connection
+
+
+SCOPE = ('https://www.googleapis.com/auth/datastore',
+         'https://www.googleapis.com/auth/userinfo.email')
+"""The scopes required for authenticating as a Cloud Datastore consumer."""
 
 _DATASET_ENV_VAR_NAME = 'GCLOUD_DATASET_ID'
 _GCD_DATASET_ENV_VAR_NAME = 'DATASTORE_DATASET'
@@ -141,6 +148,28 @@ def get_default_dataset_id():
     :returns: The default dataset ID if one has been set.
     """
     return _DEFAULTS.dataset_id
+
+
+def get_connection():
+    """Shortcut method to establish a connection to the Cloud Datastore.
+
+    Use this if you are going to access several datasets
+    with the same set of credentials (unlikely):
+
+    >>> from gcloud import datastore
+
+    >>> connection = datastore.get_connection()
+    >>> key1 = datastore.Key('Kind', 1234, dataset_id='dataset1')
+    >>> key2 = datastore.Key('Kind', 1234, dataset_id='dataset2')
+    >>> entity1 = datastore.get(key1, connection=connection)
+    >>> entity2 = datastore.get(key2, connection=connection)
+
+    :rtype: :class:`gcloud.datastore.connection.Connection`
+    :returns: A connection defined with the proper credentials.
+    """
+    implicit_credentials = credentials.get_credentials()
+    scoped_credentials = implicit_credentials.create_scoped(SCOPE)
+    return Connection(credentials=scoped_credentials)
 
 
 def get_default_connection():

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -172,6 +172,16 @@ def get_connection():
     return Connection(credentials=scoped_credentials)
 
 
+def set_default_connection(connection=None):
+    """Set default connection either explicitly or implicitly as fall-back.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: A connection provided to be the default.
+    """
+    connection = connection or get_connection()
+    _DEFAULTS.connection = connection
+
+
 def get_default_connection():
     """Get default connection.
 

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -250,8 +250,15 @@ class _DefaultsContainer(object):
         """Return the implicit default dataset ID."""
         return _determine_default_dataset_id()
 
+    @_lazy_property_deco
+    @staticmethod
+    def connection():
+        """Return the implicit default connection.."""
+        return get_connection()
+
     def __init__(self, connection=None, dataset_id=None, implicit=False):
-        self.connection = connection
+        if connection is not None or not implicit:
+            self.connection = connection
         if dataset_id is not None or not implicit:
             self.dataset_id = dataset_id
 

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -189,8 +189,8 @@ class Batch(object):
         if not _dataset_ids_equal(self._dataset_id, key.dataset_id):
             raise ValueError("Key must be from same dataset as batch")
 
-        key_pb = key.to_protobuf()
-        helpers._add_keys_to_request(self.mutation.delete, [key_pb])
+        key_pb = helpers._prepare_key_for_request(key.to_protobuf())
+        self.mutation.delete.add().CopyFrom(key_pb)
 
     def begin(self):
         """No-op

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -308,17 +308,3 @@ def _prepare_key_for_request(key_pb):
         new_key_pb.partition_id.ClearField('dataset_id')
         key_pb = new_key_pb
     return key_pb
-
-
-def _add_keys_to_request(request_field_pb, key_pbs):
-    """Add protobuf keys to a request object.
-
-    :type request_field_pb: `RepeatedCompositeFieldContainer`
-    :param request_field_pb: A repeated proto field that contains keys.
-
-    :type key_pbs: list of :class:`gcloud.datastore._datastore_v1_pb2.Key`
-    :param key_pbs: The keys to add to a request.
-    """
-    for key_pb in key_pbs:
-        key_pb = _prepare_key_for_request(key_pb)
-        request_field_pb.add().CopyFrom(key_pb)

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -15,42 +15,6 @@
 import unittest2
 
 
-class Test_set_default_connection(unittest2.TestCase):
-
-    def setUp(self):
-        from gcloud.datastore._testing import _setup_defaults
-        _setup_defaults(self)
-
-    def tearDown(self):
-        from gcloud.datastore._testing import _tear_down_defaults
-        _tear_down_defaults(self)
-
-    def _callFUT(self, connection=None):
-        from gcloud.datastore import set_default_connection
-        return set_default_connection(connection=connection)
-
-    def test_set_explicit(self):
-        from gcloud.datastore import _implicit_environ
-
-        self.assertEqual(_implicit_environ.get_default_connection(), None)
-        fake_cnxn = object()
-        self._callFUT(connection=fake_cnxn)
-        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
-
-    def test_set_implicit(self):
-        from gcloud._testing import _Monkey
-        from gcloud import datastore
-        from gcloud.datastore import _implicit_environ
-
-        self.assertEqual(_implicit_environ.get_default_connection(), None)
-
-        fake_cnxn = object()
-        with _Monkey(datastore, get_connection=lambda: fake_cnxn):
-            self._callFUT()
-
-        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
-
-
 class Test_set_defaults(unittest2.TestCase):
 
     def _callFUT(self, dataset_id=None, connection=None):

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -80,23 +80,3 @@ class Test_set_defaults(unittest2.TestCase):
 
         self.assertEqual(SET_DATASET_CALLED, [DATASET_ID])
         self.assertEqual(SET_CONNECTION_CALLED, [CONNECTION])
-
-
-class Test_get_connection(unittest2.TestCase):
-
-    def _callFUT(self):
-        from gcloud.datastore import get_connection
-        return get_connection()
-
-    def test_it(self):
-        from gcloud import credentials
-        from gcloud.datastore.connection import Connection
-        from gcloud.test_credentials import _Client
-        from gcloud._testing import _Monkey
-
-        client = _Client()
-        with _Monkey(credentials, client=client):
-            found = self._callFUT()
-        self.assertTrue(isinstance(found, Connection))
-        self.assertTrue(found._credentials is client._signed)
-        self.assertTrue(client._get_app_default_called)

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -417,6 +417,41 @@ class Test_get_connection(unittest2.TestCase):
         self.assertTrue(client._get_app_default_called)
 
 
+class Test_set_default_connection(unittest2.TestCase):
+
+    def setUp(self):
+        from gcloud.datastore._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.datastore._testing import _tear_down_defaults
+        _tear_down_defaults(self)
+
+    def _callFUT(self, connection=None):
+        from gcloud.datastore._implicit_environ import set_default_connection
+        return set_default_connection(connection=connection)
+
+    def test_set_explicit(self):
+        from gcloud.datastore import _implicit_environ
+
+        self.assertEqual(_implicit_environ.get_default_connection(), None)
+        fake_cnxn = object()
+        self._callFUT(connection=fake_cnxn)
+        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
+
+    def test_set_implicit(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        self.assertEqual(_implicit_environ.get_default_connection(), None)
+
+        fake_cnxn = object()
+        with _Monkey(_implicit_environ, get_connection=lambda: fake_cnxn):
+            self._callFUT()
+
+        self.assertEqual(_implicit_environ.get_default_connection(), fake_cnxn)
+
+
 class _AppIdentity(object):
 
     def __init__(self, app_id):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -397,6 +397,26 @@ class Test_lazy_loaded_dataset_id(unittest2.TestCase):
             'dataset_id' in _implicit_environ._DEFAULTS.__dict__)
 
 
+class Test_get_connection(unittest2.TestCase):
+
+    def _callFUT(self):
+        from gcloud.datastore._implicit_environ import get_connection
+        return get_connection()
+
+    def test_it(self):
+        from gcloud import credentials
+        from gcloud.datastore.connection import Connection
+        from gcloud.test_credentials import _Client
+        from gcloud._testing import _Monkey
+
+        client = _Client()
+        with _Monkey(credentials, client=client):
+            found = self._callFUT()
+        self.assertTrue(isinstance(found, Connection))
+        self.assertTrue(found._credentials is client._signed)
+        self.assertTrue(client._get_app_default_called)
+
+
 class _AppIdentity(object):
 
     def __init__(self, app_id):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -344,7 +344,7 @@ class Test__lazy_property_deco(unittest2.TestCase):
         self.assertEqual(lazy_prop._name, 'test_func')
 
 
-class Test_lazy_loaded_dataset_id(unittest2.TestCase):
+class Test_lazy_loading(unittest2.TestCase):
 
     def setUp(self):
         from gcloud.datastore._testing import _setup_defaults
@@ -353,15 +353,6 @@ class Test_lazy_loaded_dataset_id(unittest2.TestCase):
     def tearDown(self):
         from gcloud.datastore._testing import _tear_down_defaults
         _tear_down_defaults(self)
-
-    def test_prop_default(self):
-        from gcloud.datastore import _implicit_environ
-        from gcloud.datastore._implicit_environ import _DefaultsContainer
-        from gcloud.datastore._implicit_environ import _LazyProperty
-
-        self.assertTrue(isinstance(_DefaultsContainer.dataset_id,
-                                   _LazyProperty))
-        self.assertEqual(_implicit_environ._DEFAULTS.dataset_id, None)
 
     def test_prop_on_wrong_class(self):
         from gcloud.datastore._implicit_environ import _LazyProperty
@@ -376,7 +367,7 @@ class Test_lazy_loaded_dataset_id(unittest2.TestCase):
         self.assertTrue(FakeEnv.dataset_id is data_prop)
         self.assertTrue(FakeEnv().dataset_id is data_prop)
 
-    def test_prop_descriptor(self):
+    def test_descriptor_for_dataset_id(self):
         from gcloud._testing import _Monkey
         from gcloud.datastore import _implicit_environ
 
@@ -385,16 +376,29 @@ class Test_lazy_loaded_dataset_id(unittest2.TestCase):
 
         DEFAULT = object()
 
-        def mock_default():
-            return DEFAULT
-
         with _Monkey(_implicit_environ,
-                     _determine_default_dataset_id=mock_default):
+                     _determine_default_dataset_id=lambda: DEFAULT):
             lazy_loaded = _implicit_environ._DEFAULTS.dataset_id
 
         self.assertEqual(lazy_loaded, DEFAULT)
         self.assertTrue(
             'dataset_id' in _implicit_environ._DEFAULTS.__dict__)
+
+    def test_descriptor_for_connection(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        self.assertFalse(
+            'connection' in _implicit_environ._DEFAULTS.__dict__)
+
+        DEFAULT = object()
+
+        with _Monkey(_implicit_environ, get_connection=lambda: DEFAULT):
+            lazy_loaded = _implicit_environ._DEFAULTS.connection
+
+        self.assertEqual(lazy_loaded, DEFAULT)
+        self.assertTrue(
+            'connection' in _implicit_environ._DEFAULTS.__dict__)
 
 
 class Test_get_connection(unittest2.TestCase):


### PR DESCRIPTION
**NOTE**: Has #667 as diffbase.

Happens in 4 phases:

- Remove `datastore.helpers` import in `connection`. (this would have caused a cycle if `Connection` was used in `_implicit_environ`)
- Moving `get_connection()` from `datastore.__init__` to `_implicit_environ`.
- Moving `set_default_connection()` from `datastore.__init__` to `_implicit_environ`.
- Adding lazy loading support for the connection property

Note that I had to copy `_prepare_key_for_request` from `helpers` into `connection` to avoid cyclic imports (#528 would be nice, since we could just remove `_prepare_key_for_request` all together)
