### PR TITLE
#825:  Allow passing explicit connection to 'Blob.make_public'

### DIFF
--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -521,8 +521,6 @@ class Blob(_PropertyMixin):
         :param connection: Optional. The connection to use when sending
                            requests. If not provided, falls back to default.
         """
-        if connection is None:
-            connection = self.connection
         self.acl.all().grant_read()
         self.acl.save(connection=connection)
 

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -513,10 +513,18 @@ class Blob(_PropertyMixin):
                               size=len(data), content_type=content_type,
                               connection=connection)
 
-    def make_public(self):
-        """Make this blob public giving all users read access."""
+    def make_public(self, connection=None):
+        """Make this blob public giving all users read access.
+
+        :type connection: :class:`gcloud.storage.connection.Connection` or
+                          ``NoneType``
+        :param connection: Optional. The connection to use when sending
+                           requests. If not provided, falls back to default.
+        """
+        if connection is None:
+            connection = self.connection
         self.acl.all().grant_read()
-        self.acl.save()
+        self.acl.save(connection=connection)
 
     cache_control = _scalar_property('cacheControl')
     """HTTP 'Cache-Control' header for this object.

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -729,7 +729,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(headers['Content-Type'], 'text/plain')
         self.assertEqual(rq[0]['body'], ENCODED)
 
-    def test_make_public(self):
+    def test_make_public_w_implicit_ocnnection(self):
         from gcloud.storage.acl import _ACLEntity
         from gcloud.storage._testing import _monkey_defaults
         BLOB_NAME = 'blob-name'

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -749,6 +749,24 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['data'], {'acl': permissive})
         self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
+    def test_make_public_w_explicit_connection(self):
+        from gcloud.storage.acl import _ACLEntity
+        BLOB_NAME = 'blob-name'
+        permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
+        after = {'acl': permissive}
+        connection = _Connection(after)
+        bucket = _Bucket(None)
+        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob.acl.loaded = True
+        blob.make_public(connection=connection)
+        self.assertEqual(list(blob.acl), permissive)
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
+        self.assertEqual(kw[0]['data'], {'acl': permissive})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+
     def test_cache_control_getter(self):
         BLOB_NAME = 'blob-name'
         connection = _Connection()


### PR DESCRIPTION
Requires #853 as a base.

See #825.