### PR TITLE
Making regression3 pass

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -16,6 +16,7 @@
 
 import json
 from pkg_resources import get_distribution
+import six
 from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
 
 import httplib2
@@ -295,6 +296,8 @@ class JSONConnection(Connection):
             content_type = response.get('content-type', '')
             if not content_type.startswith('application/json'):
                 raise TypeError('Expected JSON, got %s' % content_type)
+            if isinstance(content, six.binary_type):
+                content = content.decode('utf-8')
             return json.loads(content)
 
         return content

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -181,6 +181,8 @@ def _get_signed_query_params(credentials, expiration, signature_string):
     pem_key = _get_pem_key(credentials)
     # Sign the string with the RSA key.
     signer = PKCS1_v1_5.new(pem_key)
+    if not isinstance(signature_string, six.binary_type):
+        signature_string = signature_string.encode('utf-8')
     signature_hash = SHA256.new(signature_string)
     signature_bytes = signer.sign(signature_hash)
     signature = base64.b64encode(signature_bytes)

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -152,7 +152,7 @@ class TestConnection(unittest2.TestCase):
         METHOD = 'METHOD'
         DATA = 'DATA'
         conn = self._makeOne()
-        conn._http = Http({'status': '400'}, 'Entity value is indexed.')
+        conn._http = Http({'status': '400'}, b'Entity value is indexed.')
         with self.assertRaises(BadRequest) as e:
             conn._request(DATASET_ID, METHOD, DATA)
         expected_message = '400 Entity value is indexed.'

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -18,6 +18,7 @@ See: https://cloud.google.com/storage/docs/json_api/v1/status-codes
 """
 
 import json
+import six
 
 _HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
@@ -171,18 +172,18 @@ def make_exception(response, content, use_json=True):
     :rtype: instance of :class:`GCloudError`, or a concrete subclass.
     :returns: Exception specific to the error response.
     """
-    message = content
-    errors = ()
+    if isinstance(content, six.binary_type):
+        content = content.decode('utf-8')
 
-    if isinstance(content, str):
+    if isinstance(content, six.string_types):
         if use_json:
             payload = json.loads(content)
         else:
-            payload = {}
+            payload = {'message': content}
     else:
         payload = content
 
-    message = payload.get('message', message)
+    message = payload.get('message', '')
     errors = payload.get('error', {}).get('errors', ())
 
     try:

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -170,8 +170,14 @@ class Batch(Connection):
 def _unpack_batch_response(response, content):
     """Convert response, content -> [(status, reason, payload)]."""
     parser = Parser()
-    faux_message = ('Content-Type: %s\nMIME-Version: 1.0\n\n%s' %
-                    (response['content-type'], content))
+    if isinstance(content, six.binary_type):
+        content = content.decode('utf-8')
+    faux_message = ''.join([
+        'Content-Type: ',
+        response['content-type'],
+        '\nMIME-Version: 1.0\n\n',
+        content,
+    ])
 
     message = parser.parsestr(faux_message)
 

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -170,6 +170,9 @@ class Batch(Connection):
 def _unpack_batch_response(response, content):
     """Convert response, content -> [(status, reason, payload)]."""
     parser = Parser()
+    # We coerce to bytes to get consitent concat across
+    # Py2 and Py3. Percent formatting is insufficient since
+    # it includes the b in Py3.
     if not isinstance(content, six.binary_type):
         content = content.encode('utf-8')
     content_type = response['content-type']

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -34,7 +34,7 @@ class Test_lookup_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         bucket = self._callFUT(NONESUCH, connection=conn)
         self.assertEqual(bucket, None)
@@ -56,7 +56,7 @@ class Test_lookup_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:
@@ -96,7 +96,7 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         buckets = list(self._callFUT(PROJECT, conn))
         self.assertEqual(len(buckets), 0)
@@ -117,7 +117,8 @@ class Test_get_all_buckets(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"items": [{"name": "%s"}]}' % BUCKET_NAME,
+            '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME)
+            .encode('utf-8'),
         )
 
         if use_default:
@@ -159,7 +160,7 @@ class Test_get_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
-            '{}',
+            b'{}',
         )
         self.assertRaises(NotFound, self._callFUT, NONESUCH, connection=conn)
         self.assertEqual(http._called_with['method'], 'GET')
@@ -180,7 +181,7 @@ class Test_get_bucket(unittest2.TestCase):
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:
@@ -224,7 +225,7 @@ class Test_create_bucket(unittest2.TestCase):
             ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{"name": "%s"}' % BLOB_NAME,
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
         if use_default:

--- a/gcloud/storage/test_batch.py
+++ b/gcloud/storage/test_batch.py
@@ -347,7 +347,32 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(len(batch._responses), 0)
 
 
-_THREE_PART_MIME_RESPONSE = """\
+class Test__unpack_batch_response(unittest2.TestCase):
+
+    def _callFUT(self, response, content):
+        from gcloud.storage.batch import _unpack_batch_response
+        return _unpack_batch_response(response, content)
+
+    def test_bytes(self):
+        RESPONSE = {'content-type': b'multipart/mixed; boundary="DEADBEEF="'}
+        CONTENT = _THREE_PART_MIME_RESPONSE
+        result = list(self._callFUT(RESPONSE, CONTENT))
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], ('200', 'OK', {u'bar': 2, u'foo': 1}))
+        self.assertEqual(result[1], ('200', 'OK', {u'foo': 1, u'bar': 3}))
+        self.assertEqual(result[2], ('204', 'No Content', ''))
+
+    def test_unicode(self):
+        RESPONSE = {'content-type': u'multipart/mixed; boundary="DEADBEEF="'}
+        CONTENT = _THREE_PART_MIME_RESPONSE.decode('utf-8')
+        result = list(self._callFUT(RESPONSE, CONTENT))
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], ('200', 'OK', {u'bar': 2, u'foo': 1}))
+        self.assertEqual(result[1], ('200', 'OK', {u'foo': 1, u'bar': 3}))
+        self.assertEqual(result[2], ('204', 'No Content', ''))
+
+
+_THREE_PART_MIME_RESPONSE = b"""\
 --DEADBEEF=
 Content-Type: application/http
 Content-ID: <response-8a09ca85-8d1d-4f45-9eb0-da8e8b07ec83+1>

--- a/gcloud/test_exceptions.py
+++ b/gcloud/test_exceptions.py
@@ -55,7 +55,7 @@ class Test_make_exception(unittest2.TestCase):
     def test_hit_w_content_as_str(self):
         from gcloud.exceptions import NotFound
         response = _Response(404)
-        content = '{"message": "Not Found"}'
+        content = b'{"message": "Not Found"}'
         exception = self._callFUT(response, content)
         self.assertTrue(isinstance(exception, NotFound))
         self.assertEqual(exception.message, 'Not Found')

--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,8 @@ commands =
     {toxinidir}/scripts/run_regression.sh
 deps =
     unittest2
+    # Use a development checkout of httplib2 until a release is made
+    # incorporating https://github.com/jcgregorio/httplib2/pull/291
+    # and https://github.com/jcgregorio/httplib2/pull/296
+    -egit+https://github.com/jcgregorio/httplib2.git#egg=httplib2
     protobuf>=3.0.0-alpha-1

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,4 @@ commands =
     {toxinidir}/scripts/run_regression.sh
 deps =
     unittest2
-#   Use a development checkout of oauth2client until a release is made
-#   which fixes https://github.com/google/oauth2client/issues/125
-    -egit+https://github.com/google/oauth2client.git#egg=oauth2client
     protobuf>=3.0.0-alpha-1


### PR DESCRIPTION
- Uses latest release of `oauth2client` which incorporates google/oauth2client#126
- Pulling from `HEAD` in `httplib2` until jcgregorio/httplib2#291 and jcgregorio/httplib2#296 are incorporated
- Updating bytes/unicode handling, mostly as in #724 
- Updating `storage.batch._unpack_batch_response` to straddle Py2/Py3. The email native `str` dependency is tricky there.
- Added some more tests to cover unicode/bytes branching in library code
- Updated regression for storage to explicitly use binary when `str` is insufficient in Py3

**NOTE**: As in google/oauth2client#126, using `%s` for a Py2 and Py3 codebase caused us issues in `_unpack_batch_response`