### PR TITLE
#744: return Subscription instances from `pubsub.list_subscriptions()`

### DIFF
--- a/gcloud/pubsub/__init__.py
+++ b/gcloud/pubsub/__init__.py
@@ -29,6 +29,7 @@ from gcloud._helpers import set_default_project
 from gcloud.connection import get_scoped_connection
 from gcloud.pubsub import _implicit_environ
 from gcloud.pubsub._implicit_environ import get_default_connection
+from gcloud.pubsub.api import list_subscriptions
 from gcloud.pubsub.api import list_topics
 from gcloud.pubsub.connection import Connection
 

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -55,7 +55,7 @@ class Subscription(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/create
         """
-        data = {'topic': self.topic.path}
+        data = {'topic': self.topic.full_name}
 
         if self.ack_deadline is not None:
             data['ackDeadline'] = self.ack_deadline

--- a/gcloud/pubsub/test_api.py
+++ b/gcloud/pubsub/test_api.py
@@ -97,23 +97,23 @@ class Test_list_subscriptions(unittest2.TestCase):
     def test_w_implicit_connection_wo_paging(self):
         from gcloud._testing import _monkey_defaults as _monkey_base_defaults
         from gcloud.pubsub._testing import _monkey_defaults
+        from gcloud.pubsub.subscription import Subscription
         PROJECT = 'PROJECT'
-        SUB_NAME = 'topic_name'
+        SUB_NAME = 'subscription_name'
         SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
         TOPIC_NAME = 'topic_name'
         TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        TOKEN = 'TOKEN'
-        returned = {'subscriptions': [{'name': SUB_PATH, 'topic': TOPIC_PATH}],
-                    'nextPageToken': TOKEN}
+        SUB_INFO = [{'name': SUB_PATH, 'topic': TOPIC_PATH}]
+        returned = {'subscriptions': SUB_INFO}
         conn = _Connection(returned)
         with _monkey_base_defaults(project=PROJECT):
             with _monkey_defaults(connection=conn):
-                response = self._callFUT()
-        subscriptions = response['subscriptions']
+                subscriptions, next_page_token = self._callFUT()
         self.assertEqual(len(subscriptions), 1)
-        self.assertEqual(subscriptions[0],
-                         {'name': SUB_PATH, 'topic': TOPIC_PATH})
-        self.assertEqual(response['nextPageToken'], TOKEN)
+        self.assertTrue(isinstance(subscriptions[0], Subscription))
+        self.assertEqual(subscriptions[0].name, SUB_NAME)
+        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
+        self.assertEqual(next_page_token, None)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
@@ -121,24 +121,33 @@ class Test_list_subscriptions(unittest2.TestCase):
         self.assertEqual(req['query_params'], {})
 
     def test_w_explicit_connection_and_project_w_paging(self):
+        from gcloud.pubsub.subscription import Subscription
         PROJECT = 'PROJECT'
-        SUB_NAME = 'topic_name'
+        SUB_NAME = 'subscription_name'
         SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
         TOPIC_NAME = 'topic_name'
         TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        ACK_DEADLINE = 42
+        PUSH_ENDPOINT = 'https://push.example.com/endpoint'
         TOKEN1 = 'TOKEN1'
         TOKEN2 = 'TOKEN2'
         SIZE = 1
-        returned = {'subscriptions': [{'name': SUB_PATH, 'topic': TOPIC_PATH}],
-                    'nextPageToken': TOKEN2}
+        SUB_INFO = [{'name': SUB_PATH,
+                     'topic': TOPIC_PATH,
+                     'ackDeadlineSeconds': ACK_DEADLINE,
+                     'pushConfig': {'pushEndpoint': PUSH_ENDPOINT}}]
+        returned = {'subscriptions': SUB_INFO, 'nextPageToken': TOKEN2}
         conn = _Connection(returned)
-        response = self._callFUT(SIZE, TOKEN1,
-                                 project=PROJECT, connection=conn)
-        subscriptions = response['subscriptions']
+        subscriptions, next_page_token = self._callFUT(SIZE, TOKEN1,
+                                                       project=PROJECT,
+                                                       connection=conn)
         self.assertEqual(len(subscriptions), 1)
-        self.assertEqual(subscriptions[0],
-                         {'name': SUB_PATH, 'topic': TOPIC_PATH})
-        self.assertEqual(response['nextPageToken'], TOKEN2)
+        self.assertTrue(isinstance(subscriptions[0], Subscription))
+        self.assertEqual(subscriptions[0].name, SUB_NAME)
+        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
+        self.assertEqual(subscriptions[0].ack_deadline, ACK_DEADLINE)
+        self.assertEqual(subscriptions[0].push_endpoint, PUSH_ENDPOINT)
+        self.assertEqual(next_page_token, TOKEN2)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
@@ -147,22 +156,31 @@ class Test_list_subscriptions(unittest2.TestCase):
                          {'pageSize': SIZE, 'pageToken': TOKEN1})
 
     def test_w_topic_name(self):
+        from gcloud.pubsub.subscription import Subscription
         PROJECT = 'PROJECT'
-        SUB_NAME = 'topic_name'
-        SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
+        SUB_NAME_1 = 'subscription_1'
+        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_1)
+        SUB_NAME_2 = 'subscription_2'
+        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_2)
         TOPIC_NAME = 'topic_name'
         TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        SUB_INFO = [{'name': SUB_PATH_1, 'topic': TOPIC_PATH},
+                    {'name': SUB_PATH_2, 'topic': TOPIC_PATH}]
         TOKEN = 'TOKEN'
-        returned = {'subscriptions': [{'name': SUB_PATH, 'topic': TOPIC_PATH}],
-                    'nextPageToken': TOKEN}
+        returned = {'subscriptions': SUB_INFO, 'nextPageToken': TOKEN}
         conn = _Connection(returned)
-        response = self._callFUT(topic_name=TOPIC_NAME,
-                                 project=PROJECT, connection=conn)
-        subscriptions = response['subscriptions']
-        self.assertEqual(len(subscriptions), 1)
-        self.assertEqual(subscriptions[0],
-                         {'name': SUB_PATH, 'topic': TOPIC_PATH})
-        self.assertEqual(response['nextPageToken'], TOKEN)
+        subscriptions, next_page_token = self._callFUT(topic_name=TOPIC_NAME,
+                                                       project=PROJECT,
+                                                       connection=conn)
+        self.assertEqual(len(subscriptions), 2)
+        self.assertTrue(isinstance(subscriptions[0], Subscription))
+        self.assertEqual(subscriptions[0].name, SUB_NAME_1)
+        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
+        self.assertTrue(isinstance(subscriptions[1], Subscription))
+        self.assertEqual(subscriptions[1].name, SUB_NAME_2)
+        self.assertEqual(subscriptions[1].topic.name, TOPIC_NAME)
+        self.assertTrue(subscriptions[1].topic is subscriptions[0].topic)
+        self.assertEqual(next_page_token, TOKEN)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -296,4 +296,5 @@ class _Topic(object):
         self.name = name
         self.project = project
         self.connection = connection
-        self.path = 'projects/%s/topics/%s' % (project, name)
+        self.full_name = 'projects/%s/topics/%s' % (project, name)
+        self.path = '/projects/%s/topics/%s' % (project, name)

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -35,6 +35,8 @@ class TestTopic(unittest2.TestCase):
                 topic = self._makeOne(TOPIC_NAME)
         self.assertEqual(topic.name, TOPIC_NAME)
         self.assertEqual(topic.project, PROJECT)
+        self.assertEqual(topic.full_name,
+                         'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME))
         self.assertTrue(topic.connection is conn)
 
     def test_ctor_w_explicit_project_and_connection(self):
@@ -44,6 +46,8 @@ class TestTopic(unittest2.TestCase):
         topic = self._makeOne(TOPIC_NAME, project=PROJECT, connection=conn)
         self.assertEqual(topic.name, TOPIC_NAME)
         self.assertEqual(topic.project, PROJECT)
+        self.assertEqual(topic.full_name,
+                         'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME))
         self.assertTrue(topic.connection is conn)
 
     def test_create(self):

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -51,9 +51,14 @@ class Topic(object):
         self.connection = connection
 
     @property
+    def full_name(self):
+        """Fully-qualified name used in topic / subscription APIs"""
+        return 'projects/%s/topics/%s' % (self.project, self.name)
+
+    @property
     def path(self):
         """URL path for the topic's APIs"""
-        return '/projects/%s/topics/%s' % (self.project, self.name)
+        return '/%s' % (self.full_name)
 
     def create(self):
         """API call:  create the topic via a PUT request


### PR DESCRIPTION
Includes regression tests for subscription creation, as well as fixes for bugs found via the regression tests.

See: #744