### PR TITLE
#797:  Add sortable message timestamp

### DIFF
--- a/gcloud/pubsub/message.py
+++ b/gcloud/pubsub/message.py
@@ -19,7 +19,7 @@ import datetime
 
 import pytz
 
-RFC3369 = '%Y-%m-%dT%H:%M:%S.%fZ'
+_RFC3339_MICROS = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 class Message(object):
@@ -54,13 +54,13 @@ class Message(object):
         """Return timestamp from attributes, if passed.
 
         :rtype: datetime
-        :returns: timestamp (in UTC timezone) parsed from RFC 3369 timestamp
+        :returns: timestamp (in UTC timezone) parsed from RFC 3339 timestamp
         :raises: ValueError if timestamp not in ``attributes``, or malformed
         """
         stamp = self.attributes.get('timestamp')
         if stamp is None:
             raise ValueError('No timestamp')
-        return datetime.datetime.strptime(stamp, RFC3369).replace(
+        return datetime.datetime.strptime(stamp, _RFC3339_MICROS).replace(
             tzinfo=pytz.UTC)
 
     @classmethod

--- a/gcloud/pubsub/message.py
+++ b/gcloud/pubsub/message.py
@@ -51,11 +51,15 @@ class Message(object):
 
     @property
     def timestamp(self):
-        """Return timestamp from attributes, if passed.
+        """Return sortable timestamp from attributes, if passed.
+
+        Allows sorting messages in publication order (assuming consistent
+        clocks across all publishers).
 
         :rtype: datetime
         :returns: timestamp (in UTC timezone) parsed from RFC 3339 timestamp
-        :raises: ValueError if timestamp not in ``attributes``, or malformed
+        :raises: ValueError if timestamp not in ``attributes``, or if it does
+                 not match the RFC 3339 format.
         """
         stamp = self.attributes.get('timestamp')
         if stamp is None:

--- a/gcloud/pubsub/message.py
+++ b/gcloud/pubsub/message.py
@@ -15,6 +15,11 @@
 """Define API Topics."""
 
 import base64
+import datetime
+
+import pytz
+
+RFC3369 = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 class Message(object):
@@ -43,6 +48,20 @@ class Message(object):
         if self._attributes is None:
             self._attributes = {}
         return self._attributes
+
+    @property
+    def timestamp(self):
+        """Return timestamp from attributes, if passed.
+
+        :rtype: datetime
+        :returns: timestamp (in UTC timezone) parsed from RFC 3369 timestamp
+        :raises: ValueError if timestamp not in ``attributes``, or malformed
+        """
+        stamp = self.attributes.get('timestamp')
+        if stamp is None:
+            raise ValueError('No timestamp')
+        return datetime.datetime.strptime(stamp, RFC3369).replace(
+            tzinfo=pytz.UTC)
 
     @classmethod
     def from_api_repr(cls, api_repr):

--- a/gcloud/pubsub/test_message.py
+++ b/gcloud/pubsub/test_message.py
@@ -91,13 +91,13 @@ class TestMessage(unittest2.TestCase):
 
     def test_timestamp_w_timestamp_in_attributes(self):
         from datetime import datetime
-        import pytz
+        from pytz import utc
+        from gcloud.pubsub.message import _RFC3339_MICROS
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
         TIMESTAMP = '2015-04-10T18:42:27.131956Z'
-        RFC3369 = '%Y-%m-%dT%H:%M:%S.%fZ'
-        naive = datetime.strptime(TIMESTAMP, RFC3369)
-        timestamp = naive.replace(tzinfo=pytz.utc)
+        naive = datetime.strptime(TIMESTAMP, _RFC3339_MICROS)
+        timestamp = naive.replace(tzinfo=utc)
         ATTRS = {'timestamp': TIMESTAMP}
         message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
                                 attributes=ATTRS)

--- a/gcloud/pubsub/test_message.py
+++ b/gcloud/pubsub/test_message.py
@@ -66,3 +66,39 @@ class TestMessage(unittest2.TestCase):
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.attributes, ATTRS)
+
+    def test_timestamp_no_attributes(self):
+        DATA = b'DEADBEEF'
+        MESSAGE_ID = b'12345'
+        message = self._makeOne(data=DATA, message_id=MESSAGE_ID)
+
+        def _to_fail():
+            return message.timestamp
+
+        self.assertRaises(ValueError, _to_fail)
+
+    def test_timestamp_wo_timestamp_in_attributes(self):
+        DATA = b'DEADBEEF'
+        MESSAGE_ID = b'12345'
+        ATTRS = {'a': 'b'}
+        message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
+                                attributes=ATTRS)
+
+        def _to_fail():
+            return message.timestamp
+
+        self.assertRaises(ValueError, _to_fail)
+
+    def test_timestamp_w_timestamp_in_attributes(self):
+        from datetime import datetime
+        import pytz
+        DATA = b'DEADBEEF'
+        MESSAGE_ID = b'12345'
+        TIMESTAMP = '2015-04-10T18:42:27.131956Z'
+        RFC3369 = '%Y-%m-%dT%H:%M:%S.%fZ'
+        naive = datetime.strptime(TIMESTAMP, RFC3369)
+        timestamp = naive.replace(tzinfo=pytz.utc)
+        ATTRS = {'timestamp': TIMESTAMP}
+        message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
+                                attributes=ATTRS)
+        self.assertEqual(message.timestamp, timestamp)


### PR DESCRIPTION
Based on #809.

Allows subscribers of timestamping topics to sort messages.