### PR TITLE
Using fully implicit auth in datastore regression.

### DIFF
--- a/regression/clear_datastore.py
+++ b/regression/clear_datastore.py
@@ -21,7 +21,6 @@ from gcloud.datastore import _implicit_environ
 
 
 _implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_defaults()
 
 
 FETCH_MAX = 20

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -24,7 +24,6 @@ from regression import populate_datastore
 
 
 _implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_defaults()
 
 
 class TestDatastore(unittest2.TestCase):

--- a/regression/populate_datastore.py
+++ b/regression/populate_datastore.py
@@ -21,7 +21,6 @@ from gcloud.datastore import _implicit_environ
 
 
 _implicit_environ._DATASET_ENV_VAR_NAME = 'GCLOUD_TESTS_DATASET_ID'
-datastore.set_defaults()
 
 
 ANCESTOR = ('Book', 'GoT')


### PR DESCRIPTION
This makes sure that our setup for auth / connection / dataset_id works without ever calling `set_defaults()`.