### PR TITLE
Adding storage.api._require_connection to allow fallback behavior.

### DIFF
--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -51,6 +51,7 @@ from gcloud.storage.api import create_bucket
 from gcloud.storage.api import get_all_buckets
 from gcloud.storage.api import get_bucket
 from gcloud.storage.api import lookup_bucket
+from gcloud.storage.batch import Batch
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.connection import Connection

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -155,6 +155,11 @@ class Batch(Connection):
         self._responses = list(_unpack_batch_response(response, content))
         return self._responses
 
+    @staticmethod
+    def current():
+        """Return the topmost batch, or None."""
+        return _BATCHES.top
+
     def __enter__(self):
         _BATCHES.push(self)
         return self

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -22,7 +22,6 @@ from gcloud import exceptions
 from gcloud import storage
 from gcloud import _helpers
 from gcloud.storage._helpers import _base64_md5hash
-from gcloud.storage.batch import Batch
 
 
 HTTP = httplib2.Http()
@@ -52,7 +51,7 @@ class TestStorageBuckets(unittest2.TestCase):
         self.case_buckets_to_delete = []
 
     def tearDown(self):
-        with Batch() as batch:
+        with storage.Batch() as batch:
             for bucket_name in self.case_buckets_to_delete:
                 storage.Bucket(bucket_name, connection=batch).delete()
 


### PR DESCRIPTION
Allows fallback in this order:
- explicit connection
- current batch
- default connection
- raise exception

Also adding Batch.current() to determine the top batch in context.

Also making `storage.Batch` publicly visible (reduces number of imports).

This was peeled off from #759