### PR TITLE
Suppress output of demo comments w/ leading '##'.

### DIFF
--- a/gcloud/datastore/demo/demo.py
+++ b/gcloud/datastore/demo/demo.py
@@ -1,16 +1,16 @@
-# Copyright 2014 Google Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+## Copyright 2014 Google Inc. All rights reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
 # Welcome to the gCloud Datastore Demo! (hit enter)
 # We're going to walk through some of the basics...
 # Don't worry though. You don't need to do anything, just keep hitting enter...

--- a/gcloud/demo.py
+++ b/gcloud/demo.py
@@ -26,7 +26,7 @@ class DemoRunner(object):
 
     KEYPRESS_DELAY = 0.02
     GLOBALS, LOCALS = globals(), locals()
-    CODE, COMMENT = 'code', 'comment'
+    CODE, COMMENT, COPYRIGHT = 'code', 'comment', 'copright'
 
     def __init__(self, fp):
         self.lines = [line.rstrip() for line in fp.readlines()]
@@ -55,10 +55,11 @@ class DemoRunner(object):
 
     @classmethod
     def get_line_type(cls, line):
+        if line.startswith('##'):
+            return cls.COPYRIGHT
         if line.startswith('#'):
             return cls.COMMENT
-        else:
-            return cls.CODE
+        return cls.CODE
 
     def get_indent_level(self, line):
         if not line.strip():

--- a/gcloud/storage/demo/demo.py
+++ b/gcloud/storage/demo/demo.py
@@ -1,3 +1,16 @@
+## Copyright 2014 Google Inc. All rights reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
 # Welcome to the gCloud Storage Demo! (hit enter)
 
 # We're going to walk through some of the basics...,

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ deps =
     Sphinx
 
 [pep8]
+ignore = E123,E266
 exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py,*.egg/,.*/,_gcloud_vendor/
 verbose = 1
 


### PR DESCRIPTION
Addresses: https://github.com/GoogleCloudPlatform/gcloud-python/pull/719#discussion_r26483278

pep8 changes to deal with bogus E266 (and E123, which is disabled by default, but shows up when any non-default ignore is added).