### PR TITLE
Ensuring response from httplib2 is treated as str in Python 2 and bytes in Python3

### DIFF
--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -152,7 +152,7 @@ class TestConnection(unittest2.TestCase):
         METHOD = 'METHOD'
         DATA = 'DATA'
         conn = self._makeOne()
-        conn._http = Http({'status': '400'}, 'Entity value is indexed.')
+        conn._http = Http({'status': '400'}, b'Entity value is indexed.')
         with self.assertRaises(BadRequest) as e:
             conn._request(DATASET_ID, METHOD, DATA)
         expected_message = '400 Entity value is indexed.'

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -172,19 +172,18 @@ def make_exception(response, content, use_json=True):
     :rtype: instance of :class:`GCloudError`, or a concrete subclass.
     :returns: Exception specific to the error response.
     """
-    message = content
-    errors = ()
-
     if isinstance(content, six.binary_type):
-        message = content.decode('utf-8')
+        content_decoded = content.decode('utf-8')
         if use_json:
-            payload = json.loads(message)
+            payload = json.loads(content_decoded)
         else:
-            payload = {}
+            payload = {
+                'message': content_decoded
+            }
     else:
         payload = content
 
-    message = payload.get('message', message)
+    message = payload.get('message', '')
     errors = payload.get('error', {}).get('errors', ())
 
     try:

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -18,6 +18,7 @@ See: https://cloud.google.com/storage/docs/json_api/v1/status-codes
 """
 
 import json
+import six
 
 _HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
@@ -174,9 +175,10 @@ def make_exception(response, content, use_json=True):
     message = content
     errors = ()
 
-    if isinstance(content, str):
+    if isinstance(content, six.binary_type):
+        message = content.decode('utf-8')
         if use_json:
-            payload = json.loads(content)
+            payload = json.loads(message)
         else:
             payload = {}
     else:

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -235,6 +235,6 @@ class Connection(base_connection.Connection):
             content_type = response.get('content-type', '')
             if not content_type.startswith('application/json'):
                 raise TypeError('Expected JSON, got %s' % content_type)
-            return json.loads(content)
+            return json.loads(content.decode('utf-8'))
 
         return content

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -16,6 +16,7 @@
 
 import json
 
+import six
 from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
 
 from gcloud import connection as base_connection
@@ -230,6 +231,9 @@ class Connection(base_connection.Connection):
 
         if not 200 <= response.status < 300:
             raise make_exception(response, content)
+
+        if not isinstance(content, six.binary_type):
+            raise TypeError('Expected binary type, got %s' % type(content))
 
         if content and expect_json:
             content_type = response.get('content-type', '')

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -35,7 +35,7 @@ class Test_lookup_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         bucket = self._callFUT(NONESUCH, connection=conn)
         self.assertEqual(bucket, None)
@@ -58,7 +58,7 @@ class Test_lookup_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode(),
         )
 
         if use_default:
@@ -98,7 +98,7 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         buckets = list(self._callFUT(conn))
         self.assertEqual(len(buckets), 0)
@@ -119,7 +119,7 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"items": [{"name": "%s"}]}' % BUCKET_NAME,
+            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME).encode(),
         )
 
         if use_default:

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -58,7 +58,7 @@ class Test_lookup_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"name": "{0}"}}'.format(BLOB_NAME).encode(),
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:
@@ -119,7 +119,7 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME).encode(),
+            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME).encode('utf-8'),
         )
 
         if use_default:

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -119,7 +119,8 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME).encode('utf-8'),
+            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME)
+            .encode('utf-8'),
         )
 
         if use_default:
@@ -161,7 +162,7 @@ class Test_get_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         self.assertRaises(NotFound, self._callFUT, NONESUCH, connection=conn)
         self.assertEqual(http._called_with['method'], 'GET')
@@ -183,7 +184,7 @@ class Test_get_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:
@@ -226,7 +227,7 @@ class Test_create_bucket(unittest2.TestCase):
             ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -106,12 +106,12 @@ class TestConnection(unittest2.TestCase):
         URI = 'http://example.com/test'
         http = conn._http = Http(
             {'status': '200', 'content-type': 'text/plain'},
-            '',
+            b'',
         )
         headers, content = conn._make_request('GET', URI)
         self.assertEqual(headers['status'], '200')
         self.assertEqual(headers['content-type'], 'text/plain')
-        self.assertEqual(content, '')
+        self.assertEqual(content, b'')
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
         self.assertEqual(http._called_with['body'], None)
@@ -128,7 +128,7 @@ class TestConnection(unittest2.TestCase):
         URI = 'http://example.com/test'
         http = conn._http = Http(
             {'status': '200', 'content-type': 'text/plain'},
-            '',
+            b'',
         )
         conn._make_request('GET', URI, {}, 'application/json')
         self.assertEqual(http._called_with['method'], 'GET')
@@ -148,7 +148,7 @@ class TestConnection(unittest2.TestCase):
         URI = 'http://example.com/test'
         http = conn._http = Http(
             {'status': '200', 'content-type': 'text/plain'},
-            '',
+            b'',
         )
         conn._make_request('GET', URI, headers={'X-Foo': 'foo'})
         self.assertEqual(http._called_with['method'], 'GET')
@@ -173,7 +173,7 @@ class TestConnection(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         self.assertEqual(conn.api_request('GET', PATH), {})
         self.assertEqual(http._called_with['method'], 'GET')
@@ -191,7 +191,7 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(PROJECT)
         conn._http = Http(
             {'status': '200', 'content-type': 'text/plain'},
-            'CONTENT',
+            b'CONTENT',
         )
 
         self.assertRaises(TypeError, conn.api_request, 'GET', '/')
@@ -201,10 +201,10 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(PROJECT)
         conn._http = Http(
             {'status': '200', 'content-type': 'text/plain'},
-            'CONTENT',
+            b'CONTENT',
         )
         self.assertEqual(conn.api_request('GET', '/', expect_json=False),
-                         'CONTENT')
+                         b'CONTENT')
 
     def test_api_request_w_query_params(self):
         from six.moves.urllib.parse import parse_qsl
@@ -213,7 +213,7 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(PROJECT)
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         self.assertEqual(conn.api_request('GET', '/', {'foo': 'bar'}), {})
         self.assertEqual(http._called_with['method'], 'GET')
@@ -247,7 +247,7 @@ class TestConnection(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         self.assertEqual(conn.api_request('POST', '/', data=DATA), {})
         self.assertEqual(http._called_with['method'], 'POST')
@@ -267,7 +267,7 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(PROJECT)
         conn._http = Http(
             {'status': '404', 'content-type': 'text/plain'},
-            '{}'
+            b'{}',
         )
         self.assertRaises(NotFound, conn.api_request, 'GET', '/')
 
@@ -277,7 +277,7 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(PROJECT)
         conn._http = Http(
             {'status': '500', 'content-type': 'text/plain'},
-            '{}',
+            b'{}',
         )
         self.assertRaises(InternalServerError, conn.api_request, 'GET', '/')
 

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -281,6 +281,15 @@ class TestConnection(unittest2.TestCase):
         )
         self.assertRaises(InternalServerError, conn.api_request, 'GET', '/')
 
+    def test_api_request_non_binary_response(self):
+        PROJECT = 'project'
+        conn = self._makeOne(PROJECT)
+        conn._http = Http(
+            {'status': '200', 'content-type': 'application/json'},
+            u'CONTENT',
+        )
+        self.assertRaises(TypeError, conn.api_request, 'GET', '/')
+
 
 class Http(object):
 

--- a/gcloud/test_exceptions.py
+++ b/gcloud/test_exceptions.py
@@ -55,7 +55,7 @@ class Test_make_exception(unittest2.TestCase):
     def test_hit_w_content_as_str(self):
         from gcloud.exceptions import NotFound
         response = _Response(404)
-        content = '{"message": "Not Found"}'
+        content = b'{"message": "Not Found"}'
         exception = self._callFUT(response, content)
         self.assertTrue(isinstance(exception, NotFound))
         self.assertEqual(exception.message, 'Not Found')


### PR DESCRIPTION
When using Python 3 `httplib2` [returns response content as `bytes`](https://github.com/jcgregorio/httplib2/wiki/Examples-Python3), but the content is `str` in Python 2. This causes problems when passing the content to `json.loads`, which requires `str` always.

Tests were passing previously because they were mocking the response by `httplib2` as a `str`. These tests have been changed to use the `b` notation, which resolves to `str` in Python 2 and `bytes` in Python 3.

This is the follow-up from PR #697.