### PR TITLE
Decouple connection from Blob

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -20,6 +20,9 @@ These are *not* part of the API.
 from Crypto.Hash import MD5
 import base64
 
+from gcloud.storage._implicit_environ import get_default_connection
+from gcloud.storage.batch import Batch
+
 
 class _PropertyMixin(object):
     """Abstract mixin for cloud storage classes with associated propertties.
@@ -99,6 +102,30 @@ class _PropertyMixin(object):
             method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'})
         self._set_properties(api_response)
+
+
+def _require_connection(connection=None):
+    """Infer a connection from the environment, if not passed explicitly.
+
+    :type connection: :class:`gcloud.storage.connection.Connection`
+    :param connection: Optional.
+
+    :rtype: :class:`gcloud.storage.connection.Connection`
+    :returns: A connection based on the current environment.
+    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
+             cannot be inferred from the environment.
+    """
+    # NOTE: We use current Batch directly since it inherits from Connection.
+    if connection is None:
+        connection = Batch.current()
+
+    if connection is None:
+        connection = get_default_connection()
+
+    if connection is None:
+        raise EnvironmentError('Connection could not be inferred.')
+
+    return connection
 
 
 def _scalar_property(fieldname):

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -20,8 +20,7 @@ rather than via Connection.
 
 from gcloud.exceptions import NotFound
 from gcloud._helpers import get_default_project
-from gcloud.storage._implicit_environ import get_default_connection
-from gcloud.storage.batch import Batch
+from gcloud.storage._helpers import _require_connection
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.iterator import Iterator
 
@@ -227,27 +226,3 @@ class _BucketIterator(Iterator):
             bucket = Bucket(name, connection=self.connection)
             bucket._set_properties(item)
             yield bucket
-
-
-def _require_connection(connection=None):
-    """Infer a connection from the environment, if not passed explicitly.
-
-    :type connection: :class:`gcloud.storage.connection.Connection`
-    :param connection: Optional.
-
-    :rtype: :class:`gcloud.storage.connection.Connection`
-    :returns: A connection based on the current environment.
-    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
-             cannot be inferred from the environment.
-    """
-    # NOTE: We use current Batch directly since it inherits from Connection.
-    if connection is None:
-        connection = Batch.current()
-
-    if connection is None:
-        connection = get_default_connection()
-
-    if connection is None:
-        raise EnvironmentError('Connection could not be inferred.')
-
-    return connection

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -209,18 +209,24 @@ class Blob(_PropertyMixin):
             api_access_endpoint=_API_ACCESS_ENDPOINT,
             expiration=expiration, method=method)
 
-    def exists(self):
+    def exists(self, connection=None):
         """Determines whether or not this blob exists.
+
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
 
         :rtype: boolean
         :returns: True if the blob exists in Cloud Storage.
         """
+        connection = _require_connection(connection)
         try:
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.
             query_params = {'fields': 'name'}
-            self.connection.api_request(method='GET', path=self.path,
-                                        query_params=query_params)
+            connection.api_request(method='GET', path=self.path,
+                                   query_params=query_params)
             return True
         except NotFound:
             return False

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -331,7 +331,7 @@ class Blob(_PropertyMixin):
         return string_buffer.getvalue()
 
     def upload_from_file(self, file_obj, rewind=False, size=None,
-                         content_type=None, num_retries=6):
+                         content_type=None, num_retries=6, connection=None):
         """Upload the contents of this blob from a file-like object.
 
         The content type of the upload will either be
@@ -367,7 +367,13 @@ class Blob(_PropertyMixin):
 
         :type num_retries: integer
         :param num_retries: Number of upload retries. Defaults to 6.
+
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
         """
+        connection = _require_connection(connection)
         content_type = (content_type or self._properties.get('contentType') or
                         'application/octet-stream')
 
@@ -377,11 +383,10 @@ class Blob(_PropertyMixin):
 
         # Get the basic stats about the file.
         total_bytes = size or os.fstat(file_obj.fileno()).st_size
-        conn = self.connection
         headers = {
             'Accept': 'application/json',
             'Accept-Encoding': 'gzip, deflate',
-            'User-Agent': conn.USER_AGENT,
+            'User-Agent': connection.USER_AGENT,
         }
 
         upload = transfer.Upload(file_obj, content_type, total_bytes,
@@ -393,20 +398,20 @@ class Blob(_PropertyMixin):
         upload_config = _UploadConfig()
 
         # Temporary URL, until we know simple vs. resumable.
-        base_url = conn.API_BASE_URL + '/upload'
-        upload_url = conn.build_api_url(api_base_url=base_url,
-                                        path=self.bucket.path + '/o')
+        base_url = connection.API_BASE_URL + '/upload'
+        upload_url = connection.build_api_url(api_base_url=base_url,
+                                              path=self.bucket.path + '/o')
 
         # Use apitools 'Upload' facility.
         request = http_wrapper.Request(upload_url, 'POST', headers)
 
         upload.ConfigureRequest(upload_config, request, url_builder)
         query_params = url_builder.query_params
-        base_url = conn.API_BASE_URL + '/upload'
-        request.url = conn.build_api_url(api_base_url=base_url,
-                                         path=self.bucket.path + '/o',
-                                         query_params=query_params)
-        upload.InitializeUpload(request, conn.http)
+        base_url = connection.API_BASE_URL + '/upload'
+        request.url = connection.build_api_url(api_base_url=base_url,
+                                               path=self.bucket.path + '/o',
+                                               query_params=query_params)
+        upload.InitializeUpload(request, connection.http)
 
         # Should we be passing callbacks through from caller?  We can't
         # pass them as None, because apitools wants to print to the console
@@ -416,7 +421,7 @@ class Blob(_PropertyMixin):
                 callback=lambda *args: None,
                 finish_callback=lambda *args: None)
         else:
-            http_response = http_wrapper.MakeRequest(conn.http, request,
+            http_response = http_wrapper.MakeRequest(connection.http, request,
                                                      retries=num_retries)
         response_content = http_response.content
         if not isinstance(response_content,
@@ -424,7 +429,8 @@ class Blob(_PropertyMixin):
             response_content = response_content.decode('utf-8')
         self._set_properties(json.loads(response_content))
 
-    def upload_from_filename(self, filename, content_type=None):
+    def upload_from_filename(self, filename, content_type=None,
+                             connection=None):
         """Upload this blob's contents from the content of a named file.
 
         The content type of the upload will either be
@@ -448,15 +454,22 @@ class Blob(_PropertyMixin):
 
         :type content_type: string or ``NoneType``
         :param content_type: Optional type of content being uploaded.
+
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
         """
         content_type = content_type or self._properties.get('contentType')
         if content_type is None:
             content_type, _ = mimetypes.guess_type(filename)
 
         with open(filename, 'rb') as file_obj:
-            self.upload_from_file(file_obj, content_type=content_type)
+            self.upload_from_file(file_obj, content_type=content_type,
+                                  connection=connection)
 
-    def upload_from_string(self, data, content_type='text/plain'):
+    def upload_from_string(self, data, content_type='text/plain',
+                           connection=None):
         """Upload contents of this blob from the provided string.
 
         .. note::
@@ -473,14 +486,19 @@ class Blob(_PropertyMixin):
         :type data: bytes or text
         :param data: The data to store in this blob.  If the value is
                      text, it will be encoded as UTF-8.
+
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
         """
         if isinstance(data, six.text_type):
             data = data.encode('utf-8')
         string_buffer = BytesIO()
         string_buffer.write(data)
         self.upload_from_file(file_obj=string_buffer, rewind=True,
-                              size=len(data),
-                              content_type=content_type)
+                              size=len(data), content_type=content_type,
+                              connection=connection)
 
     def make_public(self):
         """Make this blob public giving all users read access."""

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -115,6 +115,44 @@ class Test__scalar_property(unittest2.TestCase):
         self.assertEqual(test._patched, ('solfege', 'Latido'))
 
 
+class Test__require_connection(unittest2.TestCase):
+
+    def _callFUT(self, connection=None):
+        from gcloud.storage._helpers import _require_connection
+        return _require_connection(connection=connection)
+
+    def _monkey(self, connection):
+        from gcloud.storage._testing import _monkey_defaults
+        return _monkey_defaults(connection=connection)
+
+    def test_implicit_unset(self):
+        with self._monkey(None):
+            with self.assertRaises(EnvironmentError):
+                self._callFUT()
+
+    def test_implicit_unset_w_existing_batch(self):
+        CONNECTION = object()
+        with self._monkey(None):
+            with _NoCommitBatch(connection=CONNECTION):
+                self.assertEqual(self._callFUT(), CONNECTION)
+
+    def test_implicit_unset_passed_explicitly(self):
+        CONNECTION = object()
+        with self._monkey(None):
+            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
+
+    def test_implicit_set(self):
+        IMPLICIT_CONNECTION = object()
+        with self._monkey(IMPLICIT_CONNECTION):
+            self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
+
+    def test_implicit_set_passed_explicitly(self):
+        IMPLICIT_CONNECTION = object()
+        CONNECTION = object()
+        with self._monkey(IMPLICIT_CONNECTION):
+            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
+
+
 class Test__base64_md5hash(unittest2.TestCase):
 
     def _callFUT(self, bytes_to_sign):
@@ -208,3 +246,18 @@ class _Base64(object):
     def b64encode(self, value):
         self._called_b64encode.append(value)
         return value
+
+
+class _NoCommitBatch(object):
+
+    def __init__(self, connection):
+        self._connection = connection
+
+    def __enter__(self):
+        from gcloud.storage.batch import _BATCHES
+        _BATCHES.push(self._connection)
+        return self._connection
+
+    def __exit__(self, *args):
+        from gcloud.storage.batch import _BATCHES
+        _BATCHES.pop()

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -349,44 +349,6 @@ class Test__BucketIterator(unittest2.TestCase):
         self.assertEqual(bucket.name, BLOB_NAME)
 
 
-class Test__require_connection(unittest2.TestCase):
-
-    def _callFUT(self, connection=None):
-        from gcloud.storage.api import _require_connection
-        return _require_connection(connection=connection)
-
-    def _monkey(self, connection):
-        from gcloud.storage._testing import _monkey_defaults
-        return _monkey_defaults(connection=connection)
-
-    def test_implicit_unset(self):
-        with self._monkey(None):
-            with self.assertRaises(EnvironmentError):
-                self._callFUT()
-
-    def test_implicit_unset_w_existing_batch(self):
-        CONNECTION = object()
-        with self._monkey(None):
-            with _NoCommitBatch(connection=CONNECTION):
-                self.assertEqual(self._callFUT(), CONNECTION)
-
-    def test_implicit_unset_passed_explicitly(self):
-        CONNECTION = object()
-        with self._monkey(None):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
-
-    def test_implicit_set(self):
-        IMPLICIT_CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
-
-    def test_implicit_set_passed_explicitly(self):
-        IMPLICIT_CONNECTION = object()
-        CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
-
-
 class Http(object):
 
     _called_with = None
@@ -399,18 +361,3 @@ class Http(object):
     def request(self, **kw):
         self._called_with = kw
         return self._response, self._content
-
-
-class _NoCommitBatch(object):
-
-    def __init__(self, connection):
-        self._connection = connection
-
-    def __enter__(self):
-        from gcloud.storage.batch import _BATCHES
-        _BATCHES.push(self._connection)
-        return self._connection
-
-    def __exit__(self, *args):
-        from gcloud.storage.batch import _BATCHES
-        _BATCHES.pop()

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -266,19 +266,19 @@ class Test_Blob(unittest2.TestCase):
         NONESUCH = 'nonesuch'
         not_found_response = {'status': NOT_FOUND}
         connection = _Connection(not_found_response)
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(NONESUCH, bucket=bucket)
-        self.assertFalse(blob.exists())
+        self.assertFalse(blob.exists(connection=connection))
 
     def test_exists_hit(self):
         from six.moves.http_client import OK
         BLOB_NAME = 'blob-name'
         found_response = {'status': OK}
         connection = _Connection(found_response)
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
-        self.assertTrue(blob.exists())
+        self.assertTrue(blob.exists(connection=connection))
 
     def test_rename(self):
         BLOB_NAME = 'blob-name'
@@ -299,11 +299,11 @@ class Test_Blob(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         not_found_response = {'status': NOT_FOUND}
         connection = _Connection(not_found_response)
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         blob.delete()
-        self.assertFalse(blob.exists())
+        self.assertFalse(blob.exists(connection=connection))
 
     def _download_to_file_helper(self, chunk_size=None):
         from six.moves.http_client import OK

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -318,7 +318,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
@@ -326,7 +326,7 @@ class Test_Blob(unittest2.TestCase):
             blob._CHUNK_SIZE_MULTIPLE = 1
             blob.chunk_size = chunk_size
         fh = BytesIO()
-        blob.download_to_file(fh)
+        blob.download_to_file(fh, connection=connection)
         self.assertEqual(fh.getvalue(), b'abcdef')
 
     def test_download_to_file_default(self):
@@ -350,7 +350,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK,
                       'updated': '2014-12-06T13:13:50.690Z'}
@@ -358,7 +358,7 @@ class Test_Blob(unittest2.TestCase):
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
         with NamedTemporaryFile() as f:
-            blob.download_to_filename(f.name)
+            blob.download_to_filename(f.name, connection=connection)
             f.flush()
             with open(f.name, 'rb') as g:
                 wrote = g.read()
@@ -379,13 +379,13 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
-        fetched = blob.download_as_string()
+        fetched = blob.download_as_string(connection=connection)
         self.assertEqual(fetched, b'abcdef')
 
     def _upload_from_file_simple_test_helper(self, properties=None,

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -401,7 +401,7 @@ class Test_Blob(unittest2.TestCase):
         connection = _Connection(
             (response, b'{}'),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
@@ -409,7 +409,8 @@ class Test_Blob(unittest2.TestCase):
             fh.write(DATA)
             fh.flush()
             blob.upload_from_file(fh, rewind=True,
-                                  content_type=content_type_arg)
+                                  content_type=content_type_arg,
+                                  connection=connection)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -470,7 +471,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b''),
             (chunk2_response, b'{}'),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
@@ -479,7 +480,7 @@ class Test_Blob(unittest2.TestCase):
             with NamedTemporaryFile() as fh:
                 fh.write(DATA)
                 fh.flush()
-                blob.upload_from_file(fh, rewind=True)
+                blob.upload_from_file(fh, rewind=True, connection=connection)
         rq = connection.http._requested
         self.assertEqual(len(rq), 3)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -528,14 +529,14 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
         with NamedTemporaryFile() as fh:
             fh.write(DATA)
             fh.flush()
-            blob.upload_from_file(fh, rewind=True)
+            blob.upload_from_file(fh, rewind=True, connection=connection)
             self.assertEqual(fh.tell(), len(DATA))
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
@@ -575,7 +576,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket,
                              properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
@@ -583,7 +584,8 @@ class Test_Blob(unittest2.TestCase):
         with NamedTemporaryFile(suffix='.jpeg') as fh:
             fh.write(DATA)
             fh.flush()
-            blob.upload_from_filename(fh.name, content_type=content_type_arg)
+            blob.upload_from_filename(fh.name, content_type=content_type_arg,
+                                      connection=connection)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -640,11 +642,11 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
-        blob.upload_from_string(DATA)
+        blob.upload_from_string(DATA, connection=connection)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -679,11 +681,11 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
-        bucket = _Bucket(connection)
+        bucket = _Bucket(None)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
-        blob.upload_from_string(DATA)
+        blob.upload_from_string(DATA, connection=connection)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -118,21 +118,25 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
 
     def test___contains___miss(self):
+        from gcloud.storage._testing import _monkey_defaults
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
-        bucket = self._makeOne(NAME, connection)
-        self.assertFalse(NONESUCH in bucket)
+        bucket = self._makeOne(NAME, None)
+        with _monkey_defaults(connection=connection):
+            self.assertFalse(NONESUCH in bucket)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
 
     def test___contains___hit(self):
+        from gcloud.storage._testing import _monkey_defaults
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({'name': BLOB_NAME})
-        bucket = self._makeOne(NAME, connection)
-        self.assertTrue(BLOB_NAME in bucket)
+        bucket = self._makeOne(NAME, None)
+        with _monkey_defaults(connection=connection):
+            self.assertTrue(BLOB_NAME in bucket)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))


### PR DESCRIPTION
~~**NOTE**: Has #822 as diffbase.~~

Towards #728 

@tseaver I made a separate commit for each method with used `Blob.connection` but can combine them if you like.

I wanted to get rid of the `Blob.connection` property, but `_PropertyMixin.reload()` and `_PropertyMixin.patch()` use it as well as `ObjectACL.reload()` and `ObjectACL.save()`.