### PR TITLE
Separating _patch_properties and PATCH on Bucket.

### DIFF
--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -751,6 +751,7 @@ class Test_Bucket(unittest2.TestCase):
         connection = _Connection({'location': 'AS'})
         bucket = self._makeOne(connection, NAME)
         bucket.location = 'AS'
+        bucket.patch()
         self.assertEqual(bucket.location, 'AS')
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -911,6 +912,7 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(connection, NAME, before)
         self.assertFalse(bucket.versioning_enabled)
         bucket.versioning_enabled = True
+        bucket.patch()
         self.assertTrue(bucket.versioning_enabled)
         kw = connection._requested
         self.assertEqual(len(kw), 1)


### PR DESCRIPTION
@tseaver there is plenty to discuss here and I will enumerate.

In the immediately relevant category is my uses of `self.patch()` in several of the methods. I was unclear if we think they should be setters or actual API requests.

Relates to #632.