### PR TITLE
Fixed some python2->3 string issues

### DIFF
--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -173,7 +173,7 @@ def make_exception(response, content, use_json=True):
     :returns: Exception specific to the error response.
     """
     if six.PY3 and isinstance(content, bytes):
-        content = content.decode('utf-8')
+        content = content.decode('utf-8') # pragma: NO COVER Py3K
 
     message = content
     errors = ()

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -173,7 +173,7 @@ def make_exception(response, content, use_json=True):
     :returns: Exception specific to the error response.
     """
     if six.PY3 and isinstance(content, bytes):
-        content = content.decode('utf-8') # pragma: NO COVER Py3K
+        content = content.decode('utf-8')  # pragma: NO COVER Py3K
 
     message = content
     errors = ()

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -18,6 +18,7 @@ See: https://cloud.google.com/storage/docs/json_api/v1/status-codes
 """
 
 import json
+import six
 
 _HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
@@ -171,6 +172,9 @@ def make_exception(response, content, use_json=True):
     :rtype: instance of :class:`GCloudError`, or a concrete subclass.
     :returns: Exception specific to the error response.
     """
+    if six.PY3 and isinstance(content, bytes):
+        content = content.decode('utf-8')
+
     message = content
     errors = ()
 

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -237,7 +237,7 @@ class Connection(base_connection.Connection):
             raise make_exception(response, content)
 
         if six.PY3 and isinstance(content, bytes):
-            content = content.decode('utf-8') # pragma: NO COVER Py3K
+            content = content.decode('utf-8')  # pragma: NO COVER Py3K
 
         if content and expect_json:
             content_type = response.get('content-type', '')

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -15,6 +15,7 @@
 """Create / interact with gcloud storage connections."""
 
 import json
+import six
 
 from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
 
@@ -234,6 +235,9 @@ class Connection(base_connection.Connection):
 
         if not 200 <= response.status < 300:
             raise make_exception(response, content)
+
+        if six.PY3 and isinstance(content, bytes):
+            content = content.decode('utf-8')
 
         if content and expect_json:
             content_type = response.get('content-type', '')

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -237,7 +237,7 @@ class Connection(base_connection.Connection):
             raise make_exception(response, content)
 
         if six.PY3 and isinstance(content, bytes):
-            content = content.decode('utf-8')
+            content = content.decode('utf-8') # pragma: NO COVER Py3K
 
         if content and expect_json:
             content_type = response.get('content-type', '')


### PR DESCRIPTION

* httplib2 breaks if headers are not strings:  https://github.com/jcgregorio/httplib2/blob/master/python3/README
  fixes: #653
* exception message was confusing and broken as byte string.