### PR TITLE
Fix regression3 failures in pubsub

### DIFF
--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -126,12 +126,12 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(req['method'], 'DELETE')
         self.assertEqual(req['path'], '/%s' % PATH)
 
-    def test_publish_single_wo_attrs(self):
+    def test_publish_single_bytes_wo_attrs(self):
         import base64
         TOPIC_NAME = 'topic_name'
         PROJECT = 'PROJECT'
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
         MESSAGE = {'data': B64,
                    'attributes': {}}
@@ -151,7 +151,7 @@ class TestTopic(unittest2.TestCase):
         TOPIC_NAME = 'topic_name'
         PROJECT = 'PROJECT'
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
         MESSAGE = {'data': B64,
                    'attributes': {'attr1': 'value1', 'attr2': 'value2'}}

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -113,7 +113,8 @@ class Topic(object):
         :rtype: str
         :returns: message ID assigned by the server to the published message
         """
-        message_data = {'data': base64.b64encode(message), 'attributes': attrs}
+        message_b = base64.b64encode(message).decode('ascii')
+        message_data = {'data': message_b, 'attributes': attrs}
         data = {'messages': [message_data]}
         response = self.connection.api_request(method='POST',
                                                path='%s:publish' % self.path,

--- a/regression/pubsub.py
+++ b/regression/pubsub.py
@@ -114,7 +114,7 @@ class TestPubsub(unittest2.TestCase):
         self.to_delete.append(subscription)
 
         MESSAGE = b'MESSAGE'
-        EXTRA = b'EXTRA'
+        EXTRA = 'EXTRA'
         topic.publish(MESSAGE, extra=EXTRA)
 
         received = subscription.pull()


### PR DESCRIPTION
- Message payload must be bytes, base64ed, but then must be serializable to JSON.

- Likewise, 'attributes' values must be serializable to JSON.