### PR TITLE
Using defaults container in storage (for implicit).

### DIFF
--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -14,8 +14,8 @@
 
 """Module to provide implicit behavior based on enviroment.
 
-Acts as a mutable namespace to allow the datastore package to
-imply the current dataset ID and connection from the enviroment.
+Allows the datastore package to infer the current dataset ID and
+connection from the enviroment.
 """
 
 import os

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -40,7 +40,7 @@ The main concepts with this API are:
 import os
 
 from gcloud import credentials
-from gcloud.storage._implicit_environ import _DEFAULTS
+from gcloud.storage import _implicit_environ
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
 from gcloud.storage._implicit_environ import get_default_project
@@ -80,7 +80,7 @@ def set_default_bucket(bucket=None):
             bucket = Bucket(connection=connection, name=bucket_name)
 
     if bucket is not None:
-        _DEFAULTS.bucket = bucket
+        _implicit_environ._DEFAULTS.bucket = bucket
 
 
 def set_default_project(project=None):
@@ -99,7 +99,7 @@ def set_default_project(project=None):
         project = os.getenv(_PROJECT_ENV_VAR_NAME)
 
     if project is not None:
-        _DEFAULTS.project = project
+        _implicit_environ._DEFAULTS.project = project
 
 
 def set_default_connection(project=None, connection=None):
@@ -115,7 +115,7 @@ def set_default_connection(project=None, connection=None):
         project = get_default_project()
 
     connection = connection or get_connection(project)
-    _DEFAULTS.connection = connection
+    _implicit_environ._DEFAULTS.connection = connection
 
 
 def set_defaults(bucket=None, project=None, connection=None):

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -40,7 +40,10 @@ The main concepts with this API are:
 import os
 
 from gcloud import credentials
-from gcloud.storage import _implicit_environ
+from gcloud.storage._implicit_environ import _DEFAULTS
+from gcloud.storage._implicit_environ import get_default_bucket
+from gcloud.storage._implicit_environ import get_default_connection
+from gcloud.storage._implicit_environ import get_default_project
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.connection import Connection
@@ -71,13 +74,13 @@ def set_default_bucket(bucket=None):
     """
     if bucket is None:
         bucket_name = os.getenv(_BUCKET_ENV_VAR_NAME)
-        connection = _implicit_environ.CONNECTION
+        connection = get_default_connection()
 
         if bucket_name is not None and connection is not None:
             bucket = Bucket(connection=connection, name=bucket_name)
 
     if bucket is not None:
-        _implicit_environ.BUCKET = bucket
+        _DEFAULTS.bucket = bucket
 
 
 def set_default_project(project=None):
@@ -96,7 +99,7 @@ def set_default_project(project=None):
         project = os.getenv(_PROJECT_ENV_VAR_NAME)
 
     if project is not None:
-        _implicit_environ.PROJECT = project
+        _DEFAULTS.project = project
 
 
 def set_default_connection(project=None, connection=None):
@@ -109,10 +112,10 @@ def set_default_connection(project=None, connection=None):
     :param connection: A connection provided to be the default.
     """
     if project is None:
-        project = _implicit_environ.PROJECT
+        project = get_default_project()
 
     connection = connection or get_connection(project)
-    _implicit_environ.CONNECTION = connection
+    _DEFAULTS.connection = connection
 
 
 def set_defaults(bucket=None, project=None, connection=None):

--- a/gcloud/storage/_implicit_environ.py
+++ b/gcloud/storage/_implicit_environ.py
@@ -14,16 +14,55 @@
 
 """Module to provide implicit behavior based on enviroment.
 
-Acts as a mutable namespace to allow the datastore package to
-infer the current dataset ID and connection from the enviroment.
+Allows the storage package to infer the current project, default bucket
+and connection from the enviroment.
 """
 
 
-PROJECT = None
-"""Module global to allow persistent implied project from enviroment."""
+class _DefaultsContainer(object):
+    """Container for defaults.
 
-BUCKET = None
-"""Module global to allow persistent implied bucket from enviroment."""
+    :type project: string
+    :param project: Persistent implied project from environment.
 
-CONNECTION = None
-"""Module global to allow persistent implied connection from enviroment."""
+    :type bucket: :class:`gcloud.storage.bucket.Bucket`
+    :param bucket: Persistent implied default bucket from environment.
+
+    :type connection: :class:`gcloud.storage.connection.Connection`
+    :param connection: Persistent implied connection from environment.
+    """
+
+    def __init__(self, project=None, bucket=None, connection=None):
+        self.project = project
+        self.bucket = bucket
+        self.connection = connection
+
+
+def get_default_project():
+    """Get default project.
+
+    :rtype: string or ``NoneType``
+    :returns: The default project if one has been set.
+    """
+    return _DEFAULTS.project
+
+
+def get_default_bucket():
+    """Get default bucket.
+
+    :rtype: :class:`gcloud.storage.bucket.Bucket` or ``NoneType``
+    :returns: The default bucket if one has been set.
+    """
+    return _DEFAULTS.bucket
+
+
+def get_default_connection():
+    """Get default connection.
+
+    :rtype: :class:`gcloud.storage.connection.Connection` or ``NoneType``
+    :returns: The default connection if one has been set.
+    """
+    return _DEFAULTS.connection
+
+
+_DEFAULTS = _DefaultsContainer()

--- a/gcloud/storage/_testing.py
+++ b/gcloud/storage/_testing.py
@@ -1,0 +1,33 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared storage testing utilities."""
+
+from gcloud._testing import _Monkey
+from gcloud.storage import _implicit_environ
+from gcloud.storage._implicit_environ import _DefaultsContainer
+
+
+def _monkey_defaults(*args, **kwargs):
+    mock_defaults = _DefaultsContainer(*args, **kwargs)
+    return _Monkey(_implicit_environ, _DEFAULTS=mock_defaults)
+
+
+def _setup_defaults(test_case, *args, **kwargs):
+    test_case._replaced_defaults = _implicit_environ._DEFAULTS
+    _implicit_environ._DEFAULTS = _DefaultsContainer(*args, **kwargs)
+
+
+def _tear_down_defaults(test_case):
+    _implicit_environ._DEFAULTS = test_case._replaced_defaults

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -88,7 +88,7 @@ class Blob(_PropertyMixin):
             name = properties.get('name')
 
         if bucket is None:
-            bucket = _implicit_environ.BUCKET
+            bucket = _implicit_environ.get_default_bucket()
 
         if bucket is None:
             raise ValueError('A Blob must have a bucket set.')

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -29,6 +29,7 @@ class Test_Blob(unittest2.TestCase):
         from gcloud.storage import _implicit_environ
 
         FAKE_BUCKET = _Bucket(None)
+
         def mock_get_bucket():
             return FAKE_BUCKET
 

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -29,7 +29,10 @@ class Test_Blob(unittest2.TestCase):
         from gcloud.storage import _implicit_environ
 
         FAKE_BUCKET = _Bucket(None)
-        with _Monkey(_implicit_environ, BUCKET=FAKE_BUCKET):
+        def mock_get_bucket():
+            return FAKE_BUCKET
+
+        with _Monkey(_implicit_environ, get_default_bucket=mock_get_bucket):
             blob = self._makeOne(None)
 
         self.assertEqual(blob.bucket, FAKE_BUCKET)

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -20,7 +20,6 @@ import unittest2
 from gcloud import exceptions
 from gcloud import storage
 from gcloud.storage._helpers import _base64_md5hash
-from gcloud.storage import _implicit_environ
 from gcloud.storage.batch import Batch
 
 
@@ -30,7 +29,7 @@ SHARED_BUCKETS = {}
 storage._PROJECT_ENV_VAR_NAME = 'GCLOUD_TESTS_PROJECT_ID'
 storage.set_defaults()
 
-CONNECTION = _implicit_environ.CONNECTION
+CONNECTION = storage.get_default_connection()
 
 
 def setUpModule():


### PR DESCRIPTION
This is in preparation to have lazy-loading auth and other settings as is done in the datastore.