### PR TITLE
Using futures in batched requests

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -292,12 +292,13 @@ class JSONConnection(Connection):
         if not 200 <= response.status < 300:
             raise make_exception(response, content)
 
-        if content and expect_json:
+        if isinstance(content, six.binary_type):
+            content = content.decode('utf-8')
+
+        if expect_json and content and isinstance(content, six.string_types):
             content_type = response.get('content-type', '')
             if not content_type.startswith('application/json'):
                 raise TypeError('Expected JSON, got %s' % content_type)
-            if isinstance(content, six.binary_type):
-                content = content.decode('utf-8')
             return json.loads(content)
 
         return content

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -309,13 +309,13 @@ class JSONConnection(Connection):
         if not 200 <= response.status < 300:
             raise make_exception(response, content)
 
-        if isinstance(content, six.binary_type):
-            content = content.decode('utf-8')
-
-        if expect_json and content and isinstance(content, six.string_types):
+        string_or_bytes = (six.binary_type, six.text_type)
+        if content and expect_json and isinstance(content, string_or_bytes):
             content_type = response.get('content-type', '')
             if not content_type.startswith('application/json'):
                 raise TypeError('Expected JSON, got %s' % content_type)
+            if isinstance(content, six.binary_type):
+                content = content.decode('utf-8')
             return json.loads(content)
 
         return content

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -208,7 +208,8 @@ class JSONConnection(Connection):
 
         return self._do_request(method, url, headers, data, target_object)
 
-    def _do_request(self, method, url, headers, data, dummy):
+    def _do_request(self, method, url, headers, data,
+                    target_object):  # pylint: disable=unused-argument
         """Low-level helper:  perform the actual API request over HTTP.
 
         Allows batch context managers to override and defer a request.
@@ -225,9 +226,9 @@ class JSONConnection(Connection):
         :type data: string
         :param data: The data to send as the body of the request.
 
-        :type dummy: object or :class:`NoneType`
-        :param dummy: Unused ``target_object`` here but may be used
-                      by a superclass.
+        :type target_object: object or :class:`NoneType`
+        :param target_object: Unused ``target_object`` here but may be used
+                              by a superclass.
 
         :rtype: tuple of ``response`` (a dictionary of sorts)
                 and ``content`` (a string).

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -84,7 +84,7 @@ class _PropertyMixin(object):
     def _set_properties(self, value):
         """Set the properties for the current object.
 
-        :type value: dict
+        :type value: dict or :class:`gcloud.storage.batch._FutureDict`
         :param value: The properties to be set.
         """
         self._properties = value

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -88,6 +88,8 @@ class _PropertyMixin(object):
         :param value: The properties to be set.
         """
         self._properties = value
+        if hasattr(value, 'owner'):
+            value.owner = self
         # If the values are reset, the changes must as well.
         self._changes = set()
 

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -88,8 +88,6 @@ class _PropertyMixin(object):
         :param value: The properties to be set.
         """
         self._properties = value
-        if hasattr(value, 'owner'):
-            value.owner = self
         # If the values are reset, the changes must as well.
         self._changes = set()
 

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -60,7 +60,8 @@ class _PropertyMixin(object):
         # are handled via custom endpoints.
         query_params = {'projection': 'noAcl'}
         api_response = connection.api_request(
-            method='GET', path=self.path, query_params=query_params)
+            method='GET', path=self.path, query_params=query_params,
+            _target_object=self)
         self._set_properties(api_response)
 
     def _patch_property(self, name, value):
@@ -108,7 +109,7 @@ class _PropertyMixin(object):
                                  for key in self._changes)
         api_response = connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
-            query_params={'projection': 'full'})
+            query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
 
 

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -71,6 +71,61 @@ class NoContent(object):
     status = 204
 
 
+class _FutureDict(object):
+    """Class to hold a future value for a deferred request.
+
+    Used by for requests that get sent in a :class:`Batch`.
+
+    :type owner: object
+    :param owner: Optional. A blob or bucket (or other type) that depends on
+                  this future.
+    """
+
+    def __init__(self, owner=None):
+        self.owner = owner
+
+    @staticmethod
+    def get(key, default=None):
+        """Stand-in for dict.get.
+
+        :type key: object
+        :param key: Hashable dictionary key.
+
+        :type default: object
+        :param default: Fallback value to dict.get.
+
+        :raises: :class:`KeyError` always since the future is intended to fail
+                 as a dictionary.
+        """
+        raise KeyError('Cannot get(%r, default=%r) on a future' % (
+            key, default))
+
+    def __getitem__(self, key):
+        """Stand-in for dict[key].
+
+        :type key: object
+        :param key: Hashable dictionary key.
+
+        :raises: :class:`KeyError` always since the future is intended to fail
+                 as a dictionary.
+        """
+        raise KeyError('Cannot get item %r from a future' % (key,))
+
+    def __setitem__(self, key, value):
+        """Stand-in for dict[key] = value.
+
+        :type key: object
+        :param key: Hashable dictionary key.
+
+        :type value: object
+        :param value: Dictionary value.
+
+        :raises: :class:`KeyError` always since the future is intended to fail
+                 as a dictionary.
+        """
+        raise KeyError('Cannot set %r -> %r on a future' % (key, value))
+
+
 class Batch(Connection):
     """Proxy an underlying connection, batching up change operations.
 

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -235,8 +235,8 @@ class Batch(Connection):
 
         url = '%s/batch' % self.API_BASE_URL
 
-        _req = self._connection._make_request
-        response, content = _req('POST', url, data=body, headers=headers)
+        response, content = self._connection._make_request(
+            'POST', url, data=body, headers=headers)
         responses = list(_unpack_batch_response(response, content))
         self._finish_futures(responses)
         return responses

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -227,7 +227,8 @@ class Blob(_PropertyMixin):
             # minimize the returned payload.
             query_params = {'fields': 'name'}
             connection.api_request(method='GET', path=self.path,
-                                   query_params=query_params)
+                                   query_params=query_params,
+                                   _target_object=self)
             return True
         except NotFound:
             return False

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -73,22 +73,12 @@ class Test_PropertyMixin(unittest2.TestCase):
         # Make sure changes get reset by reload.
         self.assertEqual(derived._changes, set())
 
-    def test__set_properties_no_future(self):
+    def test__set_properties(self):
         mixin = self._makeOne()
         self.assertEqual(mixin._properties, {})
-        VALUE = {'foo': 'bar'}
+        VALUE = object()
         mixin._set_properties(VALUE)
         self.assertEqual(mixin._properties, VALUE)
-        self.assertFalse(hasattr(VALUE, 'owner'))
-
-    def test__set_properties_future(self):
-        from gcloud.storage.batch import _FutureDict
-        mixin = self._makeOne()
-        future = _FutureDict()
-        self.assertEqual(future.owner, None)
-        mixin._set_properties(future)
-        self.assertEqual(mixin._properties, future)
-        self.assertEqual(future.owner, mixin)
 
     def test__patch_property(self):
         derived = self._derivedClass()()

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -73,6 +73,23 @@ class Test_PropertyMixin(unittest2.TestCase):
         # Make sure changes get reset by reload.
         self.assertEqual(derived._changes, set())
 
+    def test__set_properties_no_future(self):
+        mixin = self._makeOne()
+        self.assertEqual(mixin._properties, {})
+        VALUE = {'foo': 'bar'}
+        mixin._set_properties(VALUE)
+        self.assertEqual(mixin._properties, VALUE)
+        self.assertFalse(hasattr(VALUE, 'owner'))
+
+    def test__set_properties_future(self):
+        from gcloud.storage.batch import _FutureDict
+        mixin = self._makeOne()
+        future = _FutureDict()
+        self.assertEqual(future.owner, None)
+        mixin._set_properties(future)
+        self.assertEqual(mixin._properties, future)
+        self.assertEqual(future.owner, mixin)
+
     def test__patch_property(self):
         derived = self._derivedClass()()
         derived._patch_property('foo', 'Foo')

--- a/gcloud/storage/test_batch.py
+++ b/gcloud/storage/test_batch.py
@@ -404,6 +404,38 @@ Content-Length: 0
 """
 
 
+class Test__FutureDict(unittest2.TestCase):
+
+    def _makeOne(self, *args, **kw):
+        from gcloud.storage.batch import _FutureDict
+        return _FutureDict(*args, **kw)
+
+    def test_ctor_defaults(self):
+        future = self._makeOne()
+        self.assertEqual(future.owner, None)
+
+    def test_ctor_owner(self):
+        OWNER = object()
+        future = self._makeOne(owner=OWNER)
+        self.assertTrue(future.owner is OWNER)
+
+    def test_get(self):
+        future = self._makeOne()
+        self.assertRaises(KeyError, future.get, None)
+
+    def test___getitem__(self):
+        future = self._makeOne()
+        value = orig_value = object()
+        with self.assertRaises(KeyError):
+            value = future[None]
+        self.assertTrue(value is orig_value)
+
+    def test___setitem__(self):
+        future = self._makeOne()
+        with self.assertRaises(KeyError):
+            future[None] = None
+
+
 class _Connection(object):
 
     project = 'TESTING'

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -162,6 +162,7 @@ class Test_Bucket(unittest2.TestCase):
             'query_params': {
                 'fields': 'name',
             },
+            '_target_object': None,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -186,6 +187,7 @@ class Test_Bucket(unittest2.TestCase):
             'query_params': {
                 'fields': 'name',
             },
+            '_target_object': None,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -330,7 +332,11 @@ class Test_Bucket(unittest2.TestCase):
         connection = _Connection()
         bucket = self._makeOne(NAME)
         self.assertRaises(NotFound, bucket.delete, connection=connection)
-        expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
+        expected_cw = [{
+            'method': 'DELETE',
+            'path': bucket.path,
+            '_target_object': None,
+        }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
     def test_delete_explicit_hit(self):
@@ -341,7 +347,11 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(NAME, connection)
         result = bucket.delete(force=True, connection=connection)
         self.assertTrue(result is None)
-        expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
+        expected_cw = [{
+            'method': 'DELETE',
+            'path': bucket.path,
+            '_target_object': None,
+        }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
     def test_delete_explicit_force_delete_blobs(self):
@@ -361,7 +371,11 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(NAME, connection)
         result = bucket.delete(force=True, connection=connection)
         self.assertTrue(result is None)
-        expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
+        expected_cw = [{
+            'method': 'DELETE',
+            'path': bucket.path,
+            '_target_object': None,
+        }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
     def test_delete_explicit_force_miss_blobs(self):
@@ -374,7 +388,11 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(NAME, connection)
         result = bucket.delete(force=True, connection=connection)
         self.assertTrue(result is None)
-        expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
+        expected_cw = [{
+            'method': 'DELETE',
+            'path': bucket.path,
+            '_target_object': None,
+        }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
     def test_delete_explicit_too_many(self):

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -255,7 +255,7 @@ class TestJSONConnection(unittest2.TestCase):
             b'CONTENT',
         )
         self.assertEqual(conn.api_request('GET', '/', expect_json=False),
-                         b'CONTENT')
+                         u'CONTENT')
 
     def test_api_request_w_query_params(self):
         from six.moves.urllib.parse import parse_qsl

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -255,7 +255,7 @@ class TestJSONConnection(unittest2.TestCase):
             b'CONTENT',
         )
         self.assertEqual(conn.api_request('GET', '/', expect_json=False),
-                         u'CONTENT')
+                         b'CONTENT')
 
     def test_api_request_w_query_params(self):
         from six.moves.urllib.parse import parse_qsl


### PR DESCRIPTION
~~Has #810 as diffbase.~~

@tseaver Note this does not support the `Iterator` subclasses, but I have tested with a fair amount of other requests.

It **does** enable `GET` requests, but does so in a somewhat incomplete way.

The main issues are

1.  In `Iterator.get_next_page_response`

    ```python
    self.next_page_token = response.get('nextPageToken')
    ```

    fails when `response` is a `_Future`

1.  In `_BucketIterator.get_items_from_response`

    ```python
    for item in response.get('items', []):
    ```

    fails when `response` is a `_Future`

The first is easy to deal with (e.g. `hasattr(response, 'get')`) but the second is not as easy because we need to start an ~~and~~ iterator before knowing what will end up in the response.