### PR TITLE
Make it easy to open a documentation bug from the docs themselves

### DIFF
--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -746,9 +746,10 @@ h2 .headerlink:hover {
 }
 
 #file-issue {
-  position: absolute;
-  right: 20px;
-  top: 20px;
+    position: absolute;
+    right: 20px;
+    top: 20px;
+    display: none;
 }
 
 .v-list {
@@ -1066,6 +1067,10 @@ h2 .headerlink:hover {
         padding: 0 0 0 1em;
         height: 70px;
         line-height: 70px;
+    }
+
+    #file-issue {
+        display: inline;
     }
 
     /*

--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -752,6 +752,11 @@ h2 .headerlink:hover {
     display: none;
 }
 
+#file-issue-secondary {
+    margin-top: 1em;
+    display: inline-block;
+}
+
 .v-list {
     color: rgba(0,0,0,0.2);
 }
@@ -1029,26 +1034,6 @@ h2 .headerlink:hover {
 
 }
 
-@media only screen and (min-width: 45em) {
-
-    /*
-     Docs Header
-    */
-
-    .versions {
-        position: absolute;
-        top: 6em;
-        right: 2em;
-        margin: 0;
-    }
-
-    .v-btn {
-        font-size: 0.7em;
-        line-height: normal;
-    }
-
-}
-
 @media only screen and (min-width: 50em) {
 
     /*
@@ -1071,6 +1056,10 @@ h2 .headerlink:hover {
 
     #file-issue {
         display: inline;
+    }
+
+    #file-issue-secondary {
+        display: none;
     }
 
     /*
@@ -1144,7 +1133,15 @@ h2 .headerlink:hover {
     }
 
     .versions {
-        top: 7em;
+        position: absolute;
+        top: 6em;
+        right: 2em;
+        margin: 0;
+    }
+
+    .v-btn {
+        font-size: 0.7em;
+        line-height: normal;
     }
 
     /*

--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -745,6 +745,12 @@ h2 .headerlink:hover {
     opacity: 0.3;
 }
 
+#file-issue {
+  position: absolute;
+  right: 20px;
+  top: 20px;
+}
+
 .v-list {
     color: rgba(0,0,0,0.2);
 }

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -81,6 +81,13 @@ https://googlecloudplatform.github.io/gcloud-node" title="Node.js docs page">
           </li>
         </ul>
       </nav><!-- end of .main-nav -->
+      {%- if show_source and has_source and pagename %}
+      {%- set issue_uri = issue_uri_template.format(pagename, release) %}
+      {%- endif %}
+      <a href="{{ issue_uri }}" target="_blank" class="v-btn" id="file-issue">
+        <img src="_static/images/icon-link-github.svg" />
+        Report an Issue
+      </a>
     </header><!-- end of .page-header -->
     {% endblock %}
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -82,7 +82,7 @@ https://googlecloudplatform.github.io/gcloud-node" title="Node.js docs page">
         </ul>
       </nav><!-- end of .main-nav -->
       {%- if show_source and has_source and pagename %}
-      {%- set issue_uri = issue_uri_template.format(pagename, release) %}
+      {%- set issue_uri = issue_uri_template.format(pagename|urlencode, release|urlencode) %}
       {%- endif %}
       <a href="{{ issue_uri }}" target="_blank" class="v-btn" id="file-issue">
         <img src="_static/images/icon-link-github.svg" />

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -108,6 +108,12 @@ https://googlecloudplatform.github.io/gcloud-node" title="Node.js docs page">
               Version History ({{ release|e }})
             </a>
           </div><!-- end of .versions -->
+          <div>
+            <a href="{{ issue_uri }}" target="_blank" class="v-btn" id="file-issue-secondary">
+              <img src="_static/images/icon-link-github.svg" />
+              Report an Issue
+            </a>
+          </div>
       </header>
 
       <section class="content">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 
 from pkg_resources import get_distribution
 import sys, os
+import urllib
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -179,6 +180,8 @@ html_add_permalinks = '#'
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'gclouddoc'
 
+html_context = {}
+
 
 # -- Options for LaTeX output --------------------------------------------------
 
@@ -257,3 +260,14 @@ texinfo_documents = [
 # This pulls class descriptions from the class docstring,
 # and parameter definitions from the __init__ docstring.
 autoclass_content = 'both'
+
+issue_uri = ('https://github.com/GoogleCloudPlatform/gcloud-python/issues/'
+             'new?' + urllib.urlencode({'title': '[Documentation Issue] '}))
+issue_uri_template = (
+    issue_uri + '&' + urllib.urlencode({'body': 'Page Name: '}) + '{0}' +
+    urllib.quote('\nRelease: ') + '{1}')
+
+html_context.update(
+    issue_uri=issue_uri,
+    issue_uri_template=issue_uri_template,
+)


### PR DESCRIPTION
Fixes #98.

A typical "Report an Issue" button will link to:
https://github.com/GoogleCloudPlatform/gcloud-python/issues/new?title=%5BDocumentation+Issue%5D+&body=Page+Name%3A+datastore-api%0ARelease%3A%200.4.1

The `release` in the link will either be a stable release (as in http://googlecloudplatform.github.io/gcloud-python/0.4.1/index.html) or will be a commit hash (as in http://googlecloudplatform.github.io/gcloud-python/master/)

(The "release" may need some URL escaping.)