### PR TITLE
Preparing to use futures in storage.

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -54,10 +54,9 @@ class _PropertyMixin(object):
         # Pass only '?projection=noAcl' here because 'acl' and related
         # are handled via custom endpoints.
         query_params = {'projection': 'noAcl'}
-        self._properties = self.connection.api_request(
+        api_response = self.connection.api_request(
             method='GET', path=self.path, query_params=query_params)
-        # If the api_request succeeded, we reset changes.
-        self._changes = set()
+        self._set_properties(api_response)
 
     def _patch_property(self, name, value):
         """Update field of this object's properties.
@@ -77,6 +76,16 @@ class _PropertyMixin(object):
         self._changes.add(name)
         self._properties[name] = value
 
+    def _set_properties(self, value):
+        """Set the properties for the current object.
+
+        :type value: dict
+        :param value: The properties to be set.
+        """
+        self._properties = value
+        # If the values are reset, the changes must as well.
+        self._changes = set()
+
     def patch(self):
         """Sends all changed properties in a PATCH request.
 
@@ -86,11 +95,10 @@ class _PropertyMixin(object):
         # to work properly w/ 'noAcl'.
         update_properties = dict((key, self._properties[key])
                                  for key in self._changes)
-        self._properties = self.connection.api_request(
+        api_response = self.connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'})
-        # If the api_request succeeded, we reset changes.
-        self._changes = set()
+        self._set_properties(api_response)
 
 
 def _scalar_property(fieldname):

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -227,7 +227,7 @@ class _BucketIterator(Iterator):
         for item in response.get('items', []):
             name = item.get('name')
             bucket = Bucket(name, connection=self.connection)
-            bucket._properties = item
+            bucket._set_properties(item)
             yield bucket
 
 

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -386,7 +386,7 @@ class Blob(_PropertyMixin):
         if not isinstance(response_content,
                           six.string_types):  # pragma: NO COVER  Python3
             response_content = response_content.decode('utf-8')
-        self._properties = json.loads(response_content)
+        self._set_properties(json.loads(response_content))
 
     def upload_from_filename(self, filename, content_type=None):
         """Upload this blob's contents from the content of a named file.

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -75,7 +75,7 @@ class _BlobIterator(Iterator):
         for item in response.get('items', []):
             name = item.get('name')
             blob = Blob(name, bucket=self.bucket)
-            blob._properties = item
+            blob._set_properties(item)
             yield blob
 
 
@@ -152,9 +152,10 @@ class Bucket(_PropertyMixin):
                                    'from environment.')
 
         query_params = {'project': project}
-        self._properties = self.connection.api_request(
+        api_response = self.connection.api_request(
             method='POST', path='/b', query_params=query_params,
             data={'name': self.name})
+        self._set_properties(api_response)
 
     @property
     def acl(self):
@@ -220,7 +221,7 @@ class Bucket(_PropertyMixin):
                                                    path=blob.path)
             name = response.get('name')  # Expect this to be blob_name
             blob = Blob(name, bucket=self)
-            blob._properties = response
+            blob._set_properties(response)
             return blob
         except NotFound:
             return None
@@ -408,7 +409,7 @@ class Bucket(_PropertyMixin):
         new_blob = Blob(bucket=destination_bucket, name=new_name)
         api_path = blob.path + '/copyTo' + new_blob.path
         copy_result = self.connection.api_request(method='POST', path=api_path)
-        new_blob._properties = copy_result
+        new_blob._set_properties(copy_result)
         return new_blob
 
     def upload_file(self, filename, blob_name=None):

--- a/gcloud/storage/iterator.py
+++ b/gcloud/storage/iterator.py
@@ -26,7 +26,7 @@ those results into an iterable of the actual objects you want::
       items = response.get('items', [])
       for item in items:
         my_item = MyItemClass(other_arg=True)
-        my_item._properties = item
+        my_item._set_properties(item)
         yield my_item
 
 You then can use this to get **all** the results from a resource::


### PR DESCRIPTION
Wraps setting/getting of object `_properties` in custom methods. This will allow centralized detection of a future in a response and will also allow replacing with the value on access if it is ready.

Towards #775 

----

@tseaver LMK what you think of this. The next step (I have yet to write it) is to make `Batch._do_request` return a future object. These objects will be owned and kept in order by the `Batch` and eventually populated. (This may be an issue because `JSONConnection.api_request` will try to parse the response if we use `expect_json=True`. We simultaneously want to parse the non-batched JSON responses and just ignore the futures)