### PR TITLE
Remove properties= from Blob and Bucket constructors

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -39,20 +39,15 @@ class _PropertyMixin(object):
         """Abstract getter for the object path."""
         raise NotImplementedError
 
-    def __init__(self, name=None, properties=None):
+    def __init__(self, name=None):
         """_PropertyMixin constructor.
 
         :type name: string
         :param name: The name of the object.
-
-        :type properties: dict
-        :param properties: All the other data provided by Cloud Storage.
         """
         self.name = name
         self._properties = {}
         self._changes = set()
-        if properties is not None:
-            self._properties.update(properties)
 
     @property
     def properties(self):

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -62,17 +62,14 @@ class Blob(_PropertyMixin):
     # ACL rules are lazily retrieved.
     _acl = None
 
-    def __init__(self, name, bucket=None, properties=None):
-        if name is None and properties is not None:
-            name = properties.get('name')
-
+    def __init__(self, name, bucket=None):
         if bucket is None:
             bucket = _implicit_environ.get_default_bucket()
 
         if bucket is None:
             raise ValueError('A Blob must have a bucket set.')
 
-        super(Blob, self).__init__(name=name, properties=properties)
+        super(Blob, self).__init__(name=name)
 
         self.bucket = bucket
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -69,7 +69,10 @@ class _BlobIterator(Iterator):
         """
         self.prefixes = tuple(response.get('prefixes', ()))
         for item in response.get('items', []):
-            yield Blob(None, properties=item, bucket=self.bucket)
+            name = item.get('name')
+            blob = Blob(name, bucket=self.bucket)
+            blob._properties = item
+            yield blob
 
 
 class Bucket(_PropertyMixin):
@@ -188,7 +191,10 @@ class Bucket(_PropertyMixin):
         try:
             response = self.connection.api_request(method='GET',
                                                    path=blob.path)
-            return Blob(None, bucket=self, properties=response)
+            name = response.get('name')  # Expect this to be blob_name
+            blob = Blob(name, bucket=self)
+            blob._properties = response
+            return blob
         except NotFound:
             return None
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -92,10 +92,8 @@ class Bucket(_PropertyMixin):
     # ACL rules are lazily retrieved.
     _acl = _default_object_acl = None
 
-    def __init__(self, name=None, connection=None, properties=None):
-        if name is None and properties is not None:
-            name = properties.get('name')
-        super(Bucket, self).__init__(name=name, properties=properties)
+    def __init__(self, name=None, connection=None):
+        super(Bucket, self).__init__(name=name)
         self._connection = connection
 
     def __repr__(self):

--- a/gcloud/storage/iterator.py
+++ b/gcloud/storage/iterator.py
@@ -25,7 +25,9 @@ those results into an iterable of the actual objects you want::
     def get_items_from_response(self, response):
       items = response.get('items', [])
       for item in items:
-        yield MyItemClass(properties=item, other_arg=True)
+        my_item = MyItemClass(other_arg=True)
+        my_item._properties = item
+        yield my_item
 
 You then can use this to get **all** the results from a resource::
 

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -30,7 +30,7 @@ class Test_lookup_bucket(unittest2.TestCase):
             'storage',
             conn.API_VERSION,
             'b',
-            'nonesuch',
+            'nonesuch?projection=noAcl',
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
@@ -52,7 +52,7 @@ class Test_lookup_bucket(unittest2.TestCase):
             'storage',
             conn.API_VERSION,
             'b',
-            '%s' % (BLOB_NAME,),
+            '%s?projection=noAcl' % (BLOB_NAME,),
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},
@@ -156,7 +156,7 @@ class Test_get_bucket(unittest2.TestCase):
             'storage',
             conn.API_VERSION,
             'b',
-            'nonesuch',
+            'nonesuch?projection=noAcl',
         ])
         http = conn._http = Http(
             {'status': '404', 'content-type': 'application/json'},
@@ -177,7 +177,7 @@ class Test_get_bucket(unittest2.TestCase):
             'storage',
             conn.API_VERSION,
             'b',
-            '%s' % (BLOB_NAME,),
+            '%s?projection=noAcl' % (BLOB_NAME,),
         ])
         http = conn._http = Http(
             {'status': '200', 'content-type': 'application/json'},

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -64,9 +64,9 @@ class Test_Bucket(unittest2.TestCase):
 
     def _makeOne(self, *args, **kw):
         from gcloud.storage.bucket import Bucket
-        properties = kw.pop('properties', {})
+        properties = kw.pop('properties', None)
         bucket = Bucket(*args, **kw)
-        bucket._properties = properties
+        bucket._properties = properties or {}
         return bucket
 
     def test_ctor_defaults(self):


### PR DESCRIPTION
**NOTE**: Has #759 as a diffbase.

This is an implementation detail intended to make internal code have an easier time constructing entities, but never had a story for end-users.

The only real changes are effectively:

```diff
-            yield Bucket(properties=item, connection=self._ctor_connection)
+            name = item.get('name')
+            bucket = Bucket(name, connection=self._ctor_connection)
+            bucket._properties = item
+            yield bucket
```

For test conveniences, I've allowed `_makeOne()` to delegate the `properties=` keyword in the way it used to be used in the actual constructors.