### PR TITLE
Fixing demo runner: used to print empty newline at beginning of demo.

### DIFF
--- a/gcloud/datastore/demo/demo.py
+++ b/gcloud/datastore/demo/demo.py
@@ -1,3 +1,7 @@
+# Welcome to the gCloud Datastore Demo! (hit enter)
+# We're going to walk through some of the basics...
+# Don't worry though. You don't need to do anything, just keep hitting enter...
+
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Welcome to the gCloud Datastore Demo! (hit enter)
-# We're going to walk through some of the basics...
-# Don't worry though. You don't need to do anything, just keep hitting enter...
 
 # Let's start by importing the demo module and initializing our connection.
 from gcloud import datastore

--- a/gcloud/demo.py
+++ b/gcloud/demo.py
@@ -41,9 +41,11 @@ class DemoRunner(object):
     def run(self):
         line_groups = itertools.groupby(self.lines, self.get_line_type)
 
+        newline = False  # Don't use newline on the first statement.
         for group_type, lines in line_groups:
             if group_type == self.COMMENT:
-                self.write(lines)
+                self.write(lines, newline=newline)
+                newline = True
 
             elif group_type == self.CODE:
                 self.code(lines)
@@ -70,8 +72,8 @@ class DemoRunner(object):
         if newline:
             sys.stdout.write('\n')
 
-    def write(self, lines):
-        self._print()
+    def write(self, lines, newline=True):
+        self._print(newline=newline)
         self._print('\n'.join(lines), False)
         self.wait()
 

--- a/gcloud/storage/demo/demo.py
+++ b/gcloud/storage/demo/demo.py
@@ -1,7 +1,20 @@
 # Welcome to the gCloud Storage Demo! (hit enter)
-
-# We're going to walk through some of the basics...,
+# We're going to walk through some of the basics...
 # Don't worry though. You don't need to do anything, just keep hitting enter...
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Let's start by importing the demo module and getting a connection:
 import time


### PR DESCRIPTION
~~Also removing license from datastore demo.~~

Also putting license below the fold (adding back to storage demo). This is so that the user sees the message

> You don't need to do anything, just keep hitting enter...

printed first.

@jgeewax Is it OK to remove the license from the `demo.py` files? Without the opening line (in the demo) of:

```python
# Welcome to the gCloud Storage Demo! (hit enter)
```

it is unclear what to do next (e.g. if it starts with a giant glob of license text).

See my [previous comment][1] for some context.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/pull/716#issue-60879127