### PR TITLE
STORAGE: Allowing Batch() constructor to fall back to implicit.

### DIFF
--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -26,6 +26,7 @@ import json
 import six
 
 from gcloud._localstack import _LocalStack
+from gcloud.storage import _implicit_environ
 from gcloud.storage.connection import Connection
 
 
@@ -78,7 +79,10 @@ class Batch(Connection):
     """
     _MAX_BATCH_SIZE = 1000
 
-    def __init__(self, connection):
+    def __init__(self, connection=None):
+        if connection is None:
+            connection = _implicit_environ.get_default_connection()
+
         super(Batch, self).__init__(project=connection.project)
         self._connection = connection
         self._requests = []

--- a/gcloud/storage/test_batch.py
+++ b/gcloud/storage/test_batch.py
@@ -68,6 +68,14 @@ class TestMIMEApplicationHTTP(unittest2.TestCase):
 
 class TestBatch(unittest2.TestCase):
 
+    def setUp(self):
+        from gcloud.storage._testing import _setup_defaults
+        _setup_defaults(self)
+
+    def tearDown(self):
+        from gcloud.storage._testing import _tear_down_defaults
+        _tear_down_defaults(self)
+
     def _getTargetClass(self):
         from gcloud.storage.batch import Batch
         return Batch
@@ -79,6 +87,19 @@ class TestBatch(unittest2.TestCase):
         http = _HTTP()
         connection = _Connection(http=http)
         batch = self._makeOne(connection)
+        self.assertTrue(batch._connection is connection)
+        self.assertEqual(batch.project, connection.project)
+        self.assertEqual(len(batch._requests), 0)
+        self.assertEqual(len(batch._responses), 0)
+
+    def test_ctor_w_implicit_connection(self):
+        from gcloud.storage._testing import _monkey_defaults
+
+        http = _HTTP()
+        connection = _Connection(http=http)
+        with _monkey_defaults(connection=connection):
+            batch = self._makeOne()
+
         self.assertTrue(batch._connection is connection)
         self.assertEqual(batch.project, connection.project)
         self.assertEqual(len(batch._requests), 0)

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -29,8 +29,6 @@ SHARED_BUCKETS = {}
 storage._PROJECT_ENV_VAR_NAME = 'GCLOUD_TESTS_PROJECT_ID'
 storage.set_defaults()
 
-CONNECTION = storage.get_default_connection()
-
 
 def setUpModule():
     if 'test_bucket' not in SHARED_BUCKETS:
@@ -52,7 +50,7 @@ class TestStorageBuckets(unittest2.TestCase):
         self.case_buckets_to_delete = []
 
     def tearDown(self):
-        with Batch(CONNECTION) as batch:
+        with Batch() as batch:
             for bucket_name in self.case_buckets_to_delete:
                 storage.Bucket(connection=batch, name=bucket_name).delete()
 


### PR DESCRIPTION
~~**NOTE**: Has #721 as diffbase.~~

Also removing last explicit use of the implicit connection in storage regression test.
