### PR TITLE
Adding passenv to tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,15 +55,18 @@ deps =
     pylint
     unittest2
     protobuf==3.0.0-alpha-1
+passenv = {[testenv:regression]passenv}
 
 [testenv:regression]
 basepython =
     python2.7
 commands =
     {toxinidir}/scripts/run_regression.sh
+passenv = GOOGLE_* GCLOUD_* TRAVIS* encrypted_*
 
 [testenv:regression3]
 basepython =
     python3.4
 commands =
     {toxinidir}/scripts/run_regression.sh
+passenv = {[testenv:regression]passenv}


### PR DESCRIPTION
~~Just a test PR for #874~~
    
Fixes #874. As of tox 2.0, no environment variables are passed through by default.
