### PR TITLE
Making cors a property instead of having two separate methods.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -457,28 +457,30 @@ class Bucket(_PropertyMixin):
         blob.upload_from_file(file_obj)
         return blob
 
-    def get_cors(self):
+    @property
+    def cors(self):
         """Retrieve CORS policies configured for this bucket.
 
         See: http://www.w3.org/TR/cors/ and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :rtype: list(dict)
+        :rtype: list of dictionaries
         :returns: A sequence of mappings describing each CORS policy.
         """
-        return [policy.copy() for policy in self.properties.get('cors', ())]
+        return [copy.deepcopy(policy)
+                for policy in self.properties.get('cors', ())]
 
-    def update_cors(self, entries):
-        """Update CORS policies configured for this bucket.
+    @cors.setter
+    def cors(self, entries):
+        """Set CORS policies configured for this bucket.
 
         See: http://www.w3.org/TR/cors/ and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :type entries: list(dict)
+        :type entries: list of dictionaries
         :param entries: A sequence of mappings describing each CORS policy.
         """
         self._patch_properties({'cors': entries})
-        self.patch()
 
     def get_default_object_acl(self):
         """Get the current Default Object ACL rules.


### PR DESCRIPTION
@tseaver based on your [comment][1], this drops one of the non-`property` data access pairs. More importantly, it drops one of the internal users of `patch()`.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/issues/728#issuecomment-86621610