### PR TITLE
Accomodate JSON services which do not return JSON payloads for errors.

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -119,6 +119,9 @@ class JSONConnection(Connection):
     API_URL_TEMPLATE = None
     """A template for the URL of a particular API call."""
 
+    JSON_ERRORS = True
+    """Overridable for services which do not return JSON errors."""
+
     @classmethod
     def build_api_url(cls, path, query_params=None,
                       api_base_url=None, api_version=None):
@@ -289,7 +292,7 @@ class JSONConnection(Connection):
             method=method, url=url, data=data, content_type=content_type)
 
         if not 200 <= response.status < 300:
-            raise make_exception(response, content)
+            raise make_exception(response, content, use_json=self.JSON_ERRORS)
 
         if content and expect_json:
             content_type = response.get('content-type', '')

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -28,3 +28,6 @@ class Connection(base_connection.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/pubsub/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    JSON_ERRORS = False
+    """Pubsub API does not return JSON payloads for errors ?!?."""

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -325,6 +325,16 @@ class TestJSONConnection(unittest2.TestCase):
         )
         self.assertRaises(NotFound, conn.api_request, 'GET', '/')
 
+    def test_api_request_w_404_no_JSON_in_payload(self):
+        from gcloud.exceptions import NotFound
+        conn = self._makeMockOne()
+        conn.JSON_ERRORS = False
+        conn._http = _Http(
+            {'status': '404', 'content-type': 'text/plain'},
+            'Not Found'
+        )
+        self.assertRaises(NotFound, conn.api_request, 'GET', '/')
+
     def test_api_request_w_500(self):
         from gcloud.exceptions import InternalServerError
         conn = self._makeMockOne()


### PR DESCRIPTION
I'm lookin' at you, pubsub.