### PR TITLE
Updating Sphinx theme from default to classic.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'default'
+html_theme = 'classic'
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:


### PR DESCRIPTION
This warning occurs in Sphinx 1.3 (and we treat all warnings as
errors). Thus it broke the most recent builds:
https://travis-ci.org/GoogleCloudPlatform/gcloud-python/builds/54014910
https://travis-ci.org/GoogleCloudPlatform/gcloud-python/builds/54015649