### PR TITLE
Returning native datetime objects for Bucket/Blob time properties.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -33,6 +33,7 @@ You can also use the bucket as an iterator::
   ...   print blob
 """
 
+import datetime
 import copy
 import os
 import six
@@ -45,6 +46,7 @@ from gcloud.storage.acl import BucketACL
 from gcloud.storage.acl import DefaultObjectACL
 from gcloud.storage.iterator import Iterator
 from gcloud.storage.blob import Blob
+from gcloud.storage.blob import _GOOGLE_TIMESTAMP_FORMAT
 
 
 class _BlobIterator(Iterator):
@@ -684,11 +686,13 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :rtype: string or ``NoneType``
-        :returns: RFC3339 valid timestamp, or ``None`` if the property is not
-                  set locally.
+        :rtype: :class:`datetime.datetime` or ``NoneType``
+        :returns: Datetime object parsed from RFC3339 valid timestamp, or
+                  ``None`` if the property is not set locally.
         """
-        return self._properties.get('timeCreated')
+        value = self._properties.get('timeCreated')
+        if value is not None:
+            return datetime.datetime.strptime(value, _GOOGLE_TIMESTAMP_FORMAT)
 
     @property
     def versioning_enabled(self):

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -125,12 +125,12 @@ class Test_Blob(unittest2.TestCase):
         from gcloud.storage import blob as MUT
 
         BLOB_NAME = 'blob-name'
-        EXPIRATION = '2014-10-16T20:34:37Z'
+        EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
-               '&Expiration=2014-10-16T20:34:37Z')
+               '&Expiration=2014-10-16T20:34:37.000Z')
 
         SIGNER = _Signer()
         with _Monkey(MUT, generate_signed_url=SIGNER):
@@ -151,12 +151,12 @@ class Test_Blob(unittest2.TestCase):
         from gcloud.storage import blob as MUT
 
         BLOB_NAME = 'parent/child'
-        EXPIRATION = '2014-10-16T20:34:37Z'
+        EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
-               '&Expiration=2014-10-16T20:34:37Z')
+               '&Expiration=2014-10-16T20:34:37.000Z')
 
         SIGNER = _Signer()
         with _Monkey(MUT, generate_signed_url=SIGNER):
@@ -176,12 +176,12 @@ class Test_Blob(unittest2.TestCase):
         from gcloud.storage import blob as MUT
 
         BLOB_NAME = 'blob-name'
-        EXPIRATION = '2014-10-16T20:34:37Z'
+        EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
-               '&Expiration=2014-10-16T20:34:37Z')
+               '&Expiration=2014-10-16T20:34:37.000Z')
 
         SIGNER = _Signer()
         with _Monkey(MUT, generate_signed_url=SIGNER):
@@ -267,7 +267,6 @@ class Test_Blob(unittest2.TestCase):
     def test_download_to_filename(self):
         import os
         import time
-        import datetime
         from six.moves.http_client import OK
         from six.moves.http_client import PARTIAL_CONTENT
         from tempfile import NamedTemporaryFile
@@ -292,11 +291,7 @@ class Test_Blob(unittest2.TestCase):
             with open(f.name, 'rb') as g:
                 wrote = g.read()
                 mtime = os.path.getmtime(f.name)
-                updatedTime = time.mktime(
-                    datetime.datetime.strptime(
-                        blob._properties['updated'],
-                        '%Y-%m-%dT%H:%M:%S.%fz').timetuple()
-                )
+                updatedTime = time.mktime(blob.updated.timetuple())
         self.assertEqual(wrote, b'abcdef')
         self.assertEqual(mtime, updatedTime)
 
@@ -990,22 +985,36 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(blob.storage_class, STORAGE_CLASS)
 
     def test_time_deleted(self):
+        import datetime
         BLOB_NAME = 'blob-name'
         connection = _Connection()
         bucket = _Bucket(connection)
-        TIME_DELETED = '2014-11-05T20:34:37Z'
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37)
+        TIME_DELETED = TIMESTAMP.isoformat() + '.000Z'
         properties = {'timeDeleted': TIME_DELETED}
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
-        self.assertEqual(blob.time_deleted, TIME_DELETED)
+        self.assertEqual(blob.time_deleted, TIMESTAMP)
+
+    def test_time_deleted_unset(self):
+        BUCKET = object()
+        blob = self._makeOne('blob-name', bucket=BUCKET)
+        self.assertEqual(blob.time_deleted, None)
 
     def test_updated(self):
+        import datetime
         BLOB_NAME = 'blob-name'
         connection = _Connection()
         bucket = _Bucket(connection)
-        UPDATED = '2014-11-05T20:34:37Z'
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37)
+        UPDATED = TIMESTAMP.isoformat() + '.000Z'
         properties = {'updated': UPDATED}
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
-        self.assertEqual(blob.updated, UPDATED)
+        self.assertEqual(blob.updated, TIMESTAMP)
+
+    def test_updated_unset(self):
+        BUCKET = object()
+        blob = self._makeOne('blob-name', bucket=BUCKET)
+        self.assertEqual(blob.updated, None)
 
 
 class _Responder(object):

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -856,10 +856,16 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(bucket.storage_class, STORAGE_CLASS)
 
     def test_time_created(self):
-        TIME_CREATED = '2014-11-05T20:34:37Z'
+        import datetime
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37)
+        TIME_CREATED = TIMESTAMP.isoformat() + '.000Z'
         properties = {'timeCreated': TIME_CREATED}
         bucket = self._makeOne(properties=properties)
-        self.assertEqual(bucket.time_created, TIME_CREATED)
+        self.assertEqual(bucket.time_created, TIMESTAMP)
+
+    def test_time_created_unset(self):
+        bucket = self._makeOne()
+        self.assertEqual(bucket.time_created, None)
 
     def test_versioning_enabled_getter_missing(self):
         NAME = 'name'


### PR DESCRIPTION
Note this was almost in #793 but dropped due to RFC3339 questions.

@craigcitro @thobrla can you vet an assumption for me? Will timestamps returned conform to

```python
_GOOGLE_TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
# For example
TIME_DELETED = '2014-11-05T20:34:37.000Z'
```

I ask because `'2014-11-05T20:34:37Z'` is also totally valid according to RFC3339 and I'm wondering if we can get away with using `datetime` alone (and not having to use the [`strict-rfc3339`][1] library for the full generality of RFC3339).

[1]: https://pypi.python.org/pypi/strict-rfc3339/