### PR TITLE
For consistency, replace all use of `project_id` w/ `project`.

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -8,7 +8,7 @@ Connection / Authorization
 
   - credentials (derived from GAE / GCE environ if present).
 
-  - ``project_id`` (derived from GAE / GCE environ if present).
+  - ``project`` (derived from GAE / GCE environ if present).
 
   - ``scopes``
 
@@ -29,7 +29,7 @@ Create a new topic for an explicit project:
 .. doctest::
 
    >>> from gcloud.pubsub import Topic
-   >>> topic = Topic('topic_name', project_id='my.project')
+   >>> topic = Topic('topic_name', project='my.project')
    >>> topic.create()  # API request
 
 Check for the existance of a topic:
@@ -54,7 +54,7 @@ List topics for an explicit project:
 .. doctest::
 
    >>> from gcloud.pubsub import list_topics
-   >>> topics = list_topics(project_id='my.project')  # API request
+   >>> topics = list_topics(project='my.project')  # API request
    >>> [topic.name for topic in topics]
    ['topic_name']
 

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -340,13 +340,13 @@ class _BaseHTTPConnection(object):
 
 class _HTTPConnection(_BaseHTTPConnection):
 
-    def __init__(self, status, project_id):
+    def __init__(self, status, project):
         super(_HTTPConnection, self).__init__()
         self.status = status
-        self.project_id = project_id
+        self.project = project
 
     def getresponse(self):
-        return _HTTPResponse(self.status, self.project_id)
+        return _HTTPResponse(self.status, self.project)
 
 
 class _TimeoutHTTPConnection(_BaseHTTPConnection):

--- a/regression/pubsub.py
+++ b/regression/pubsub.py
@@ -57,10 +57,10 @@ class TestPubsub(unittest2.TestCase):
 
         # Retrieve the topics.
         all_topics, _ = pubsub.list_topics()
-        project_id = pubsub.get_default_project()
+        project = pubsub.get_default_project()
         created = [topic for topic in all_topics
                    if topic.name in topics_to_create and
-                   topic.project == project_id]
+                   topic.project == project]
         self.assertEqual(len(created), len(topics_to_create))
 
     def test_create_subscription(self):

--- a/regression/regression_utils.py
+++ b/regression/regression_utils.py
@@ -28,7 +28,7 @@ Please check the Contributing guide for instructions.
 """
 
 
-def get_environ(require_datastore=False, require_storage=False):
+def check_environ(require_datastore=False, require_storage=False):
     if require_datastore:
         if DATASET_ID is None or not os.path.isfile(CREDENTIALS):
             print(ENVIRON_ERROR_MSG, file=sys.stderr)
@@ -38,8 +38,3 @@ def get_environ(require_datastore=False, require_storage=False):
         if PROJECT_ID is None or not os.path.isfile(CREDENTIALS):
             print(ENVIRON_ERROR_MSG, file=sys.stderr)
             sys.exit(1)
-
-    return {
-        'project_id': PROJECT_ID,
-        'dataset_id': DATASET_ID,
-    }

--- a/regression/run_regression.py
+++ b/regression/run_regression.py
@@ -42,9 +42,9 @@ def main():
     args = parser.parse_args()
     # Make sure environ is set before running test.
     if args.package == 'datastore':
-        regression_utils.get_environ(require_datastore=True)
+        regression_utils.check_environ(require_datastore=True)
     elif args.package == 'storage':
-        regression_utils.get_environ(require_storage=True)
+        regression_utils.check_environ(require_storage=True)
     test_result = run_module_tests(args.package)
     if not test_result.wasSuccessful():
         sys.exit(1)


### PR DESCRIPTION
Also, rename `regression_utils.get_environ` -> `check_environ`, and drop return value (which only caller was ignoring).