### PR TITLE
Removing most remaining uses of self.connection in Bucket

### DIFF
--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -196,7 +196,7 @@ def create_bucket(bucket_name, project=None, connection=None):
     """
     connection = _require_connection(connection)
     bucket = Bucket(bucket_name, connection=connection)
-    bucket.create(project)
+    bucket.create(project, connection=connection)
     return bucket
 
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -211,7 +211,7 @@ class Bucket(_PropertyMixin):
 
         return self.path_helper(self.name)
 
-    def get_blob(self, blob_name):
+    def get_blob(self, blob_name, connection=None):
         """Get a blob object by name.
 
         This will return None if the blob doesn't exist::
@@ -227,13 +227,19 @@ class Bucket(_PropertyMixin):
         :type blob_name: string
         :param blob_name: The name of the blob to retrieve.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :rtype: :class:`gcloud.storage.blob.Blob` or None
         :returns: The blob object if it exists, otherwise None.
         """
+        connection = _require_connection(connection)
         blob = Blob(bucket=self, name=blob_name)
         try:
-            response = self.connection.api_request(method='GET',
-                                                   path=blob.path)
+            response = connection.api_request(method='GET',
+                                              path=blob.path)
             name = response.get('name')  # Expect this to be blob_name
             blob = Blob(name, bucket=self)
             blob._set_properties(response)
@@ -304,7 +310,7 @@ class Bucket(_PropertyMixin):
             result.next_page_token = page_token
         return result
 
-    def delete(self, force=False):
+    def delete(self, force=False, connection=None):
         """Delete this bucket.
 
         The bucket **must** be empty in order to submit a delete request. If
@@ -323,9 +329,15 @@ class Bucket(_PropertyMixin):
         :type force: boolean
         :param force: If True, empties the bucket's objects then deletes it.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :raises: :class:`ValueError` if ``force`` is ``True`` and the bucket
                  contains more than 256 objects / blobs.
         """
+        connection = _require_connection(connection)
         if force:
             blobs = list(self.list_blobs(
                 max_results=self._MAX_OBJECTS_FOR_BUCKET_DELETE + 1))
@@ -339,11 +351,12 @@ class Bucket(_PropertyMixin):
                 raise ValueError(message)
 
             # Ignore 404 errors on delete.
-            self.delete_blobs(blobs, on_error=lambda blob: None)
+            self.delete_blobs(blobs, on_error=lambda blob: None,
+                              connection=connection)
 
-        self.connection.api_request(method='DELETE', path=self.path)
+        connection.api_request(method='DELETE', path=self.path)
 
-    def delete_blob(self, blob_name):
+    def delete_blob(self, blob_name, connection=None):
         """Deletes a blob from the current bucket.
 
         If the blob isn't found (backend 404), raises a
@@ -366,16 +379,22 @@ class Bucket(_PropertyMixin):
         :type blob_name: string
         :param blob_name: A blob name to delete.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :raises: :class:`gcloud.exceptions.NotFound` (to suppress
                  the exception, call ``delete_blobs``, passing a no-op
                  ``on_error`` callback, e.g.::
 
                  >>> bucket.delete_blobs([blob], on_error=lambda blob: None)
         """
+        connection = _require_connection(connection)
         blob_path = Blob.path_helper(self.path, blob_name)
-        self.connection.api_request(method='DELETE', path=blob_path)
+        connection.api_request(method='DELETE', path=blob_path)
 
-    def delete_blobs(self, blobs, on_error=None):
+    def delete_blobs(self, blobs, on_error=None, connection=None):
         """Deletes a list of blobs from the current bucket.
 
         Uses :func:`Bucket.delete_blob` to delete each individual blob.
@@ -388,15 +407,21 @@ class Bucket(_PropertyMixin):
                          :class:`gcloud.exceptions.NotFound`;
                          otherwise, the exception is propagated.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :raises: :class:`gcloud.exceptions.NotFound` (if
                  `on_error` is not passed).
         """
+        connection = _require_connection(connection)
         for blob in blobs:
             try:
                 blob_name = blob
                 if not isinstance(blob_name, six.string_types):
                     blob_name = blob.name
-                self.delete_blob(blob_name)
+                self.delete_blob(blob_name, connection=connection)
             except NotFound:
                 if on_error is not None:
                     on_error(blob)

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -428,7 +428,9 @@ class Bucket(_PropertyMixin):
                 else:
                     raise
 
-    def copy_blob(self, blob, destination_bucket, new_name=None):
+    @staticmethod
+    def copy_blob(blob, destination_bucket, new_name=None,
+                  connection=None):
         """Copy the given blob to the given bucket, optionally with a new name.
 
         :type blob: string or :class:`gcloud.storage.blob.Blob`
@@ -441,18 +443,24 @@ class Bucket(_PropertyMixin):
         :type new_name: string
         :param new_name: (optional) the new name for the copied file.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :rtype: :class:`gcloud.storage.blob.Blob`
         :returns: The new Blob.
         """
+        connection = _require_connection(connection)
         if new_name is None:
             new_name = blob.name
         new_blob = Blob(bucket=destination_bucket, name=new_name)
         api_path = blob.path + '/copyTo' + new_blob.path
-        copy_result = self.connection.api_request(method='POST', path=api_path)
+        copy_result = connection.api_request(method='POST', path=api_path)
         new_blob._set_properties(copy_result)
         return new_blob
 
-    def upload_file(self, filename, blob_name=None):
+    def upload_file(self, filename, blob_name=None, connection=None):
         """Shortcut method to upload a file into this bucket.
 
         Use this method to quickly put a local file in Cloud Storage.
@@ -485,16 +493,21 @@ class Bucket(_PropertyMixin):
                           of the bucket with the same name as on your local
                           file system.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :rtype: :class:`Blob`
         :returns: The updated Blob object.
         """
         if blob_name is None:
             blob_name = os.path.basename(filename)
         blob = Blob(bucket=self, name=blob_name)
-        blob.upload_from_filename(filename)
+        blob.upload_from_filename(filename, connection=connection)
         return blob
 
-    def upload_file_object(self, file_obj, blob_name=None):
+    def upload_file_object(self, file_obj, blob_name=None, connection=None):
         """Shortcut method to upload a file object into this bucket.
 
         Use this method to quickly put a local file in Cloud Storage.
@@ -527,13 +540,18 @@ class Bucket(_PropertyMixin):
                           of the bucket with the same name as on your local
                           file system.
 
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+
         :rtype: :class:`Blob`
         :returns: The updated Blob object.
         """
         if blob_name is None:
             blob_name = os.path.basename(file_obj.name)
         blob = Blob(bucket=self, name=blob_name)
-        blob.upload_from_file(file_obj)
+        blob.upload_from_file(file_obj, connection=connection)
         return blob
 
     @property

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -154,8 +154,8 @@ class Test_Bucket(unittest2.TestCase):
                 raise NotFound(args)
 
         BUCKET_NAME = 'bucket-name'
-        bucket = self._makeOne(BUCKET_NAME, connection=_FakeConnection)
-        self.assertFalse(bucket.exists())
+        bucket = self._makeOne(BUCKET_NAME)
+        self.assertFalse(bucket.exists(connection=_FakeConnection))
         expected_called_kwargs = {
             'method': 'GET',
             'path': bucket.path,
@@ -178,8 +178,8 @@ class Test_Bucket(unittest2.TestCase):
                 return object()
 
         BUCKET_NAME = 'bucket-name'
-        bucket = self._makeOne(BUCKET_NAME, connection=_FakeConnection)
-        self.assertTrue(bucket.exists())
+        bucket = self._makeOne(BUCKET_NAME)
+        self.assertTrue(bucket.exists(connection=_FakeConnection))
         expected_called_kwargs = {
             'method': 'GET',
             'path': bucket.path,
@@ -202,8 +202,8 @@ class Test_Bucket(unittest2.TestCase):
         DATA = {'name': BUCKET_NAME}
         connection = _Connection(DATA)
         PROJECT = 'PROJECT'
-        bucket = self._makeOne(BUCKET_NAME, connection=connection)
-        bucket.create(PROJECT)
+        bucket = self._makeOne(BUCKET_NAME)
+        bucket.create(PROJECT, connection=connection)
 
         kw, = connection._requested
         self.assertEqual(kw['method'], 'POST')
@@ -217,9 +217,9 @@ class Test_Bucket(unittest2.TestCase):
         DATA = {'name': BUCKET_NAME}
         connection = _Connection(DATA)
         PROJECT = 'PROJECT'
-        bucket = self._makeOne(BUCKET_NAME, connection=connection)
+        bucket = self._makeOne(BUCKET_NAME)
         with _monkey_defaults(project=PROJECT):
-            bucket.create()
+            bucket.create(connection=connection)
 
         kw, = connection._requested
         self.assertEqual(kw['method'], 'POST')

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -255,8 +255,9 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
-        bucket = self._makeOne(NAME, connection)
-        self.assertTrue(bucket.get_blob(NONESUCH) is None)
+        bucket = self._makeOne(NAME)
+        result = bucket.get_blob(NONESUCH, connection=connection)
+        self.assertTrue(result is None)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
@@ -265,8 +266,8 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({'name': BLOB_NAME})
-        bucket = self._makeOne(NAME, connection)
-        blob = bucket.get_blob(BLOB_NAME)
+        bucket = self._makeOne(NAME)
+        blob = bucket.get_blob(BLOB_NAME, connection=connection)
         self.assertTrue(blob.bucket is bucket)
         self.assertEqual(blob.name, BLOB_NAME)
         kw, = connection._requested
@@ -325,8 +326,8 @@ class Test_Bucket(unittest2.TestCase):
         from gcloud.exceptions import NotFound
         NAME = 'name'
         connection = _Connection()
-        bucket = self._makeOne(NAME, connection)
-        self.assertRaises(NotFound, bucket.delete)
+        bucket = self._makeOne(NAME)
+        self.assertRaises(NotFound, bucket.delete, connection=connection)
         expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
@@ -336,7 +337,8 @@ class Test_Bucket(unittest2.TestCase):
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         bucket = self._makeOne(NAME, connection)
-        self.assertEqual(bucket.delete(force=True), None)
+        result = bucket.delete(force=True, connection=connection)
+        self.assertTrue(result is None)
         expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
@@ -355,7 +357,8 @@ class Test_Bucket(unittest2.TestCase):
                                  DELETE_BLOB2_RESP)
         connection._delete_bucket = True
         bucket = self._makeOne(NAME, connection)
-        self.assertEqual(bucket.delete(force=True), None)
+        result = bucket.delete(force=True, connection=connection)
+        self.assertTrue(result is None)
         expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
@@ -367,7 +370,8 @@ class Test_Bucket(unittest2.TestCase):
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         bucket = self._makeOne(NAME, connection)
-        self.assertEqual(bucket.delete(force=True), None)
+        result = bucket.delete(force=True, connection=connection)
+        self.assertTrue(result is None)
         expected_cw = [{'method': 'DELETE', 'path': bucket.path}]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
@@ -395,8 +399,9 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
-        bucket = self._makeOne(NAME, connection)
-        self.assertRaises(NotFound, bucket.delete_blob, NONESUCH)
+        bucket = self._makeOne(NAME)
+        self.assertRaises(NotFound, bucket.delete_blob, NONESUCH,
+                          connection=connection)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
@@ -405,8 +410,8 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
-        bucket = self._makeOne(NAME, connection)
-        result = bucket.delete_blob(BLOB_NAME)
+        bucket = self._makeOne(NAME)
+        result = bucket.delete_blob(BLOB_NAME, connection=connection)
         self.assertTrue(result is None)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
@@ -423,8 +428,8 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
-        bucket = self._makeOne(NAME, connection)
-        bucket.delete_blobs([BLOB_NAME])
+        bucket = self._makeOne(NAME)
+        bucket.delete_blobs([BLOB_NAME], connection=connection)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'DELETE')
@@ -436,8 +441,9 @@ class Test_Bucket(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         NONESUCH = 'nonesuch'
         connection = _Connection({})
-        bucket = self._makeOne(NAME, connection)
-        self.assertRaises(NotFound, bucket.delete_blobs, [BLOB_NAME, NONESUCH])
+        bucket = self._makeOne(NAME)
+        self.assertRaises(NotFound, bucket.delete_blobs, [BLOB_NAME, NONESUCH],
+                          connection=connection)
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]['method'], 'DELETE')
@@ -450,9 +456,10 @@ class Test_Bucket(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         NONESUCH = 'nonesuch'
         connection = _Connection({})
-        bucket = self._makeOne(NAME, connection)
+        bucket = self._makeOne(NAME)
         errors = []
-        bucket.delete_blobs([BLOB_NAME, NONESUCH], errors.append)
+        bucket.delete_blobs([BLOB_NAME, NONESUCH], errors.append,
+                            connection=connection)
         self.assertEqual(errors, [NONESUCH])
         kw = connection._requested
         self.assertEqual(len(kw), 2)


### PR DESCRIPTION
Towards #728 and #825 

Still left using `Bucket.connection` is `Bucket.list_blobs` (since the `_BlobIterator` constructor needs to be changed for that). Still using an attached connection is `Bucket.make_public`, but I wasn't sure how to attack it.

As in other cases all the double-under methods have to fall back to implicit as their only option.