### PR TITLE
#649: Raise ValueError if single entity is passed to 'datastore.put'.

### DIFF
--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -20,6 +20,7 @@ Query objects rather than via protobufs.
 
 from gcloud.datastore import _implicit_environ
 from gcloud.datastore.batch import Batch
+from gcloud.datastore.entity import Entity
 from gcloud.datastore.transaction import Transaction
 from gcloud.datastore import helpers
 
@@ -252,6 +253,9 @@ def put(entities, connection=None, dataset_id=None):
              one or more entities has a key with a dataset ID not matching
              the passed / inferred dataset ID.
     """
+    if isinstance(entities, Entity):
+        raise ValueError("Pass a sequence of entities")
+
     if not entities:
         return
 

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -627,6 +627,11 @@ class Test_put_function(unittest2.TestCase):
         result = self._callFUT([])
         self.assertEqual(result, None)
 
+    def test_w_single_empty_entity(self):
+        # https://github.com/GoogleCloudPlatform/gcloud-python/issues/649
+        from gcloud.datastore.entity import Entity
+        self.assertRaises(ValueError, self._callFUT, Entity())
+
     def test_no_batch_w_partial_key(self):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Entity


### PR DESCRIPTION
Fixes #649.