### PR TITLE
Moving Bucket._patch_properties (and patch) to _PropertyMixin.

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -106,8 +106,8 @@ class _PropertyMixin(object):
         This method will only update the fields provided and will not
         touch the other fields.
 
-        It will also reload the properties locally based on the server's
-        response.
+        It **will not** reload the properties from the server. The behavior is
+        local only and syncing occurs via :meth:`patch`.
 
         :type properties: dict
         :param properties: The dictionary of values to update.
@@ -115,11 +115,8 @@ class _PropertyMixin(object):
         :rtype: :class:`_PropertyMixin`
         :returns: The current object.
         """
-        # Pass '?projection=full' here because 'PATCH' documented not
-        # to work properly w/ 'noAcl'.
-        self._properties = self.connection.api_request(
-            method='PATCH', path=self.path, data=properties,
-            query_params={'projection': 'full'})
+        self._changes.update(properties.keys())
+        self._properties.update(properties)
         return self
 
     def patch(self):

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -138,25 +138,21 @@ class _PropertyMixin(object):
 
 
 class _PropertyBatch(object):
-    """Context manager: Batch updates to object's ``_patch_properties``
+    """Context manager: Batch updates to object.
 
     :type wrapped: class derived from :class:`_PropertyMixin`.
-    :param wrapped:  the instance whose property updates to defer/batch.
+    :param wrapped:  the instance whose property updates to batch.
     """
     def __init__(self, wrapped):
         self._wrapped = wrapped
-        self._deferred = {}
 
     def __enter__(self):
-        """Intercept / defer property updates."""
-        self._wrapped._patch_properties = self._deferred.update
+        """Do nothing method. Needed to be a context manager."""
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, value, traceback):
         """Patch deferred property updates if no error."""
-        del self._wrapped._patch_properties
-        if type is None:
-            if self._deferred:
-                self._wrapped._patch_properties(self._deferred)
+        if exc_type is None:
+            self._wrapped.patch()
 
 
 def _scalar_property(fieldname):

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -50,6 +50,7 @@ class _PropertyMixin(object):
         """
         self.name = name
         self._properties = {}
+        self._changes = set()
         if properties is not None:
             self._properties.update(properties)
 
@@ -118,6 +119,23 @@ class _PropertyMixin(object):
         # to work properly w/ 'noAcl'.
         self._properties = self.connection.api_request(
             method='PATCH', path=self.path, data=properties,
+            query_params={'projection': 'full'})
+        return self
+
+    def patch(self):
+        """Sends all changed properties in a PATCH request.
+
+        Updates the ``properties`` with the response from the backend.
+
+        :rtype: :class:`Bucket`
+        :returns: The current bucket.
+        """
+        # Pass '?projection=full' here because 'PATCH' documented not
+        # to work properly w/ 'noAcl'.
+        update_properties = dict((key, self._properties[key])
+                                 for key in self._changes)
+        self._properties = self.connection.api_request(
+            method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'})
         return self
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -94,7 +94,6 @@ class Bucket(_PropertyMixin):
             name = properties.get('name')
         super(Bucket, self).__init__(name=name, properties=properties)
         self._connection = connection
-        self._changes = set()
 
     def __repr__(self):
         return '<Bucket: %s>' % self.name
@@ -784,21 +783,4 @@ class Bucket(_PropertyMixin):
         """
         self._changes.update(properties.keys())
         self._properties.update(properties)
-        return self
-
-    def patch(self):
-        """Sends all changed properties in a PATCH request.
-
-        Updates the ``properties`` with the response from the backend.
-
-        :rtype: :class:`Bucket`
-        :returns: The current bucket.
-        """
-        # Pass '?projection=full' here because 'PATCH' documented not
-        # to work properly w/ 'noAcl'.
-        update_properties = dict((key, self._properties[key])
-                                 for key in self._changes)
-        self._properties = self.connection.api_request(
-            method='PATCH', path=self.path, data=update_properties,
-            query_params={'projection': 'full'})
         return self

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -764,23 +764,3 @@ class Bucket(_PropertyMixin):
             for blob in self:
                 blob.acl.all().grant_read()
                 blob.save_acl()
-
-    def _patch_properties(self, properties):
-        """Update particular fields of this object's properties.
-
-        This method will only update the fields provided and will not
-        touch the other fields.
-
-        It **will not** reload the properties from the server as is done
-        in :meth:`_PropertyMixin._patch_properties`. The behavior is
-        local only and syncing occurs via :meth:`patch`.
-
-        :type properties: dict
-        :param properties: The dictionary of values to update.
-
-        :rtype: :class:`Bucket`
-        :returns: The current bucket.
-        """
-        self._changes.update(properties.keys())
-        self._properties.update(properties)
-        return self

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -53,6 +53,7 @@ class Test_PropertyMixin(unittest2.TestCase):
             derived._patch_properties({'foo': 'Foo'})
             derived._patch_properties({'bar': 'Baz'})
             derived._patch_properties({'foo': 'Qux'})
+        derived.patch()
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
@@ -87,6 +88,7 @@ class Test_PropertyMixin(unittest2.TestCase):
         connection = _Connection({'foo': 'Foo'})
         derived = self._derivedClass(connection, '/path')()
         self.assertTrue(derived._patch_properties({'foo': 'Foo'}) is derived)
+        derived.patch()
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
@@ -163,6 +165,7 @@ class TestPropertyBatch(unittest2.TestCase):
             wrapped._patch_properties({'bar': 'Baz'})
             wrapped._patch_properties({'foo': 'Qux'})
             self.assertEqual(len(kw), 0)
+        wrapped.patch()
         # exited w/o error -> call to the real '_patch_properties'
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -53,7 +53,6 @@ class Test_PropertyMixin(unittest2.TestCase):
             derived._patch_properties({'foo': 'Foo'})
             derived._patch_properties({'bar': 'Baz'})
             derived._patch_properties({'foo': 'Qux'})
-        derived.patch()
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
@@ -97,7 +96,7 @@ class Test_PropertyMixin(unittest2.TestCase):
         self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
 
-class TestPropertyBatch(unittest2.TestCase):
+class Test_PropertyBatch(unittest2.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage._helpers import _PropertyBatch
@@ -129,21 +128,11 @@ class TestPropertyBatch(unittest2.TestCase):
         self.assertEqual(before, after)
         self.assertTrue(batch._wrapped is wrapped)
 
-    def test_cm_intercepts_restores__patch_properties(self):
-        wrapped = self._makeWrapped()
-        before = wrapped._patch_properties
-        batch = self._makeOne(wrapped)
-        with batch:
-            # No deferred patching -> no call to the real '_patch_properties'
-            during = wrapped._patch_properties
-        after = wrapped._patch_properties
-        self.assertNotEqual(before, during)
-        self.assertEqual(before, after)
-
-    def test___exit___w_error_skips__patch_properties(self):
+    def test___exit___w_error_skips_patch(self):
         class Testing(Exception):
             pass
-        wrapped = self._makeWrapped()
+        connection = _Connection()
+        wrapped = self._makeWrapped(connection)
         batch = self._makeOne(wrapped)
         try:
             with batch:
@@ -154,7 +143,10 @@ class TestPropertyBatch(unittest2.TestCase):
         except Testing:
             pass
 
-    def test___exit___no_error_aggregates__patch_properties(self):
+        kw = connection._requested
+        self.assertEqual(len(kw), 0)
+
+    def test___exit___no_error_calls_patch(self):
         connection = _Connection({'foo': 'Foo'})
         wrapped = self._makeWrapped(connection, '/path')
         batch = self._makeOne(wrapped)
@@ -165,7 +157,6 @@ class TestPropertyBatch(unittest2.TestCase):
             wrapped._patch_properties({'bar': 'Baz'})
             wrapped._patch_properties({'foo': 'Qux'})
             self.assertEqual(len(kw), 0)
-        wrapped.patch()
         # exited w/o error -> call to the real '_patch_properties'
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -667,6 +667,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.cache_control = CACHE_CONTROL
+        blob.patch()
         self.assertEqual(blob.cache_control, CACHE_CONTROL)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -701,6 +702,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.content_disposition = CONTENT_DISPOSITION
+        blob.patch()
         self.assertEqual(blob.content_disposition, CONTENT_DISPOSITION)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -727,6 +729,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.content_encoding = CONTENT_ENCODING
+        blob.patch()
         self.assertEqual(blob.content_encoding, CONTENT_ENCODING)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -753,6 +756,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.content_language = CONTENT_LANGUAGE
+        blob.patch()
         self.assertEqual(blob.content_language, CONTENT_LANGUAGE)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -779,6 +783,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.content_type = CONTENT_TYPE
+        blob.patch()
         self.assertEqual(blob.content_type, CONTENT_TYPE)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -805,6 +810,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.crc32c = CRC32C
+        blob.patch()
         self.assertEqual(blob.crc32c, CRC32C)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -858,6 +864,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.md5_hash = MD5_HASH
+        blob.patch()
         self.assertEqual(blob.md5_hash, MD5_HASH)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -893,6 +900,7 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.metadata = METADATA
+        blob.patch()
         self.assertEqual(blob.metadata, METADATA)
         kw = connection._requested
         self.assertEqual(len(kw), 1)


### PR DESCRIPTION
~~**NOTE**: Has #688 as diffbase.~~

Also updating `_PropertyBatch` to call patch on `__exit__`.

It seems removing `_patch_properties` outright is a possibility
