### PR TITLE
Using correct format of exceptions from JSON based APIs.

### DIFF
--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -179,11 +179,11 @@ def make_exception(response, content, use_json=True):
         if use_json:
             payload = json.loads(content)
         else:
-            payload = {'message': content}
+            payload = {'error': {'message': content}}
     else:
         payload = content
 
-    message = payload.get('message', '')
+    message = payload.get('error', {}).get('message', '')
     errors = payload.get('error', {}).get('errors', ())
 
     try:

--- a/gcloud/test_exceptions.py
+++ b/gcloud/test_exceptions.py
@@ -55,7 +55,7 @@ class Test_make_exception(unittest2.TestCase):
     def test_hit_w_content_as_str(self):
         from gcloud.exceptions import NotFound
         response = _Response(404)
-        content = b'{"message": "Not Found"}'
+        content = b'{"error": {"message": "Not Found"}}'
         exception = self._callFUT(response, content)
         self.assertTrue(isinstance(exception, NotFound))
         self.assertEqual(exception.message, 'Not Found')
@@ -71,7 +71,7 @@ class Test_make_exception(unittest2.TestCase):
             'reason': 'test',
             }
         response = _Response(600)
-        content = {"message": "Unknown Error", "error": {"errors": [ERROR]}}
+        content = {"error": {"message": "Unknown Error", "errors": [ERROR]}}
         exception = self._callFUT(response, content)
         self.assertTrue(isinstance(exception, GCloudError))
         self.assertEqual(exception.message, 'Unknown Error')


### PR DESCRIPTION
Also factoring out Py2/Py3 behavior as _generate_faux_mime_message().
H/T to @tseaver for the factoring out.