### PR TITLE
#827: Use short form imports in pubsub docs

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -20,7 +20,7 @@ Create a new topic for the default project:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> topic.create()  # API request
 
@@ -28,7 +28,7 @@ Create a new topic for an explicit project:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name', project_id='my.project')
    >>> topic.create()  # API request
 
@@ -36,7 +36,7 @@ Check for the existance of a topic:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> topic.exists()  # API request
    True
@@ -45,16 +45,16 @@ List topics for the default project:
 
 .. doctest::
 
-   >>> from gcloud import pubsub
-   >>> [topic.name for topic in pubsub.list_topics()]  # API request
+   >>> from gcloud.pubsub import list_topics
+   >>> [topic.name for topic in list_topics()]  # API request
    ['topic_name']
 
 List topics for an explicit project:
 
 .. doctest::
 
-   >>> from gcloud import pubsub
-   >>> topics = pubsub.list_topics(project_id='my.project')  # API request
+   >>> from gcloud.pubsub import list_topics
+   >>> topics = list_topics(project_id='my.project')  # API request
    >>> [topic.name for topic in topics]
    ['topic_name']
 
@@ -62,7 +62,7 @@ Delete a topic:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> topic.delete()  # API request
 
@@ -74,7 +74,7 @@ Publish a single message to a topic, without attributes:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> topic.publish('this is the message_payload')  # API request
    <message_id>
@@ -83,7 +83,7 @@ Publish a single message to a topic, with attributes:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> topic.publish('this is another message_payload',
    ...               attr1='value1', attr2='value2')  # API request
@@ -93,7 +93,7 @@ Publish a set of messages to a topic (as a single request):
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> with topic.batch() as batch:
    ...     batch.publish('this is the first message_payload')
@@ -115,8 +115,8 @@ Create a new pull subscription for a topic:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> subscription.create()  # API request
@@ -125,8 +125,8 @@ Create a new pull subscription for a topic with a non-default ACK deadline:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', ack_deadline=90)
    >>> subscription.create()  # API request
@@ -136,8 +136,8 @@ Create a new push subscription for a topic:
 .. doctest::
 
    >>> ENDPOINT = 'https://example.com/hook'
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', push_endpoint=ENDPOINT)
    >>> subscription.create()  # API request
@@ -146,8 +146,8 @@ Check for the existence of a subscription:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> subscription.exists()  # API request
@@ -158,8 +158,8 @@ Convert a pull subscription to push:
 .. doctest::
 
    >>> ENDPOINT = 'https://example.com/hook'
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> subscription.modify_push_configuration(push_endpoint=ENDPOINT)  # API request
@@ -169,7 +169,7 @@ Convert a push subscription to pull:
 .. doctest::
 
    >>> ENDPOINT = 'https://example.com/hook'
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic,
    ...                             push_endpoint=ENDPOINT)
@@ -179,9 +179,18 @@ List subscriptions for a topic:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
+   >>> from gcloud.pubsub import Topic
    >>> topic = Topic('topic_name')
    >>> subscriptions = topic.list_subscriptions()  # API request
+   >>> [subscription.name for subscription in subscriptions]
+   ['subscription_name']
+
+List all subscriptions for the default project:
+
+.. doctest::
+
+   >>> from gcloud.pubsub import list_subscriptions
+   >>> subscriptions = list_subscriptions()  # API request
    >>> [subscription.name for subscription in subscriptions]
    ['subscription_name']
 
@@ -189,8 +198,8 @@ Delete a subscription:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> subscription.delete()  # API request
@@ -203,8 +212,8 @@ Fetch pending messages for a pull subscription:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> with topic:
@@ -232,8 +241,8 @@ Fetch a limited number of pending messages for a pull subscription:
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> with topic:
@@ -248,8 +257,8 @@ Fetch messages for a pull subscription without blocking (none pending):
 
 .. doctest::
 
-   >>> from gcloud.pubsub.topic import Topic
-   >>> from gcloud.pubsub.subscription import Subscription
+   >>> from gcloud.pubsub import Topic
+   >>> from gcloud.pubsub import Subscription
    >>> topic = Topic('topic_name')
    >>> subscription = Subscription('subscription_name', topic)
    >>> received = subscription.pull(max_messages=1)  # API request

--- a/gcloud/pubsub/__init__.py
+++ b/gcloud/pubsub/__init__.py
@@ -32,6 +32,8 @@ from gcloud.pubsub._implicit_environ import get_default_connection
 from gcloud.pubsub.api import list_subscriptions
 from gcloud.pubsub.api import list_topics
 from gcloud.pubsub.connection import Connection
+from gcloud.pubsub.subscription import Subscription
+from gcloud.pubsub.topic import Topic
 
 
 SCOPE = ('https://www.googleapis.com/auth/pubsub',


### PR DESCRIPTION
Uses #847 as a base.

Per #827.

@jgeewax, PTAL (particuarly at 4e1d2c9).