### PR TITLE
Renaming storage.get_all_buckets to storage.list_buckets.

### DIFF
--- a/docs/_components/storage-getting-started.rst
+++ b/docs/_components/storage-getting-started.rst
@@ -184,7 +184,7 @@ If you have a full bucket, you can delete it this way::
 Listing available buckets
 -------------------------
 
-  >>> for bucket in storage.get_all_buckets(connection):
+  >>> for bucket in storage.list_buckets(connection):
   ...   print bucket.name
 
 Managing access control

--- a/docs/_components/storage-quickstart.rst
+++ b/docs/_components/storage-quickstart.rst
@@ -56,7 +56,7 @@ Once you have the connection,
 you can create buckets and blobs::
 
   >>> from gcloud import storage
-  >>> storage.get_all_buckets(connection)
+  >>> storage.list_buckets(connection)
   [<Bucket: ...>, ...]
   >>> bucket = storage.create_bucket('my-new-bucket', connection=connection)
   >>> print bucket

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -48,8 +48,8 @@ from gcloud.storage import _implicit_environ
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
 from gcloud.storage.api import create_bucket
-from gcloud.storage.api import get_all_buckets
 from gcloud.storage.api import get_bucket
+from gcloud.storage.api import list_buckets
 from gcloud.storage.api import lookup_bucket
 from gcloud.storage.batch import Batch
 from gcloud.storage.blob import Blob

--- a/gcloud/storage/demo/__init__.py
+++ b/gcloud/storage/demo/__init__.py
@@ -15,13 +15,14 @@
 import os
 from gcloud import storage
 
-__all__ = ['create_bucket', 'get_all_buckets', 'PROJECT_ID']
+__all__ = ['create_bucket', 'list_buckets', 'PROJECT_ID']
 
 PROJECT_ID = os.getenv('GCLOUD_TESTS_PROJECT_ID')
 
 
-def get_all_buckets(connection):
-    return list(storage.get_all_buckets(PROJECT_ID, connection))
+def list_buckets(connection):
+    return list(storage.list_buckets(project=PROJECT_ID,
+                                     connection=connection))
 
 
 def create_bucket(bucket_name, connection):

--- a/gcloud/storage/demo/demo.py
+++ b/gcloud/storage/demo/demo.py
@@ -25,7 +25,7 @@ from gcloud.storage import demo
 connection = storage.get_connection()
 
 # OK, now let's look at all of the buckets...
-print(demo.get_all_buckets(connection))  # This might take a second...
+print(list(demo.list_buckets(connection)))  # This might take a second...
 
 # Now let's create a new bucket...
 bucket_name = ("bucket-%s" % time.time()).replace(".", "")  # Get rid of dots.
@@ -34,7 +34,7 @@ bucket = demo.create_bucket(bucket_name, connection)
 print(bucket)
 
 # Let's look at all of the buckets again...
-print(demo.get_all_buckets(connection))
+print(list(demo.list_buckets(connection)))
 
 # How about we create a new blob inside this bucket.
 blob = storage.Blob("my-new-file.txt", bucket=bucket)

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -75,7 +75,7 @@ class TestStorageBuckets(unittest2.TestCase):
             self.case_buckets_to_delete.append(bucket_name)
 
         # Retrieve the buckets.
-        all_buckets = storage.get_all_buckets()
+        all_buckets = storage.list_buckets()
         created_buckets = [bucket for bucket in all_buckets
                            if bucket.name in buckets_to_create]
         self.assertEqual(len(created_buckets), len(buckets_to_create))


### PR DESCRIPTION
Also adding support for optional query parameters of `storage.buckets.list`.

Note this rename is "proposed" in #761. If there are issues we don't have to move forward with it.

Relates to #802.
