### PR TITLE
Using httplib2 from PyPI in regression3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 REQUIREMENTS = [
     'google-apitools',
-    'httplib2',
+    'httplib2 >= 0.9.1',
     'oauth2client >= 1.4.6',
     'protobuf >= 2.5.0',
     'pycrypto',

--- a/tox.ini
+++ b/tox.ini
@@ -67,9 +67,3 @@ basepython =
     python3.4
 commands =
     {toxinidir}/scripts/run_regression.sh
-deps =
-    {[testenv]deps}
-    # Use a development checkout of httplib2 until a release is made
-    # incorporating https://github.com/jcgregorio/httplib2/pull/291
-    # and https://github.com/jcgregorio/httplib2/pull/296
-    -egit+https://github.com/jcgregorio/httplib2.git#egg=httplib2


### PR DESCRIPTION
Release 0.9.1 of httplib2 has the fix required to make oauth2client actually work in Python 3.