### PR TITLE
Use a development checkout of oauth2client in regresion3.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,7 @@ commands =
     {toxinidir}/scripts/run_regression.sh
 deps =
     unittest2
+#   Use a development checkout of oauth2client until a release is made
+#   which fixes https://github.com/google/oauth2client/issues/125
+    -egit+https://github.com/google/oauth2client.git#egg=oauth2client
     protobuf==3.0.0-alpha-1


### PR DESCRIPTION
Allows us to work on more issues until a release is available that fixes https://github.com/google/oauth2client/issues/125.