### PR TITLE
#825: Allow passing explicit connection to `ACL.{reload,save}`

### DIFF
--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -453,11 +453,6 @@ class BucketACL(ACL):
         self.bucket = bucket
 
     @property
-    def connection(self):
-        """Compute the connection for API requests for this ACL."""
-        return self.bucket.connection
-
-    @property
     def reload_path(self):
         """Compute the path for GET API requests for this ACL."""
         return '%s/%s' % (self.bucket.path, self._URL_PATH_ELEM)
@@ -484,11 +479,6 @@ class ObjectACL(ACL):
     def __init__(self, blob):
         super(ObjectACL, self).__init__()
         self.blob = blob
-
-    @property
-    def connection(self):
-        """Compute the connection for API requests for this ACL."""
-        return self.blob.connection
 
     @property
     def reload_path(self):

--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -172,6 +172,11 @@ class ACL(object):
     _URL_PATH_ELEM = 'acl'
     loaded = False
 
+    # Subclasses must override to provide these attributes (typically,
+    # as properties).
+    reload_path = None
+    save_path = None
+
     def __init__(self):
         self.entities = {}
 
@@ -347,37 +352,6 @@ class ACL(object):
         """
         self._ensure_loaded()
         return list(self.entities.values())
-
-    @property
-    def reload_path(self):
-        """Compute the path for GET API requests for this ACL.
-
-        This is a virtual method, expected to be implemented by subclasses.
-
-        :raises: :class:`NotImplementedError` if ``_reload_path`` attribute
-                 is not set on the instance.
-        """
-        # Allow override for testing
-        path = getattr(self, '_reload_path', None)
-        if path is not None:
-            return path
-        raise NotImplementedError
-
-    @property
-    def save_path(self):
-        """Compute the path for PATCH API requests for this ACL.
-
-        This is a virtual method, expected to be implemented by subclasses.
-
-        :raises: :class:`NotImplementedError` if ``_save_path`` attribute
-                 is not set on the instance.
-
-        """
-        # Allow override for testing
-        path = getattr(self, '_save_path', None)
-        if path is not None:
-            return path
-        raise NotImplementedError
 
     def reload(self, connection=None):
         """Reload the ACL data from Cloud Storage.

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -807,13 +807,11 @@ class Test_BucketACL(unittest2.TestCase):
 
     def test_ctor(self):
         NAME = 'name'
-        connection = _Connection()
-        bucket = _Bucket(NAME, connection)
+        bucket = _Bucket(NAME)
         acl = self._makeOne(bucket)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertTrue(acl.bucket is bucket)
-        self.assertTrue(acl.connection is connection)
         self.assertEqual(acl.reload_path, '/b/%s/acl' % NAME)
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
 
@@ -829,13 +827,11 @@ class Test_DefaultObjectACL(unittest2.TestCase):
 
     def test_ctor(self):
         NAME = 'name'
-        connection = _Connection()
-        bucket = _Bucket(NAME, connection)
+        bucket = _Bucket(NAME)
         acl = self._makeOne(bucket)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertTrue(acl.bucket is bucket)
-        self.assertTrue(acl.connection is connection)
         self.assertEqual(acl.reload_path, '/b/%s/defaultObjectAcl' % NAME)
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
 
@@ -852,14 +848,12 @@ class Test_ObjectACL(unittest2.TestCase):
     def test_ctor(self):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
-        connection = _Connection()
-        bucket = _Bucket(NAME, connection)
+        bucket = _Bucket(NAME)
         blob = _Blob(bucket, BLOB_NAME)
         acl = self._makeOne(blob)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertTrue(acl.blob is blob)
-        self.assertTrue(acl.connection is connection)
         self.assertEqual(acl.reload_path, '/b/%s/o/%s/acl' % (NAME, BLOB_NAME))
         self.assertEqual(acl.save_path, '/b/%s/o/%s' % (NAME, BLOB_NAME))
 
@@ -871,19 +865,14 @@ class _Blob(object):
         self.blob = blob
 
     @property
-    def connection(self):
-        return self.bucket.connection
-
-    @property
     def path(self):
         return '%s/o/%s' % (self.bucket.path, self.blob)
 
 
 class _Bucket(object):
 
-    def __init__(self, name, connection):
+    def __init__(self, name):
         self.name = name
-        self.connection = connection
 
     @property
     def path(self):

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -833,7 +833,6 @@ class Test_DefaultObjectACL(unittest2.TestCase):
 
     def test_ctor(self):
         NAME = 'name'
-        BLOB_NAME = 'blob-name'
         connection = _Connection()
         bucket = _Bucket(NAME, connection)
         acl = self._makeOne(bucket)

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -505,35 +505,13 @@ class Test_ACL(unittest2.TestCase):
         entity = acl.entity(TYPE, ID)
         self.assertEqual(acl.get_entities(), [entity])
 
-    def test_reload_path_wo_attr(self):
-        acl = self._makeOne()
-        self.assertRaises(NotImplementedError, lambda: acl.reload_path)
-
-    def test_reload_path_w_attr(self):
-        acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
-        self.assertEqual(acl.reload_path, '/testing/acl')
-
-    def test_save_path_wo_attr(self):
-        acl = self._makeOne()
-        self.assertRaises(NotImplementedError, lambda: acl.save_path)
-
-    def test_save_path_w_attr(self):
-        acl = self._makeOne()
-        acl._save_path = '/testing'
-        self.assertEqual(acl.save_path, '/testing')
-
-    def test_reload_wo_path_raises_NotImplementedError(self):
-        acl = self._makeOne()
-        self.assertRaises(NotImplementedError, acl.reload)
-
     def test_reload_missing_w_implicit_connection(self):
         # https://github.com/GoogleCloudPlatform/gcloud-python/issues/652
         from gcloud.storage._testing import _monkey_defaults
         ROLE = 'role'
         connection = _Connection({})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
         with _monkey_defaults(connection=connection):
@@ -549,7 +527,7 @@ class Test_ACL(unittest2.TestCase):
         ROLE = 'role'
         connection = _Connection({})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
         acl.reload(connection=connection)
@@ -564,7 +542,7 @@ class Test_ACL(unittest2.TestCase):
         ROLE = 'role'
         connection = _Connection({'items': []})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
         with _monkey_defaults(connection=connection):
@@ -580,7 +558,7 @@ class Test_ACL(unittest2.TestCase):
         ROLE = 'role'
         connection = _Connection({'items': []})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
         acl.reload(connection=connection)
@@ -597,7 +575,7 @@ class Test_ACL(unittest2.TestCase):
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         with _monkey_defaults(connection=connection):
             acl.reload()
@@ -613,7 +591,7 @@ class Test_ACL(unittest2.TestCase):
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
         acl = self._makeOne()
-        acl._reload_path = '/testing/acl'
+        acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.reload(connection=connection)
         self.assertTrue(acl.loaded)
@@ -623,17 +601,12 @@ class Test_ACL(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '/testing/acl')
 
-    def test_save_wo_path_raises_NotImplementedError(self):
-        acl = self._makeOne()
-        acl.loaded = True
-        self.assertRaises(NotImplementedError, acl.save)
-
     def test_save_none_set_none_passed_w_implicit_connection(self):
         from gcloud.storage._testing import _monkey_defaults
         connection = _Connection()
         acl = self._makeOne()
         acl._connection = connection
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         with _monkey_defaults(connection=connection):
             acl.save()
         kw = connection._requested
@@ -642,7 +615,7 @@ class Test_ACL(unittest2.TestCase):
     def test_save_none_set_none_passed_w_explicit_connection(self):
         connection = _Connection()
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.save(connection=connection)
         kw = connection._requested
         self.assertEqual(len(kw), 0)
@@ -651,7 +624,7 @@ class Test_ACL(unittest2.TestCase):
         from gcloud.storage._testing import _monkey_defaults
         connection = _Connection({})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         with _monkey_defaults(connection=connection):
             acl.save()
@@ -666,7 +639,7 @@ class Test_ACL(unittest2.TestCase):
     def test_save_existing_missing_none_passed_w_explicit_connection(self):
         connection = _Connection({})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.save(connection=connection)
         self.assertEqual(list(acl), [])
@@ -683,7 +656,7 @@ class Test_ACL(unittest2.TestCase):
         AFTER = [{'entity': 'allUsers', 'role': ROLE}]
         connection = _Connection({'acl': AFTER})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers').grant(ROLE)
         with _monkey_defaults(connection=connection):
@@ -701,7 +674,7 @@ class Test_ACL(unittest2.TestCase):
         AFTER = [{'entity': 'allUsers', 'role': ROLE}]
         connection = _Connection({'acl': AFTER})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers').grant(ROLE)
         acl.save(connection=connection)
@@ -721,7 +694,7 @@ class Test_ACL(unittest2.TestCase):
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         with _monkey_defaults(connection=connection):
             acl.save(new_acl)
@@ -743,7 +716,7 @@ class Test_ACL(unittest2.TestCase):
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.save(new_acl, connection)
         entries = list(acl)
@@ -764,7 +737,7 @@ class Test_ACL(unittest2.TestCase):
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
         connection = _Connection({'acl': [STICKY]})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers', ROLE1)
         with _monkey_defaults(connection=connection):
@@ -783,7 +756,7 @@ class Test_ACL(unittest2.TestCase):
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
         connection = _Connection({'acl': [STICKY]})
         acl = self._makeOne()
-        acl._save_path = '/testing'
+        acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers', ROLE1)
         acl.clear(connection=connection)

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -536,7 +536,7 @@ class Test_ACL(unittest2.TestCase):
         acl = self._makeOne()
         self.assertRaises(NotImplementedError, acl.reload)
 
-    def test_reload_eager_missing(self):
+    def test_reload_missing(self):
         # https://github.com/GoogleCloudPlatform/gcloud-python/issues/652
         ROLE = 'role'
         connection = _Connection({})
@@ -552,7 +552,7 @@ class Test_ACL(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '/testing/acl')
 
-    def test_reload_eager_empty(self):
+    def test_reload_empty_result_clears_local(self):
         ROLE = 'role'
         connection = _Connection({'items': []})
         acl = self._makeOne()
@@ -561,13 +561,14 @@ class Test_ACL(unittest2.TestCase):
         acl.loaded = True
         acl.entity('allUsers', ROLE)
         acl.reload()
+        self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '/testing/acl')
 
-    def test_reload_eager_nonempty(self):
+    def test_reload_nonempty_result(self):
         ROLE = 'role'
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
@@ -576,20 +577,7 @@ class Test_ACL(unittest2.TestCase):
         acl._reload_path = '/testing/acl'
         acl.loaded = True
         acl.reload()
-        self.assertEqual(list(acl), [{'entity': 'allUsers', 'role': ROLE}])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '/testing/acl')
-
-    def test_reload_lazy(self):
-        ROLE = 'role'
-        connection = _Connection(
-            {'items': [{'entity': 'allUsers', 'role': ROLE}]})
-        acl = self._makeOne()
-        acl._connection = connection
-        acl._reload_path = '/testing/acl'
-        acl.reload()
+        self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [{'entity': 'allUsers', 'role': ROLE}])
         kw = connection._requested
         self.assertEqual(len(kw), 1)

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -704,6 +704,7 @@ class Test_Blob(unittest2.TestCase):
 
     def test_make_public(self):
         from gcloud.storage.acl import _ACLEntity
+        from gcloud.storage._testing import _monkey_defaults
         BLOB_NAME = 'blob-name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after = {'acl': permissive}
@@ -711,7 +712,8 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket(connection)
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.acl.loaded = True
-        blob.make_public()
+        with _monkey_defaults(connection=connection):
+            blob.make_public()
         self.assertEqual(list(blob.acl), permissive)
         kw = connection._requested
         self.assertEqual(len(kw), 1)

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -872,6 +872,7 @@ class Test_Bucket(unittest2.TestCase):
 
     def test_make_public_defaults(self):
         from gcloud.storage.acl import _ACLEntity
+        from gcloud.storage._testing import _monkey_defaults
         NAME = 'name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after = {'acl': permissive, 'defaultObjectAcl': []}
@@ -879,7 +880,8 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(NAME, connection)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
-        bucket.make_public()
+        with _monkey_defaults(connection=connection):
+            bucket.make_public()
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
         kw = connection._requested
@@ -891,6 +893,7 @@ class Test_Bucket(unittest2.TestCase):
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
         from gcloud.storage.acl import _ACLEntity
+        from gcloud.storage._testing import _monkey_defaults
         NAME = 'name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after1 = {'acl': permissive, 'defaultObjectAcl': []}
@@ -906,7 +909,8 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(NAME, connection)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = default_object_acl_loaded
-        bucket.make_public(future=True)
+        with _monkey_defaults(connection=connection):
+            bucket.make_public(future=True)
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), permissive)
         kw = connection._requested
@@ -933,6 +937,7 @@ class Test_Bucket(unittest2.TestCase):
     def test_make_public_recursive(self):
         from gcloud.storage.acl import _ACLEntity
         from gcloud.storage.bucket import _BlobIterator
+        from gcloud.storage._testing import _monkey_defaults
         _saved = []
 
         class _Blob(object):
@@ -969,7 +974,8 @@ class Test_Bucket(unittest2.TestCase):
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
         bucket._iterator_class = _Iterator
-        bucket.make_public(recursive=True)
+        with _monkey_defaults(connection=connection):
+            bucket.make_public(recursive=True)
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
         self.assertEqual(_saved, [(bucket, BLOB_NAME, True)])


### PR DESCRIPTION
See #825