### PR TITLE
Fix py2->3 string issues

### DIFF
--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -171,6 +171,9 @@ def make_exception(response, content, use_json=True):
     :rtype: instance of :class:`GCloudError`, or a concrete subclass.
     :returns: Exception specific to the error response.
     """
+    if not hasattr(content, 'keys') and not isinstance(content, str):
+        content = str(content.decode('utf-8'))
+
     message = content
     errors = ()
 

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -235,6 +235,9 @@ class Connection(base_connection.Connection):
         if not 200 <= response.status < 300:
             raise make_exception(response, content)
 
+        if not isinstance(content, str):
+            content = str(content.decode('utf-8'))
+
         if content and expect_json:
             content_type = response.get('content-type', '')
             if not content_type.startswith('application/json'):

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -206,6 +206,16 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(conn.api_request('GET', '/', expect_json=False),
                          'CONTENT')
 
+    def test_api_request_w_binary_json_string(self):
+        PROJECT = 'project'
+        conn = self._makeOne(PROJECT)
+        conn._http = Http(
+            {'status': '200', 'content-type': 'application/json'},
+            b'{"foo": "bar"}'
+        )
+        self.assertEqual(conn.api_request('GET', '/', expect_json=True),
+                         {'foo': 'bar'})
+
     def test_api_request_w_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit

--- a/gcloud/test_exceptions.py
+++ b/gcloud/test_exceptions.py
@@ -61,6 +61,15 @@ class Test_make_exception(unittest2.TestCase):
         self.assertEqual(exception.message, 'Not Found')
         self.assertEqual(list(exception.errors), [])
 
+    def test_hit_w_content_as_binary_string(self):
+        from gcloud.exceptions import BadRequest
+        response = _Response(400)
+        content = b'{"message": "Invalid argument."\n   }\n'
+        exception = self._callFUT(response, content)
+        self.assertTrue(isinstance(exception, BadRequest))
+        self.assertEqual(exception.message, 'Invalid argument.')
+        self.assertEqual(list(exception.errors), [])
+
     def test_miss_w_content_as_dict(self):
         from gcloud.exceptions import GCloudError
         ERROR = {


### PR DESCRIPTION
* Handle exceptions with binary string content. Added test.
* Handle api_requests with binary content correctly in Python 3. Added test.