### PR TITLE
Making Blob.exists() work as Bucket.exists().

### DIFF
--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -126,7 +126,7 @@ def list_buckets(project=None, max_results=None, page_token=None, prefix=None,
     # class has it as a reserved property.
     if page_token is not None:
         result.next_page_token = page_token
-    return iter(result)
+    return result
 
 
 def get_bucket(bucket_name, connection=None):

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -226,9 +226,14 @@ class Blob(_PropertyMixin):
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.
             query_params = {'fields': 'name'}
+            # We intentionally pass `_target_object=None` since fields=name
+            # would limit the local properties.
             connection.api_request(method='GET', path=self.path,
                                    query_params=query_params,
-                                   _target_object=self)
+                                   _target_object=None)
+            # NOTE: This will not fail immediately in a batch. However, when
+            #       Batch.finish() is called, the resulting `NotFound` will be
+            #       raised.
             return True
         except NotFound:
             return False


### PR DESCRIPTION
Also returning the _BucketIterator directly in
storage.api.list_buckets() rather than wrapping it in iter().

@tseaver As mentioned https://github.com/GoogleCloudPlatform/gcloud-python/pull/812#issuecomment-99170688 I said I'd fix `Blob.exists()` while making sure the iterators didn't work in batches.

It turns out they were already not working. Here is a working get request

```python
>>> from gcloud import _helpers
>>> from gcloud import storage
>>> 
>>> _helpers._PROJECT_ENV_VAR_NAME = 'GCLOUD_TESTS_PROJECT_ID'
>>> storage.set_defaults()
>>>
>>> with storage.Batch() as batch:
...     bucket = storage.get_bucket('bucket-name')
...     print bucket._properties
... 
<gcloud.storage.batch._FutureDict object at 0x7f7ce19f4a10>
>>> bucket._properties
{u'kind': u'storage#bucket', u'name': u'bucket-name', ...
```

while a bucket iterator fails since `_FutureDict.get` throws a `KeyError`:

```python
>>> with storage.Batch() as batch:
...     buckets_iter = storage.list_buckets()
...     response = buckets_iter.get_next_page_response()
... 
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "gcloud/storage/iterator.py", line 115, in get_next_page_response
    self.next_page_token = response.get('nextPageToken')
  File "gcloud/storage/batch.py", line 96, in get
    key, default))
KeyError: "Cannot get('nextPageToken', default=None) on a future"
```

and a blob iterator fails (but not quite always)

```python
>>> bucket.connection
<gcloud.storage.batch.Batch object at 0x7f3b1c56db50>
>>> bucket.connection._connection
<gcloud.storage.connection.Connection object at 0x7f3b1c56d490>
>>> bucket._connection = None
>>>
>>> with storage.Batch() as batch:
...     blobs_iter = bucket.list_blobs()
...     response = blobs_iter.get_next_page_response()
...
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "gcloud/storage/iterator.py", line 111, in get_next_page_response
    response = self.connection.api_request(
AttributeError: 'NoneType' object has no attribute 'api_request'
```