### PR TITLE
Removing use of non-batchable request in storage regression.

### DIFF
--- a/regression/storage.py
+++ b/regression/storage.py
@@ -55,7 +55,7 @@ class TestStorageBuckets(unittest2.TestCase):
     def tearDown(self):
         with Batch(CONNECTION) as batch:
             for bucket_name in self.case_buckets_to_delete:
-                batch.get_bucket(bucket_name).delete()
+                storage.Bucket(connection=batch, name=bucket_name).delete()
 
     def test_create_bucket(self):
         new_bucket_name = 'a-new-bucket'


### PR DESCRIPTION
See my [comment][1] on #15 for context.

I was in general playing around with ditching `_PropertyBatch` (or just merging that functionality into `Batch`) and trying to figure out how to [properly handle][2] the 204 response in a patch within a batch.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/issues/15#issuecomment-77965089
[2]: https://github.com/GoogleCloudPlatform/gcloud-python/pull/683#issuecomment-76275986