### PR TITLE
Fixing broken build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ pylintrc_reduced
 
 # Travis build directories.
 gcloud-python-wheels/
-ghpages/


### PR DESCRIPTION
Can't add a submodule to a path that is `.gitignore`d.

https://travis-ci.org/GoogleCloudPlatform/gcloud-python/builds/51413887