### PR TITLE
Using a fallback connection in Bucket

### DIFF
--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -83,7 +83,7 @@ def set_default_bucket(bucket=None):
         bucket_name = os.getenv(_BUCKET_ENV_VAR_NAME)
         connection = get_default_connection()
 
-        if bucket_name is not None and connection is not None:
+        if bucket_name is not None:
             bucket = Bucket(bucket_name, connection=connection)
 
     if bucket is not None:

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -51,6 +51,7 @@ from gcloud.storage.api import create_bucket
 from gcloud.storage.api import get_all_buckets
 from gcloud.storage.api import get_bucket
 from gcloud.storage.api import lookup_bucket
+from gcloud.storage.batch import Batch
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.connection import Connection

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -46,14 +46,11 @@ def lookup_bucket(bucket_name, connection=None):
     :type connection: :class:`gcloud.storage.connection.Connection` or
                       ``NoneType``
     :param connection: Optional. The connection to use when sending requests.
-                       If not provided, falls back to default.
+                       If not provided, Bucket() will fall back to default.
 
     :rtype: :class:`gcloud.storage.bucket.Bucket`
     :returns: The bucket matching the name provided or None if not found.
     """
-    if connection is None:
-        connection = get_default_connection()
-
     try:
         return get_bucket(bucket_name, connection=connection)
     except NotFound:
@@ -116,15 +113,11 @@ def get_bucket(bucket_name, connection=None):
     :type connection: :class:`gcloud.storage.connection.Connection` or
                       ``NoneType``
     :param connection: Optional. The connection to use when sending requests.
-                       If not provided, falls back to default.
+                       If not provided, Bucket() will fall back to default.
 
     :rtype: :class:`gcloud.storage.bucket.Bucket`
     :returns: The bucket matching the name provided.
-    :raises: :class:`gcloud.exceptions.NotFound`
     """
-    if connection is None:
-        connection = get_default_connection()
-
     bucket = Bucket(bucket_name, connection=connection)
     bucket._reload_properties()
     return bucket
@@ -143,6 +136,9 @@ def create_bucket(bucket_name, project=None, connection=None):
 
     This implements "storage.buckets.insert".
 
+    If the bucket already exists, will raise
+    :class:`gcloud.exceptions.Conflict`.
+
     :type project: string
     :param project: Optional. The project to use when creating bucket.
                     If not provided, falls back to default.
@@ -153,25 +149,13 @@ def create_bucket(bucket_name, project=None, connection=None):
     :type connection: :class:`gcloud.storage.connection.Connection` or
                       ``NoneType``
     :param connection: Optional. The connection to use when sending requests.
-                       If not provided, falls back to default.
+                       If not provided, Bucket() will fall back to default.
 
     :rtype: :class:`gcloud.storage.bucket.Bucket`
     :returns: The newly created bucket.
-    :raises: :class:`gcloud.exceptions.Conflict` if
-             there is a confict (bucket already exists, invalid name, etc.)
     """
-    if connection is None:
-        connection = get_default_connection()
-    if project is None:
-        project = get_default_project()
-
-    query_params = {'project': project}
-    response = connection.api_request(method='POST', path='/b',
-                                      query_params=query_params,
-                                      data={'name': bucket_name})
-    name = response.get('name')
-    bucket = Bucket(name, connection=connection)
-    bucket._properties = response
+    bucket = Bucket(bucket_name, connection=connection)
+    bucket.create(project)
     return bucket
 
 

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -155,6 +155,11 @@ class Batch(Connection):
         self._responses = list(_unpack_batch_response(response, content))
         return self._responses
 
+    @staticmethod
+    def current():
+        """Return the topmost batch, or None."""
+        return _BATCHES.top
+
     def __enter__(self):
         _BATCHES.push(self)
         return self

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -36,6 +36,7 @@ You can also use the bucket as an iterator::
 import os
 import six
 
+from gcloud._helpers import get_default_project
 from gcloud.exceptions import NotFound
 from gcloud.storage._helpers import _PropertyMixin
 from gcloud.storage._helpers import _scalar_property
@@ -126,6 +127,34 @@ class Bucket(_PropertyMixin):
             return True
         except NotFound:
             return False
+
+    def create(self, project=None):
+        """Creates current bucket.
+
+        If the bucket already exists, will raise
+        :class:`gcloud.exceptions.Conflict`.
+
+        This implements "storage.buckets.insert".
+
+        :type project: string
+        :param project: Optional. The project to use when creating bucket.
+                        If not provided, falls back to default.
+
+        :rtype: :class:`gcloud.storage.bucket.Bucket`
+        :returns: The newly created bucket.
+        :raises: :class:`EnvironmentError` if the project is not given and
+                 can't be inferred.
+        """
+        if project is None:
+            project = get_default_project()
+        if project is None:
+            raise EnvironmentError('Project could not be inferred '
+                                   'from environment.')
+
+        query_params = {'project': project}
+        self._properties = self.connection.api_request(
+            method='POST', path='/b', query_params=query_params,
+            data={'name': self.name})
 
     @property
     def acl(self):

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -282,18 +282,25 @@ class Test__BucketIterator(unittest2.TestCase):
         iterator = self._makeOne(connection)
         self.assertEqual(list(iterator.get_items_from_response({})), [])
 
-    def test_get_items_from_response_non_empty(self):
+    def _get_items_helper(self, connection):
         from gcloud.storage.bucket import Bucket
         BLOB_NAME = 'blob-name'
         response = {'items': [{'name': BLOB_NAME}]}
-        connection = object()
         iterator = self._makeOne(connection)
         buckets = list(iterator.get_items_from_response(response))
         self.assertEqual(len(buckets), 1)
         bucket = buckets[0]
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is connection)
+        self.assertTrue(bucket._connection is connection)
         self.assertEqual(bucket.name, BLOB_NAME)
+
+    def test_get_items_from_response_non_empty(self):
+        connection = object()
+        self._get_items_helper(connection)
+
+    def test_get_items_from_response_implicit_connection(self):
+        connection = None
+        self._get_items_helper(connection)
 
 
 class Http(object):

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -62,11 +62,15 @@ class Test_lookup_bucket(unittest2.TestCase):
         if use_default:
             with _monkey_defaults(connection=conn):
                 bucket = self._callFUT(BLOB_NAME)
+            # In the default case, the bucket never has a connection
+            # bound to it.
+            self.assertTrue(bucket._connection is None)
         else:
             bucket = self._callFUT(BLOB_NAME, connection=conn)
+            # In the explicit case, the bucket has a connection bound to it.
+            self.assertTrue(bucket._connection is conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -187,11 +191,15 @@ class Test_get_bucket(unittest2.TestCase):
         if use_default:
             with _monkey_defaults(connection=conn):
                 bucket = self._callFUT(BLOB_NAME)
+            # In the default case, the bucket never has a connection
+            # bound to it.
+            self.assertTrue(bucket._connection is None)
         else:
             bucket = self._callFUT(BLOB_NAME, connection=conn)
+            # In the explicit case, the bucket has a connection bound to it.
+            self.assertTrue(bucket._connection is conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -232,11 +240,15 @@ class Test_create_bucket(unittest2.TestCase):
             with _base_monkey_defaults(project=project):
                 with _monkey_defaults(connection=conn):
                     bucket = self._callFUT(BLOB_NAME)
+            # In the default case, the bucket never has a connection
+            # bound to it.
+            self.assertTrue(bucket._connection is None)
         else:
             bucket = self._callFUT(BLOB_NAME, project=project, connection=conn)
+            # In the explicit case, the bucket has a connection bound to it.
+            self.assertTrue(bucket._connection is conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'POST')
         self.assertEqual(http._called_with['uri'], URI)

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -71,7 +71,7 @@ class Test_Bucket(unittest2.TestCase):
 
     def test_ctor_defaults(self):
         bucket = self._makeOne()
-        self.assertEqual(bucket.connection, None)
+        self.assertEqual(bucket._connection, None)
         self.assertEqual(bucket.name, None)
         self.assertEqual(bucket._properties, {})
         self.assertTrue(bucket._acl is None)
@@ -1068,6 +1068,44 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['query_params'], {})
 
 
+class Test__require_connection(unittest2.TestCase):
+
+    def _callFUT(self, connection=None):
+        from gcloud.storage.bucket import _require_connection
+        return _require_connection(connection=connection)
+
+    def _monkey(self, connection):
+        from gcloud.storage._testing import _monkey_defaults
+        return _monkey_defaults(connection=connection)
+
+    def test_implicit_unset(self):
+        with self._monkey(None):
+            with self.assertRaises(EnvironmentError):
+                self._callFUT()
+
+    def test_implicit_unset_w_existing_batch(self):
+        CONNECTION = object()
+        with self._monkey(None):
+            with _NoCommitBatch(connection=CONNECTION):
+                self.assertEqual(self._callFUT(), CONNECTION)
+
+    def test_implicit_unset_passed_explicitly(self):
+        CONNECTION = object()
+        with self._monkey(None):
+            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
+
+    def test_implicit_set(self):
+        IMPLICIT_CONNECTION = object()
+        with self._monkey(IMPLICIT_CONNECTION):
+            self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
+
+    def test_implicit_set_passed_explicitly(self):
+        IMPLICIT_CONNECTION = object()
+        CONNECTION = object()
+        with self._monkey(IMPLICIT_CONNECTION):
+            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
+
+
 class _Connection(object):
     _delete_bucket = False
 
@@ -1118,3 +1156,18 @@ class MockFile(io.StringIO):
     def __init__(self, name, buffer_=None):
         super(MockFile, self).__init__(buffer_)
         self.name = name
+
+
+class _NoCommitBatch(object):
+
+    def __init__(self, connection):
+        self._connection = connection
+
+    def __enter__(self):
+        from gcloud.storage.batch import _BATCHES
+        _BATCHES.push(self._connection)
+        return self._connection
+
+    def __exit__(self, *args):
+        from gcloud.storage.batch import _BATCHES
+        _BATCHES.pop()

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -51,9 +51,9 @@ class TestStorageBuckets(unittest2.TestCase):
         self.case_buckets_to_delete = []
 
     def tearDown(self):
-        with storage.Batch() as batch:
+        with storage.Batch():
             for bucket_name in self.case_buckets_to_delete:
-                storage.Bucket(bucket_name, connection=batch).delete()
+                storage.Bucket(bucket_name).delete()
 
     def test_create_bucket(self):
         new_bucket_name = 'a-new-bucket'

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -22,7 +22,6 @@ from gcloud import exceptions
 from gcloud import storage
 from gcloud import _helpers
 from gcloud.storage._helpers import _base64_md5hash
-from gcloud.storage.batch import Batch
 
 
 HTTP = httplib2.Http()
@@ -52,7 +51,7 @@ class TestStorageBuckets(unittest2.TestCase):
         self.case_buckets_to_delete = []
 
     def tearDown(self):
-        with Batch() as batch:
+        with storage.Batch() as batch:
             for bucket_name in self.case_buckets_to_delete:
                 storage.Bucket(bucket_name, connection=batch).delete()
 


### PR DESCRIPTION
This is an alternative fix to #728, by way of making `connection` be optional.

This has an effect of cascading through everything since `ACL` and `Blob` both use the connection of the `Bucket`.

Note especially the changes to `get_bucket` and `create_bucket`, which passes `None` through to the `Bucket()` constructor and lets the environment dictate the connection (e.g. in a batch).


----

@tseaver Do you think `bucket.connection` being a non-deterministic value will be confounding?