### PR TITLE
Using 'fields' in Bucket.exists().

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -132,7 +132,11 @@ class Bucket(_PropertyMixin):
         :returns: True if the bucket exists in Cloud Storage.
         """
         try:
-            self.connection.get_bucket(self.name)
+            # We only need the status code (200 or not) so we seek to
+            # minimize the returned payload.
+            query_params = {'fields': 'name'}
+            self.connection.api_request(method='GET', path=self.path,
+                                        query_params=query_params)
             return True
         except NotFound:
             return False

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -159,14 +159,22 @@ class Test_Bucket(unittest2.TestCase):
             _called_with = []
 
             @classmethod
-            def get_bucket(cls, bucket_name):
-                cls._called_with.append(bucket_name)
-                raise NotFound(bucket_name)
+            def api_request(cls, *args, **kwargs):
+                cls._called_with.append((args, kwargs))
+                raise NotFound(args)
 
-        NAME = 'name'
-        bucket = self._makeOne(connection=_FakeConnection, name=NAME)
+        BUCKET_NAME = 'bucket-name'
+        bucket = self._makeOne(connection=_FakeConnection, name=BUCKET_NAME)
         self.assertFalse(bucket.exists())
-        self.assertEqual(_FakeConnection._called_with, [NAME])
+        expected_called_kwargs = {
+            'method': 'GET',
+            'path': bucket.path,
+            'query_params': {
+                'fields': 'name',
+            },
+        }
+        expected_cw = [((), expected_called_kwargs)]
+        self.assertEqual(_FakeConnection._called_with, expected_cw)
 
     def test_exists_hit(self):
         class _FakeConnection(object):
@@ -174,15 +182,23 @@ class Test_Bucket(unittest2.TestCase):
             _called_with = []
 
             @classmethod
-            def get_bucket(cls, bucket_name):
-                cls._called_with.append(bucket_name)
+            def api_request(cls, *args, **kwargs):
+                cls._called_with.append((args, kwargs))
                 # exists() does not use the return value
                 return object()
 
-        NAME = 'name'
-        bucket = self._makeOne(connection=_FakeConnection, name=NAME)
+        BUCKET_NAME = 'bucket-name'
+        bucket = self._makeOne(connection=_FakeConnection, name=BUCKET_NAME)
         self.assertTrue(bucket.exists())
-        self.assertEqual(_FakeConnection._called_with, [NAME])
+        expected_called_kwargs = {
+            'method': 'GET',
+            'path': bucket.path,
+            'query_params': {
+                'fields': 'name',
+            },
+        }
+        expected_cw = [((), expected_called_kwargs)]
+        self.assertEqual(_FakeConnection._called_with, expected_cw)
 
     def test_acl_property(self):
         from gcloud.storage.acl import BucketACL


### PR DESCRIPTION
This decouples Bucket.exists() from Connection.get_bucket().

@tseaver This came up when I was to [removing][1] `Connection.get_bucket()`. I opted to just use `connection.api_request` instead of dealing with the potential cycle caused by importing `storage.api` anywhere but `__init__`.

As it turns out (as I mention in #632), this is a way to reduce the response payload for checking existence (unfortunately, the headers still are  overwhelmingly verbose).

[1]: https://github.com/dhermes/gcloud-python/tree/storage-move-bucket-methods