### PR TITLE
Unwinding cases in Test_set_default_dataset_id and having better test separation

### DIFF
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -86,6 +86,16 @@ def compute_engine_id():
         connection.close()
 
 
+def _get_production_dataset_id():
+    """Gets the production application ID if it can be inferred."""
+    return os.getenv(_DATASET_ENV_VAR_NAME)
+
+
+def _get_gcd_dataset_id():
+    """Gets the GCD application ID if it can be inferred."""
+    return os.getenv(_GCD_DATASET_ENV_VAR_NAME)
+
+
 def _determine_default_dataset_id(dataset_id=None):
     """Determine default dataset ID explicitly or implicitly as fall-back.
 
@@ -104,10 +114,10 @@ def _determine_default_dataset_id(dataset_id=None):
     :returns: Default dataset ID if it can be determined.
     """
     if dataset_id is None:
-        dataset_id = os.getenv(_DATASET_ENV_VAR_NAME)
+        dataset_id = _get_production_dataset_id()
 
     if dataset_id is None:
-        dataset_id = os.getenv(_GCD_DATASET_ENV_VAR_NAME)
+        dataset_id = _get_gcd_dataset_id()
 
     if dataset_id is None:
         dataset_id = app_engine_id()

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -121,6 +121,31 @@ class Test__get_gcd_dataset_id(unittest2.TestCase):
             self.assertEqual(dataset_id, MOCK_DATASET_ID)
 
 
+class Test_app_engine_id(unittest2.TestCase):
+
+    def _callFUT(self):
+        from gcloud.datastore import _implicit_environ
+        return _implicit_environ.app_engine_id()
+
+    def test_no_value(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        with _Monkey(_implicit_environ, app_identity=None):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, None)
+
+    def test_value_set(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        APP_ENGINE_ID = object()
+        APP_IDENTITY = _AppIdentity(APP_ENGINE_ID)
+        with _Monkey(_implicit_environ, app_identity=APP_IDENTITY):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, APP_ENGINE_ID)
+
+
 class Test__determine_default_dataset_id(unittest2.TestCase):
 
     def _callFUT(self, dataset_id=None):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -65,6 +65,50 @@ class Test_get_default_dataset_id(unittest2.TestCase):
             self.assertEqual(self._callFUT(), SENTINEL)
 
 
+class Test__determine_default_dataset_id(unittest2.TestCase):
+
+    def _callFUT(self, dataset_id=None):
+        from gcloud.datastore import _implicit_environ
+        return _implicit_environ._determine_default_dataset_id(
+            dataset_id=dataset_id)
+
+    def test_it(self):
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        _callers = []
+
+        def prod_mock():
+            _callers.append('prod_mock')
+            return None
+
+        def gcd_mock():
+            _callers.append('gcd_mock')
+            return None
+
+        def gae_mock():
+            _callers.append('gae_mock')
+            return None
+
+        def gce_mock():
+            _callers.append('gce_mock')
+            return None
+
+        patched_methods = {
+            '_get_production_dataset_id': prod_mock,
+            '_get_gcd_dataset_id': gcd_mock,
+            'app_engine_id': gae_mock,
+            'compute_engine_id': gce_mock,
+        }
+
+        with _Monkey(_implicit_environ, **patched_methods):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, None)
+
+        self.assertEqual(_callers,
+                         ['prod_mock', 'gcd_mock', 'gae_mock', 'gce_mock'])
+
+
 class Test_set_default_dataset_id(unittest2.TestCase):
 
     def setUp(self):

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -65,6 +65,62 @@ class Test_get_default_dataset_id(unittest2.TestCase):
             self.assertEqual(self._callFUT(), SENTINEL)
 
 
+class Test__get_production_dataset_id(unittest2.TestCase):
+
+    def _callFUT(self, dataset_id=None):
+        from gcloud.datastore import _implicit_environ
+        return _implicit_environ._get_production_dataset_id()
+
+    def test_no_value(self):
+        import os
+        from gcloud._testing import _Monkey
+
+        environ = {}
+        with _Monkey(os, getenv=environ.get):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, None)
+
+    def test_value_set(self):
+        import os
+        from gcloud._testing import _Monkey
+        from gcloud.datastore._implicit_environ import _DATASET_ENV_VAR_NAME
+
+        MOCK_DATASET_ID = object()
+        environ = {_DATASET_ENV_VAR_NAME: MOCK_DATASET_ID}
+        with _Monkey(os, getenv=environ.get):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, MOCK_DATASET_ID)
+
+
+class Test__get_gcd_dataset_id(unittest2.TestCase):
+
+    def _callFUT(self, dataset_id=None):
+        from gcloud.datastore import _implicit_environ
+        return _implicit_environ._get_gcd_dataset_id()
+
+    def test_no_value(self):
+        import os
+        from gcloud._testing import _Monkey
+
+        environ = {}
+        with _Monkey(os, getenv=environ.get):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, None)
+
+    def test_value_set(self):
+        import os
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import _implicit_environ
+
+        MOCK_DATASET_ID = object()
+        environ = {
+            _implicit_environ._GCD_DATASET_ENV_VAR_NAME: MOCK_DATASET_ID,
+        }
+        with _Monkey(os, getenv=environ.get):
+            dataset_id = self._callFUT()
+            self.assertEqual(dataset_id, MOCK_DATASET_ID)
+
+
 class Test__determine_default_dataset_id(unittest2.TestCase):
 
     def _callFUT(self, dataset_id=None):


### PR DESCRIPTION
**NOTE**: Has #668 as diffbase

Tests previously were mixing the logic of the 4 possible environments while the simple ordering of them in `set_default_dataset_id()` and now `_determine_default_dataset_id()`.

This PR separates that logic and makes sure each environ helper is called in a specific order.

In order to do this it also introduces two one-line functions `_get_production_dataset_id()` and `_get_gcd_dataset_id()` in the implicit environ module.