### PR TITLE
STORAGE: Adding default project in get_connection.

### DIFF
--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -111,9 +111,6 @@ def set_default_connection(project=None, connection=None):
     :type connection: :class:`gcloud.storage.connection.Connection`
     :param connection: A connection provided to be the default.
     """
-    if project is None:
-        project = get_default_project()
-
     connection = connection or get_connection(project)
     _implicit_environ._DEFAULTS.connection = connection
 
@@ -141,7 +138,7 @@ def set_defaults(bucket=None, project=None, connection=None):
     set_default_bucket(bucket=bucket)
 
 
-def get_connection(project):
+def get_connection(project=None):
     """Shortcut method to establish a connection to Cloud Storage.
 
     Use this if you are going to access several buckets with the same
@@ -152,12 +149,15 @@ def get_connection(project):
     >>> bucket1 = connection.get_bucket('bucket1')
     >>> bucket2 = connection.get_bucket('bucket2')
 
-    :type project: string
-    :param project: The name of the project to connect to.
+    :type project: string or ``NoneType``
+    :param project: Optional. The name of the project to connect to. If not
+                    included, falls back to default project.
 
     :rtype: :class:`gcloud.storage.connection.Connection`
     :returns: A connection defined with the proper credentials.
     """
+    if project is None:
+        project = get_default_project()
     implicit_credentials = credentials.get_credentials()
     scoped_credentials = implicit_credentials.create_scoped(SCOPE)
     return Connection(project=project, credentials=scoped_credentials)

--- a/gcloud/storage/test___init__.py
+++ b/gcloud/storage/test___init__.py
@@ -35,6 +35,24 @@ class Test_get_connection(unittest2.TestCase):
         self.assertTrue(found._credentials is client._signed)
         self.assertTrue(client._get_app_default_called)
 
+    def test_default_project(self):
+        from gcloud import credentials
+        from gcloud.storage._testing import _monkey_defaults
+        from gcloud.storage.connection import Connection
+        from gcloud.test_credentials import _Client
+        from gcloud._testing import _Monkey
+
+        PROJECT = 'project'
+        client = _Client()
+        with _Monkey(credentials, client=client):
+            with _monkey_defaults(project=PROJECT):
+                found = self._callFUT()
+
+        self.assertTrue(isinstance(found, Connection))
+        self.assertEqual(found.project, PROJECT)
+        self.assertTrue(found._credentials is client._signed)
+        self.assertTrue(client._get_app_default_called)
+
 
 class Test_get_bucket(unittest2.TestCase):
 
@@ -309,7 +327,7 @@ class Test_set_default_connection(unittest2.TestCase):
 
                 self.assertEqual(_implicit_environ.get_default_connection(),
                                  fake_cnxn)
-                self.assertEqual(_called_args, [(PROJECT,)])
+                self.assertEqual(_called_args, [(None,)])
                 self.assertEqual(_called_kwargs, [{}])
 
     def test_set_implicit_with_explicit_project(self):


### PR DESCRIPTION
Also removing the same fallback in `set_default_connection` since it calls `get_connection()`.

--------

FWIW: I came across this while trying to make implicit auth work in storage. The fact that `get_connection` requires arguments doesn't work well with [`_LazyProperty`][1].

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/blob/8ac28d16a5f2537579df297df477263a58aa1e45/gcloud/datastore/_implicit_environ.py#L226-L227