### PR TITLE
Adding scope to credentials in Connection constructors.

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -48,7 +48,6 @@ The main concepts with this API are:
   when race conditions may occur.
 """
 
-from gcloud.datastore._implicit_environ import SCOPE
 from gcloud.datastore._implicit_environ import get_connection
 from gcloud.datastore._implicit_environ import get_default_connection
 from gcloud.datastore._implicit_environ import get_default_dataset_id
@@ -59,6 +58,7 @@ from gcloud.datastore.api import delete
 from gcloud.datastore.api import get
 from gcloud.datastore.api import put
 from gcloud.datastore.batch import Batch
+from gcloud.datastore.connection import SCOPE
 from gcloud.datastore.connection import Connection
 from gcloud.datastore.dataset import Dataset
 from gcloud.datastore.entity import Entity

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -23,13 +23,9 @@ import os
 from gcloud._helpers import _app_engine_id
 from gcloud._helpers import _compute_engine_id
 from gcloud._helpers import _lazy_property_deco
-from gcloud.connection import get_scoped_connection
+from gcloud.credentials import get_credentials
 from gcloud.datastore.connection import Connection
 
-
-SCOPE = ('https://www.googleapis.com/auth/datastore',
-         'https://www.googleapis.com/auth/userinfo.email')
-"""The scopes required for authenticating as a Cloud Datastore consumer."""
 
 _DATASET_ENV_VAR_NAME = 'GCLOUD_DATASET_ID'
 _GCD_DATASET_ENV_VAR_NAME = 'DATASTORE_DATASET'
@@ -126,7 +122,8 @@ def get_connection():
     :rtype: :class:`gcloud.datastore.connection.Connection`
     :returns: A connection defined with the proper credentials.
     """
-    return get_scoped_connection(Connection, SCOPE)
+    credentials = get_credentials()
+    return Connection(credentials=credentials)
 
 
 def set_default_connection(connection=None):

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -21,6 +21,10 @@ from gcloud.exceptions import make_exception
 from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
 
 
+SCOPE = ('https://www.googleapis.com/auth/datastore',
+         'https://www.googleapis.com/auth/userinfo.email')
+"""The scopes required for authenticating as a Cloud Datastore consumer."""
+
 _GCD_HOST_ENV_VAR_NAME = 'DATASTORE_HOST'
 
 
@@ -46,6 +50,7 @@ class Connection(connection.Connection):
     """A template for the URL of a particular API call."""
 
     def __init__(self, credentials=None, http=None, api_base_url=None):
+        credentials = self._create_scoped_credentials(credentials, SCOPE)
         super(Connection, self).__init__(credentials=credentials, http=http)
         if api_base_url is None:
             api_base_url = os.getenv(_GCD_HOST_ENV_VAR_NAME,

--- a/gcloud/datastore/test__implicit_environ.py
+++ b/gcloud/datastore/test__implicit_environ.py
@@ -305,7 +305,7 @@ class Test_get_connection(unittest2.TestCase):
 
     def test_it(self):
         from gcloud import credentials
-        from gcloud.datastore._implicit_environ import SCOPE
+        from gcloud.datastore.connection import SCOPE
         from gcloud.datastore.connection import Connection
         from gcloud.test_credentials import _Client
         from gcloud._testing import _Monkey

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -97,7 +97,12 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(conn.credentials, None)
 
     def test_ctor_explicit(self):
-        creds = object()
+        class Creds(object):
+
+            def create_scoped_required(self):
+                return False
+
+        creds = Creds()
         conn = self._makeOne(creds)
         self.assertTrue(conn.credentials is creds)
 
@@ -122,6 +127,10 @@ class TestConnection(unittest2.TestCase):
             def authorize(self, http):
                 self._called_with = http
                 return authorized
+
+            def create_scoped_required(self):
+                return False
+
         creds = Creds()
         conn = self._makeOne(creds)
         self.assertTrue(conn.http is authorized)

--- a/gcloud/pubsub/__init__.py
+++ b/gcloud/pubsub/__init__.py
@@ -26,18 +26,15 @@ The main concepts with this API are:
 
 from gcloud._helpers import get_default_project
 from gcloud._helpers import set_default_project
-from gcloud.connection import get_scoped_connection
+from gcloud.credentials import get_credentials
 from gcloud.pubsub import _implicit_environ
 from gcloud.pubsub._implicit_environ import get_default_connection
 from gcloud.pubsub.api import list_subscriptions
 from gcloud.pubsub.api import list_topics
+from gcloud.pubsub.connection import SCOPE
 from gcloud.pubsub.connection import Connection
 from gcloud.pubsub.subscription import Subscription
 from gcloud.pubsub.topic import Topic
-
-
-SCOPE = ('https://www.googleapis.com/auth/pubsub',
-         'https://www.googleapis.com/auth/cloud-platform')
 
 
 def set_default_connection(connection=None):
@@ -78,4 +75,5 @@ def get_connection():
     :rtype: :class:`gcloud.pubsub.connection.Connection`
     :returns: A connection defined with the proper credentials.
     """
-    return get_scoped_connection(Connection, SCOPE)
+    credentials = get_credentials()
+    return Connection(credentials=credentials)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -17,6 +17,11 @@
 from gcloud import connection as base_connection
 
 
+SCOPE = ('https://www.googleapis.com/auth/pubsub',
+         'https://www.googleapis.com/auth/cloud-platform')
+"""The scopes required for authenticating as a Cloud Pub/Sub consumer."""
+
+
 class Connection(base_connection.JSONConnection):
     """A connection to Google Cloud Pubsub via the JSON REST API."""
 
@@ -28,3 +33,7 @@ class Connection(base_connection.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    def __init__(self, credentials=None, http=None):
+        credentials = self._create_scoped_credentials(credentials, SCOPE)
+        super(Connection, self).__init__(credentials=credentials, http=http)

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -43,7 +43,6 @@ from gcloud import credentials
 from gcloud._helpers import get_default_project
 from gcloud._helpers import set_default_project
 from gcloud.storage import _implicit_environ
-from gcloud.storage._implicit_environ import SCOPE
 from gcloud.storage._implicit_environ import get_connection
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
@@ -55,6 +54,7 @@ from gcloud.storage.api import lookup_bucket
 from gcloud.storage.batch import Batch
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
+from gcloud.storage.connection import SCOPE
 from gcloud.storage.connection import Connection
 
 

--- a/gcloud/storage/_implicit_environ.py
+++ b/gcloud/storage/_implicit_environ.py
@@ -20,13 +20,8 @@ from the enviroment.
 
 
 from gcloud._helpers import _lazy_property_deco
-from gcloud.connection import get_scoped_connection
+from gcloud.credentials import get_credentials
 from gcloud.storage.connection import Connection
-
-
-SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
-         'https://www.googleapis.com/auth/devstorage.read_only',
-         'https://www.googleapis.com/auth/devstorage.read_write')
 
 
 class _DefaultsContainer(object):
@@ -83,7 +78,8 @@ def get_connection():
     :rtype: :class:`gcloud.storage.connection.Connection`
     :returns: A connection defined with the proper credentials.
     """
-    return get_scoped_connection(Connection, SCOPE)
+    credentials = get_credentials()
+    return Connection(credentials=credentials)
 
 
 def set_default_connection(connection=None):

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -17,6 +17,12 @@
 from gcloud import connection as base_connection
 
 
+SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
+         'https://www.googleapis.com/auth/devstorage.read_only',
+         'https://www.googleapis.com/auth/devstorage.read_write')
+"""The scopes required for authenticating as a Cloud Storage consumer."""
+
+
 class Connection(base_connection.JSONConnection):
     """A connection to Google Cloud Storage via the JSON REST API."""
 
@@ -28,3 +34,7 @@ class Connection(base_connection.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/storage/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    def __init__(self, credentials=None, http=None):
+        credentials = self._create_scoped_credentials(credentials, SCOPE)
+        super(Connection, self).__init__(credentials=credentials, http=http)

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -372,31 +372,3 @@ class _Http(object):
     def request(self, **kw):
         self._called_with = kw
         return self._response, self._content
-
-
-class Test_get_scoped_connection(unittest2.TestCase):
-
-    def _callFUT(self, klass, scopes):
-        from gcloud.connection import get_scoped_connection
-        return get_scoped_connection(klass, scopes)
-
-    def test_it(self):
-        from gcloud import credentials
-        from gcloud.test_credentials import _Client
-        from gcloud._testing import _Monkey
-
-        class _Connection(object):
-            def __init__(self, credentials):
-                self._credentials = credentials
-
-        SCOPES = ('https://www.googleapis.com/auth/example',
-                  'https://www.googleapis.com/auth/userinfo.email')
-
-        client = _Client()
-        with _Monkey(credentials, client=client):
-            found = self._callFUT(_Connection, SCOPES)
-
-        self.assertTrue(isinstance(found, _Connection))
-        self.assertTrue(found._credentials is client._signed)
-        self.assertEqual(found._credentials._scopes, SCOPES)
-        self.assertTrue(client._get_app_default_called)

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -396,6 +396,9 @@ class _Credentials(object):
         self._scopes = scopes
         return self
 
+    def create_scoped_required(self):
+        return True
+
 
 class _Client(object):
     def __init__(self):


### PR DESCRIPTION
This also obsoletes get_scoped_connection() so it is removed.

FYI @jgeewax thanks for nudging in this direction. It moves the scope adding behavior into the `Connection` constructors.