### PR TITLE
#828: Clarify nature of `pubsub-surface` document.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@
   storage-blobs
   storage-buckets
   storage-acl
+  pubsub-usage
   pubsub-api
-  pubsub-surface
   pubsub-subscription
   pubsub-topic
 

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -1,5 +1,5 @@
-``gcloud.pubsub`` API
-=====================
+Using the API
+=============
 
 Connection / Authorization
 --------------------------


### PR DESCRIPTION
- Rename to `pubsub-usage`.

- Update title to "Using the API".

Fixes #828.