### PR TITLE
Fix #799: Don't pass 'fields' query param to possibly non-existing subscription.

### DIFF
--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -74,9 +74,7 @@ class Subscription(object):
         """
         conn = self.topic.connection
         try:
-            conn.api_request(method='GET',
-                             path=self.path,
-                             query_params={'fields': 'name'})
+            conn.api_request(method='GET', path=self.path)
         except NotFound:
             return False
         else:

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -95,7 +95,7 @@ class TestSubscription(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % SUB_PATH)
-        self.assertEqual(req['query_params'], {'fields': 'name'})
+        self.assertEqual(req.get('query_params'), None)
 
     def test_exists_hit(self):
         PROJECT = 'PROJECT'
@@ -111,7 +111,7 @@ class TestSubscription(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % SUB_PATH)
-        self.assertEqual(req['query_params'], {'fields': 'name'})
+        self.assertEqual(req.get('query_params'), None)
 
     def test_reload(self):
         PROJECT = 'PROJECT'


### PR DESCRIPTION
Work around #799 (leaving open while @tmatsuo investigates).

(UPDATED by @dhermes when original commit was amended)