### PR TITLE
Adding back storage.lookup_bucket.

### DIFF
--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -44,6 +44,7 @@ from gcloud.storage import _implicit_environ
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
 from gcloud.storage._implicit_environ import get_default_project
+from gcloud.storage.api import lookup_bucket
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.connection import Connection

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -1,0 +1,57 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for interacting with Google Cloud Storage.
+
+Allows interacting with Cloud Storage via user-friendly objects
+rather than via Connection.
+"""
+
+from gcloud.exceptions import NotFound
+from gcloud.storage._implicit_environ import get_default_connection
+
+
+def lookup_bucket(bucket_name, connection=None):
+    """Get a bucket by name, returning None if not found.
+
+    You can use this if you would rather checking for a None value
+    than catching an exception::
+
+      >>> from gcloud import storage
+      >>> storage.set_defaults()
+      >>> bucket = storage.lookup_bucket('doesnt-exist')
+      >>> print bucket
+      None
+      >>> bucket = storage.lookup_bucket('my-bucket')
+      >>> print bucket
+      <Bucket: my-bucket>
+
+    :type bucket_name: string
+    :param bucket_name: The name of the bucket to get.
+
+    :type connection: :class:`gcloud.storage.connection.Connection` or
+                      ``NoneType``
+    :param connection: Optional. The connection to use when sending requests.
+                       If not provided, falls back to default.
+
+    :rtype: :class:`gcloud.storage.bucket.Bucket`
+    :returns: The bucket matching the name provided or None if not found.
+    """
+    if connection is None:
+        connection = get_default_connection()
+
+    try:
+        return connection.get_bucket(bucket_name)
+    except NotFound:
+        return None

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -1,0 +1,94 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+
+class Test_lookup_bucket(unittest2.TestCase):
+
+    def _callFUT(self, bucket_name, connection=None):
+        from gcloud.storage.api import lookup_bucket
+        return lookup_bucket(bucket_name, connection=connection)
+
+    def test_lookup_bucket_miss(self):
+        from gcloud.storage.connection import Connection
+        PROJECT = 'project'
+        NONESUCH = 'nonesuch'
+        conn = Connection(PROJECT)
+        URI = '/'.join([
+            conn.API_BASE_URL,
+            'storage',
+            conn.API_VERSION,
+            'b',
+            'nonesuch?project=%s' % PROJECT,
+        ])
+        http = conn._http = Http(
+            {'status': '404', 'content-type': 'application/json'},
+            '{}',
+        )
+        bucket = self._callFUT(NONESUCH, connection=conn)
+        self.assertEqual(bucket, None)
+        self.assertEqual(http._called_with['method'], 'GET')
+        self.assertEqual(http._called_with['uri'], URI)
+
+    def _lookup_bucket_hit_helper(self, use_default=False):
+        from gcloud.storage._testing import _monkey_defaults
+        from gcloud.storage.bucket import Bucket
+        from gcloud.storage.connection import Connection
+        PROJECT = 'project'
+        BLOB_NAME = 'blob-name'
+        conn = Connection(PROJECT)
+        URI = '/'.join([
+            conn.API_BASE_URL,
+            'storage',
+            conn.API_VERSION,
+            'b',
+            '%s?project=%s' % (BLOB_NAME, PROJECT),
+        ])
+        http = conn._http = Http(
+            {'status': '200', 'content-type': 'application/json'},
+            '{"name": "%s"}' % BLOB_NAME,
+        )
+
+        if use_default:
+            with _monkey_defaults(connection=conn):
+                bucket = self._callFUT(BLOB_NAME)
+        else:
+            bucket = self._callFUT(BLOB_NAME, connection=conn)
+
+        self.assertTrue(isinstance(bucket, Bucket))
+        self.assertTrue(bucket.connection is conn)
+        self.assertEqual(bucket.name, BLOB_NAME)
+        self.assertEqual(http._called_with['method'], 'GET')
+        self.assertEqual(http._called_with['uri'], URI)
+
+    def test_lookup_bucket_hit(self):
+        self._lookup_bucket_hit_helper(use_default=False)
+
+    def test_lookup_bucket_use_default(self):
+        self._lookup_bucket_hit_helper(use_default=True)
+
+
+class Http(object):
+
+    _called_with = None
+
+    def __init__(self, headers, content):
+        from httplib2 import Response
+        self._response = Response(headers)
+        self._content = content
+
+    def request(self, **kw):
+        self._called_with = kw
+        return self._response, self._content


### PR DESCRIPTION
This was originally removed in #588.

@tseaver I'd like to remove all the bucket functions from `Connection` and move them into `api`. WDYT?

Also it seems we'd eventually want to add a `_require_connection` as in `datastore.api`. It would be nice to come with a re-factor for re-usability (the `Batch` is the part which needs to be package specific).

--------

FWIW: I came across this while trying to make implicit auth work in storage. Importing `Connection` in `_implicit_environ` creates a cycle, essentially because `Connection` imports `Bucket`.