### PR TITLE
Removing datastore.set_defaults() from all docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,6 @@ with the Cloud Datastore using this Client Library.
 .. code:: python
 
     from gcloud import datastore
-    datastore.set_defaults()
     # Create, populate and persist an entity
     entity = datastore.Entity(key=datastore.Key('EntityKind'))
     entity.update({

--- a/docs/_components/datastore-getting-started.rst
+++ b/docs/_components/datastore-getting-started.rst
@@ -38,7 +38,6 @@ Add some data to your dataset
 Open a Python console and...
 
   >>> from gcloud import datastore
-  >>> datastore.set_defaults()
   >>> list(datastore.Query(kind='Person').fetch())
   []
   >>> entity = datastore.Entity(key=datastore.Key('Person'))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,6 @@ Cloud Datastore
 .. code-block:: python
 
   from gcloud import datastore
-  datastore.set_defaults()
 
   entity = datastore.Entity(key=datastore.Key('Person'))
   entity['name'] = 'Your name'

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -18,8 +18,6 @@ You'll typically use these to get started with the API:
 
 >>> from gcloud import datastore
 
->>> datastore.set_defaults()
-
 >>> key = datastore.Key('EntityKind', 1234)
 >>> entity = datastore.Entity(key)
 >>> query = datastore.Query(kind='EntityKind')

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -147,7 +147,6 @@ class Connection(connection.Connection):
         under the hood in :func:`gcloud.datastore.get`:
 
         >>> from gcloud import datastore
-        >>> datastore.set_defaults()
         >>> key = datastore.Key('MyKind', 1234, dataset_id='dataset-id')
         >>> datastore.get([key])
         [<Entity object>]
@@ -209,8 +208,6 @@ class Connection(connection.Connection):
         uses this method to fetch data:
 
         >>> from gcloud import datastore
-
-        >>> datastore.set_defaults()
 
         >>> query = datastore.Query(kind='MyKind')
         >>> query.add_filter('property', '=', 'val')

--- a/gcloud/datastore/demo/__init__.py
+++ b/gcloud/datastore/demo/__init__.py
@@ -23,4 +23,4 @@ DATASET_ID = os.getenv('GCLOUD_TESTS_DATASET_ID')
 
 
 def initialize():
-    datastore.set_defaults(dataset_id=DATASET_ID)
+    datastore.set_default_dataset_id(DATASET_ID)

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -28,22 +28,21 @@ class Transaction(Batch):
     mutation, and execute those within a transaction::
 
       >>> from gcloud import datastore
-      >>> from gcloud.datastore.transaction import Transaction
 
-      >>> with Transaction():
+      >>> with datastore.Transaction():
       ...     datastore.put([entity1, entity2])
 
     Because it derives from :class:`Batch`, :class`Transaction` also provides
     :meth:`put` and :meth:`delete` methods::
 
-      >>> with Transaction() as xact:
+      >>> with datastore.Transaction() as xact:
       ...     xact.put(entity1)
       ...     xact.delete(entity2.key)
 
     By default, the transaction is rolled back if the transaction block
     exits with an error::
 
-      >>> with Transaction():
+      >>> with datastore.Transaction():
       ...     do_some_work()
       ...     raise SomeException()  # rolls back
 
@@ -54,8 +53,8 @@ class Transaction(Batch):
        entities will not be available at save time!  That means, if you
        try::
 
-         >>> with Transaction():
-         ...     entity = Entity(key=Key('Thing'))
+         >>> with datastore.Transaction():
+         ...     entity = datastore.Entity(key=Key('Thing'))
          ...     datastore.put([entity])
 
        ``entity`` won't have a complete Key until the transaction is
@@ -64,8 +63,8 @@ class Transaction(Batch):
        Once you exit the transaction (or call ``commit()``), the
        automatically generated ID will be assigned to the entity::
 
-         >>> with Transaction():
-         ...     entity = Entity(key=Key('Thing'))
+         >>> with datastore.Transaction():
+         ...     entity = datastore.Entity(key=Key('Thing'))
          ...     datastore.put([entity])
          ...     assert entity.key.is_partial  # There is no ID on this key.
          ...
@@ -74,7 +73,7 @@ class Transaction(Batch):
        After completion, you can determine if a commit succeeded or failed.
        For example, trying to delete a key that doesn't exist::
 
-         >>> with Transaction() as xact:
+         >>> with datastore.Transaction() as xact:
          ...     xact.delete(key)
          ...
          >>> xact.succeeded
@@ -82,7 +81,7 @@ class Transaction(Batch):
 
        or successfully storing two entities:
 
-         >>> with Transaction() as xact:
+         >>> with datastore.Transaction() as xact:
          ...     datastore.put([entity1, entity2])
          ...
          >>> xact.succeeded
@@ -91,10 +90,10 @@ class Transaction(Batch):
     If you don't want to use the context manager you can initialize a
     transaction manually::
 
-      >>> transaction = Transaction()
+      >>> transaction = datastore.Transaction()
       >>> transaction.begin()
 
-      >>> entity = Entity(key=Key('Thing'))
+      >>> entity = datastore.Entity(key=Key('Thing'))
       >>> transaction.put(entity)
 
       >>> if error:

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -30,8 +30,6 @@ class Transaction(Batch):
       >>> from gcloud import datastore
       >>> from gcloud.datastore.transaction import Transaction
 
-      >>> datastore.set_defaults()
-
       >>> with Transaction():
       ...     datastore.put([entity1, entity2])
 


### PR DESCRIPTION
Fixes #685.

**NOTE**: I did not remove the actual method from `datastore.__init__` but easily could.

Here are the remaining uses of it.

In `datastore`:

```
$ git grep set_defaults 
gcloud/datastore/__init__.py:def set_defaults(dataset_id=None, connection=None):
gcloud/datastore/test___init__.py:class Test_set_defaults(unittest2.TestCase):
gcloud/datastore/test___init__.py:        from gcloud.datastore import set_defaults
gcloud/datastore/test___init__.py:        return set_defaults(dataset_id=dataset_id, connection=connection)
```

And `storage`:

```
gcloud/storage/__init__.py:def set_defaults(bucket=None, project=None, connection=None):
gcloud/storage/test___init__.py:class Test_set_defaults(unittest2.TestCase):
gcloud/storage/test___init__.py:        from gcloud.storage import set_defaults
gcloud/storage/test___init__.py:        return set_defaults(bucket=bucket, project=project,
regression/storage.py:storage.set_defaults()
```