### PR TITLE
STORAGE: Making Connection.get_all_buckets a standalone method.

### DIFF
--- a/docs/_components/storage-getting-started.rst
+++ b/docs/_components/storage-getting-started.rst
@@ -186,13 +186,8 @@ If you have a full bucket, you can delete it this way::
 Listing available buckets
 -------------------------
 
-The :class:`Connection <gcloud.storage.connection.Connection>` object
-itself is iterable, so you can loop over it, or call ``list`` on it to get
-a list object::
-
-  >>> for bucket in connection.get_all_buckets():
+  >>> for bucket in storage.get_all_buckets(connection):
   ...   print bucket.name
-  >>> print list(connection)
 
 Managing access control
 -----------------------

--- a/docs/_components/storage-quickstart.rst
+++ b/docs/_components/storage-quickstart.rst
@@ -55,7 +55,8 @@ and instantiating the demo connection::
 Once you have the connection,
 you can create buckets and blobs::
 
-  >>> connection.get_all_buckets()
+  >>> from gcloud import storage
+  >>> storage.get_all_buckets(connection)
   [<Bucket: ...>, ...]
   >>> bucket = connection.create_bucket('my-new-bucket')
   >>> print bucket

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -44,6 +44,7 @@ from gcloud.storage import _implicit_environ
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
 from gcloud.storage._implicit_environ import get_default_project
+from gcloud.storage.api import get_all_buckets
 from gcloud.storage.api import lookup_bucket
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket

--- a/gcloud/storage/demo/demo.py
+++ b/gcloud/storage/demo/demo.py
@@ -1,18 +1,3 @@
-# Copyright 2014 Google Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# pragma NO COVER
 # Welcome to the gCloud Storage Demo! (hit enter)
 
 # We're going to walk through some of the basics...,
@@ -21,12 +6,13 @@
 # Let's start by importing the demo module and getting a connection:
 import time
 
+from gcloud import storage
 from gcloud.storage import demo
 
 connection = demo.get_connection()
 
 # OK, now let's look at all of the buckets...
-print(connection.get_all_buckets())  # This might take a second...
+print(list(storage.get_all_buckets(connection)))  # This might take a second...
 
 # Now let's create a new bucket...
 bucket_name = ("bucket-%s" % time.time()).replace(".", "")  # Get rid of dots.
@@ -35,7 +21,7 @@ bucket = connection.create_bucket(bucket_name)
 print(bucket)
 
 # Let's look at all of the buckets again...
-print(connection.get_all_buckets())
+print(list(storage.get_all_buckets(connection)))
 
 # How about we create a new blob inside this bucket.
 blob = bucket.new_blob("my-new-file.txt")

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -80,6 +80,102 @@ class Test_lookup_bucket(unittest2.TestCase):
         self._lookup_bucket_hit_helper(use_default=True)
 
 
+class Test_get_all_buckets(unittest2.TestCase):
+
+    def _callFUT(self, connection=None):
+        from gcloud.storage.api import get_all_buckets
+        return get_all_buckets(connection=connection)
+
+    def test_empty(self):
+        from gcloud.storage.connection import Connection
+        PROJECT = 'project'
+        conn = Connection(PROJECT)
+        URI = '/'.join([
+            conn.API_BASE_URL,
+            'storage',
+            conn.API_VERSION,
+            'b?project=%s' % PROJECT,
+        ])
+        http = conn._http = Http(
+            {'status': '200', 'content-type': 'application/json'},
+            '{}',
+        )
+        buckets = list(self._callFUT(conn))
+        self.assertEqual(len(buckets), 0)
+        self.assertEqual(http._called_with['method'], 'GET')
+        self.assertEqual(http._called_with['uri'], URI)
+
+    def _get_all_buckets_non_empty_helper(self, use_default=False):
+        from gcloud.storage._testing import _monkey_defaults
+        from gcloud.storage.connection import Connection
+        PROJECT = 'project'
+        BUCKET_NAME = 'bucket-name'
+        conn = Connection(PROJECT)
+        URI = '/'.join([
+            conn.API_BASE_URL,
+            'storage',
+            conn.API_VERSION,
+            'b?project=%s' % PROJECT,
+        ])
+        http = conn._http = Http(
+            {'status': '200', 'content-type': 'application/json'},
+            '{"items": [{"name": "%s"}]}' % BUCKET_NAME,
+        )
+
+        if use_default:
+            with _monkey_defaults(connection=conn):
+                buckets = list(self._callFUT())
+        else:
+            buckets = list(self._callFUT(conn))
+
+        self.assertEqual(len(buckets), 1)
+        self.assertEqual(buckets[0].name, BUCKET_NAME)
+        self.assertEqual(http._called_with['method'], 'GET')
+        self.assertEqual(http._called_with['uri'], URI)
+
+    def test_non_empty(self):
+        self._get_all_buckets_non_empty_helper(use_default=False)
+
+    def test_non_use_default(self):
+        self._get_all_buckets_non_empty_helper(use_default=True)
+
+
+class Test__BucketIterator(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud.storage.api import _BucketIterator
+        return _BucketIterator
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_ctor(self):
+        connection = object()
+        iterator = self._makeOne(connection)
+        self.assertTrue(iterator.connection is connection)
+        self.assertEqual(iterator.path, '/b')
+        self.assertEqual(iterator.page_number, 0)
+        self.assertEqual(iterator.next_page_token, None)
+
+    def test_get_items_from_response_empty(self):
+        connection = object()
+        iterator = self._makeOne(connection)
+        self.assertEqual(list(iterator.get_items_from_response({})), [])
+
+    def test_get_items_from_response_non_empty(self):
+        from gcloud.storage.bucket import Bucket
+        BLOB_NAME = 'blob-name'
+        response = {'items': [{'name': BLOB_NAME}]}
+        connection = object()
+        iterator = self._makeOne(connection)
+        buckets = list(iterator.get_items_from_response(response))
+        self.assertEqual(len(buckets), 1)
+        bucket = buckets[0]
+        self.assertTrue(isinstance(bucket, Bucket))
+        self.assertTrue(bucket.connection is connection)
+        self.assertEqual(bucket.name, BLOB_NAME)
+
+
 class Http(object):
 
     _called_with = None

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -76,7 +76,7 @@ class TestStorageBuckets(unittest2.TestCase):
             self.case_buckets_to_delete.append(bucket_name)
 
         # Retrieve the buckets.
-        all_buckets = CONNECTION.get_all_buckets()
+        all_buckets = storage.get_all_buckets()
         created_buckets = [bucket for bucket in all_buckets
                            if bucket.name in buckets_to_create]
         self.assertEqual(len(created_buckets), len(buckets_to_create))


### PR DESCRIPTION
See comments in #700 for context.

@tseaver I figured it would be easier to digest moving one method at a time instead of all 4 at once. Still remaining:

```bash
$ git grep -e '^    def' -- gcloud/storage/connection.py
gcloud/storage/connection.py:    def __init__(self, project, *args, **kwargs):
gcloud/storage/connection.py:    def build_api_url(self, path, query_params=None, api_base_url=None,
gcloud/storage/connection.py:    def _make_request(self, method, url, data=None, content_type=None,
gcloud/storage/connection.py:    def _do_request(self, method, url, headers, data):
gcloud/storage/connection.py:    def api_request(self, method, path, query_params=None,
gcloud/storage/connection.py:    def get_bucket(self, bucket_name):
gcloud/storage/connection.py:    def create_bucket(self, bucket_name):
gcloud/storage/connection.py:    def delete_bucket(self, bucket_name):
$ git log -1 --pretty=%H
9c783090ea81ec51c6752d24a3637da78a469631
```

-----------------

NOTE: I re-ran the storage demo to make sure this worked and noticed the very first line was the license. Without the opening

```
# Welcome to the gCloud Storage Demo! (hit enter)
```

the demo is pretty tough to use. I can add the license back at the end of the file if necessary or even after `# Welcome ...` (/cc @jgeewax).