### PR TITLE
Ditching lazy loading for ACLs attached to Blob/Bucket.

### DIFF
--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -59,8 +59,6 @@ class Blob(_PropertyMixin):
 
     This must be a multiple of 256 KB per the API specification.
     """
-    # ACL rules are lazily retrieved.
-    _acl = None
 
     def __init__(self, name, bucket=None):
         if bucket is None:
@@ -72,6 +70,7 @@ class Blob(_PropertyMixin):
         super(Blob, self).__init__(name=name)
 
         self.bucket = bucket
+        self._acl = ObjectACL(self)
 
     @staticmethod
     def path_helper(bucket_path, blob_name):
@@ -91,8 +90,6 @@ class Blob(_PropertyMixin):
     @property
     def acl(self):
         """Create our ACL on demand."""
-        if self._acl is None:
-            self._acl = ObjectACL(self)
         return self._acl
 
     def __repr__(self):

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -92,12 +92,11 @@ class Bucket(_PropertyMixin):
     _MAX_OBJECTS_FOR_BUCKET_DELETE = 256
     """Maximum number of existing objects allowed in Bucket.delete()."""
 
-    # ACL rules are lazily retrieved.
-    _acl = _default_object_acl = None
-
     def __init__(self, name=None, connection=None):
         super(Bucket, self).__init__(name=name)
         self._connection = connection
+        self._acl = BucketACL(self)
+        self._default_object_acl = DefaultObjectACL(self)
 
     def __repr__(self):
         return '<Bucket: %s>' % self.name
@@ -128,15 +127,11 @@ class Bucket(_PropertyMixin):
     @property
     def acl(self):
         """Create our ACL on demand."""
-        if self._acl is None:
-            self._acl = BucketACL(self)
         return self._acl
 
     @property
     def default_object_acl(self):
         """Create our defaultObjectACL on demand."""
-        if self._default_object_acl is None:
-            self._default_object_acl = DefaultObjectACL(self)
         return self._default_object_acl
 
     @property

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -43,7 +43,8 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(blob.connection, None)
         self.assertEqual(blob.name, None)
         self.assertEqual(blob._properties, {})
-        self.assertTrue(blob._acl is None)
+        self.assertFalse(blob._acl.loaded)
+        self.assertTrue(blob._acl.blob is blob)
 
     def test_ctor_defaults(self):
         FAKE_BUCKET = _Bucket(None)
@@ -52,7 +53,8 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(blob.connection, None)
         self.assertEqual(blob.name, None)
         self.assertEqual(blob._properties, {})
-        self.assertTrue(blob._acl is None)
+        self.assertFalse(blob._acl.loaded)
+        self.assertTrue(blob._acl.blob is blob)
 
     def test_ctor_explicit(self):
         BLOB_NAME = 'blob-name'
@@ -64,7 +66,8 @@ class Test_Blob(unittest2.TestCase):
         self.assertTrue(blob.connection is connection)
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(blob.properties, properties)
-        self.assertTrue(blob._acl is None)
+        self.assertFalse(blob._acl.loaded)
+        self.assertTrue(blob._acl.blob is blob)
 
     def test_acl_property(self):
         from gcloud.storage.acl import ObjectACL

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -74,8 +74,10 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(bucket.connection, None)
         self.assertEqual(bucket.name, None)
         self.assertEqual(bucket._properties, {})
-        self.assertTrue(bucket._acl is None)
-        self.assertTrue(bucket._default_object_acl is None)
+        self.assertFalse(bucket._acl.loaded)
+        self.assertTrue(bucket._acl.bucket is bucket)
+        self.assertFalse(bucket._default_object_acl.loaded)
+        self.assertTrue(bucket._default_object_acl.bucket is bucket)
 
     def test_ctor_explicit(self):
         NAME = 'name'
@@ -85,8 +87,10 @@ class Test_Bucket(unittest2.TestCase):
         self.assertTrue(bucket.connection is connection)
         self.assertEqual(bucket.name, NAME)
         self.assertEqual(bucket._properties, properties)
-        self.assertTrue(bucket._acl is None)
-        self.assertTrue(bucket._default_object_acl is None)
+        self.assertFalse(bucket._acl.loaded)
+        self.assertTrue(bucket._acl.bucket is bucket)
+        self.assertFalse(bucket._default_object_acl.loaded)
+        self.assertTrue(bucket._default_object_acl.bucket is bucket)
 
     def test___iter___empty(self):
         NAME = 'name'


### PR DESCRIPTION
Fixes #752.

I realize there was never any discussion in #752, but here is my argument for this:

> The constructors have a tiny memory footprint and make no HTTP request.