### PR TITLE
Remove 'Bucket.connection' property

### DIFF
--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -78,10 +78,9 @@ def set_default_bucket(bucket=None):
     """
     if bucket is None:
         bucket_name = os.getenv(_BUCKET_ENV_VAR_NAME)
-        connection = get_default_connection()
 
-        if bucket_name is not None and connection is not None:
-            bucket = Bucket(bucket_name, connection=connection)
+        if bucket_name is not None:
+            bucket = Bucket(bucket_name)
 
     if bucket is not None:
         _implicit_environ._DEFAULTS.bucket = bucket

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -50,7 +50,6 @@ def lookup_bucket(bucket_name, connection=None):
     :rtype: :class:`gcloud.storage.bucket.Bucket`
     :returns: The bucket matching the name provided or None if not found.
     """
-    connection = _require_connection(connection)
     try:
         return get_bucket(bucket_name, connection=connection)
     except NotFound:
@@ -104,7 +103,6 @@ def list_buckets(project=None, max_results=None, page_token=None, prefix=None,
     :rtype: iterable of :class:`gcloud.storage.bucket.Bucket` objects.
     :returns: All buckets belonging to this project.
     """
-    connection = _require_connection(connection)
     if project is None:
         project = get_default_project()
     extra_params = {'project': project}
@@ -159,7 +157,7 @@ def get_bucket(bucket_name, connection=None):
     :raises: :class:`gcloud.exceptions.NotFound`
     """
     connection = _require_connection(connection)
-    bucket = Bucket(bucket_name, connection=connection)
+    bucket = Bucket(bucket_name)
     bucket.reload(connection=connection)
     return bucket
 
@@ -195,7 +193,7 @@ def create_bucket(bucket_name, project=None, connection=None):
     :returns: The newly created bucket.
     """
     connection = _require_connection(connection)
-    bucket = Bucket(bucket_name, connection=connection)
+    bucket = Bucket(bucket_name)
     bucket.create(project, connection=connection)
     return bucket
 
@@ -212,6 +210,7 @@ class _BucketIterator(Iterator):
     """
 
     def __init__(self, connection, extra_params=None):
+        connection = _require_connection(connection)
         super(_BucketIterator, self).__init__(connection=connection, path='/b',
                                               extra_params=extra_params)
 
@@ -223,6 +222,6 @@ class _BucketIterator(Iterator):
         """
         for item in response.get('items', []):
             name = item.get('name')
-            bucket = Bucket(name, connection=self.connection)
+            bucket = Bucket(name)
             bucket._set_properties(item)
             yield bucket

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -250,6 +250,7 @@ class Blob(_PropertyMixin):
         :rtype: :class:`Blob`
         :returns: The newly-copied blob.
         """
+        connection = _require_connection(connection)
         new_blob = self.bucket.copy_blob(self, self.bucket, new_name,
                                          connection=connection)
         self.delete(connection=connection)
@@ -269,6 +270,7 @@ class Blob(_PropertyMixin):
                  (propagated from
                  :meth:`gcloud.storage.bucket.Bucket.delete_blob`).
         """
+        connection = _require_connection(connection)
         return self.bucket.delete_blob(self.name, connection=connection)
 
     def download_to_file(self, file_obj, connection=None):

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -104,13 +104,21 @@ class Bucket(_PropertyMixin):
     _MAX_OBJECTS_FOR_BUCKET_DELETE = 256
     """Maximum number of existing objects allowed in Bucket.delete()."""
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, connection=None):
         super(Bucket, self).__init__(name=name)
+        self._connection = connection
         self._acl = BucketACL(self)
         self._default_object_acl = DefaultObjectACL(self)
 
     def __repr__(self):
         return '<Bucket: %s>' % self.name
+
+    def __iter__(self):
+        return iter(self.list_blobs())
+
+    def __contains__(self, blob_name):
+        blob = Blob(blob_name, bucket=self)
+        return blob.exists()
 
     def exists(self, connection=None):
         """Determines whether or not this bucket exists.

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -96,9 +96,6 @@ class Bucket(_PropertyMixin):
     :type name: string
     :param name: The name of the bucket.
 
-    :type connection: :class:`gcloud.storage.connection.Connection`
-    :param connection: The connection to use when sending requests.
-
     :type properties: dictionary or ``NoneType``
     :param properties: The properties associated with the bucket.
     """
@@ -107,21 +104,13 @@ class Bucket(_PropertyMixin):
     _MAX_OBJECTS_FOR_BUCKET_DELETE = 256
     """Maximum number of existing objects allowed in Bucket.delete()."""
 
-    def __init__(self, name=None, connection=None):
+    def __init__(self, name=None):
         super(Bucket, self).__init__(name=name)
-        self._connection = connection
         self._acl = BucketACL(self)
         self._default_object_acl = DefaultObjectACL(self)
 
     def __repr__(self):
         return '<Bucket: %s>' % self.name
-
-    def __iter__(self):
-        return iter(self.list_blobs())
-
-    def __contains__(self, blob_name):
-        blob = Blob(blob_name, bucket=self)
-        return blob.exists()
 
     def exists(self, connection=None):
         """Determines whether or not this bucket exists.
@@ -195,15 +184,6 @@ class Bucket(_PropertyMixin):
     def default_object_acl(self):
         """Create our defaultObjectACL on demand."""
         return self._default_object_acl
-
-    @property
-    def connection(self):
-        """Getter property for the connection to use with this Bucket.
-
-        :rtype: :class:`gcloud.storage.connection.Connection`
-        :returns: The connection to use.
-        """
-        return self._connection
 
     @staticmethod
     def path_helper(bucket_name):

--- a/gcloud/storage/test___init__.py
+++ b/gcloud/storage/test___init__.py
@@ -58,7 +58,6 @@ class Test_set_default_bucket(unittest2.TestCase):
 
                 default_bucket = _implicit_environ.get_default_bucket()
                 self.assertEqual(default_bucket.name, IMPLICIT_BUCKET_NAME)
-                self.assertEqual(default_bucket.connection, CONNECTION)
 
     def test_set_explicit_w_env_var_set(self):
         from gcloud.storage._testing import _monkey_defaults
@@ -113,7 +112,6 @@ class Test_set_default_bucket(unittest2.TestCase):
 
                 default_bucket = _implicit_environ.get_default_bucket()
                 self.assertEqual(default_bucket.name, IMPLICIT_BUCKET_NAME)
-                self.assertEqual(default_bucket.connection, CONNECTION)
 
 
 class Test_set_defaults(unittest2.TestCase):

--- a/gcloud/storage/test_api.py
+++ b/gcloud/storage/test_api.py
@@ -66,7 +66,6 @@ class Test_lookup_bucket(unittest2.TestCase):
             bucket = self._callFUT(BLOB_NAME, connection=conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -256,7 +255,6 @@ class Test_get_bucket(unittest2.TestCase):
             bucket = self._callFUT(BLOB_NAME, connection=conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -301,7 +299,6 @@ class Test_create_bucket(unittest2.TestCase):
             bucket = self._callFUT(BLOB_NAME, project=project, connection=conn)
 
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is conn)
         self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'POST')
         self.assertEqual(http._called_with['uri'], URI)
@@ -325,7 +322,6 @@ class Test__BucketIterator(unittest2.TestCase):
     def test_ctor(self):
         connection = object()
         iterator = self._makeOne(connection)
-        self.assertTrue(iterator.connection is connection)
         self.assertEqual(iterator.path, '/b')
         self.assertEqual(iterator.page_number, 0)
         self.assertEqual(iterator.next_page_token, None)
@@ -345,7 +341,6 @@ class Test__BucketIterator(unittest2.TestCase):
         self.assertEqual(len(buckets), 1)
         bucket = buckets[0]
         self.assertTrue(isinstance(bucket, Bucket))
-        self.assertTrue(bucket.connection is connection)
         self.assertEqual(bucket.name, BLOB_NAME)
 
 

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -106,6 +106,59 @@ class Test_Bucket(unittest2.TestCase):
         self.assertFalse(bucket._default_object_acl.loaded)
         self.assertTrue(bucket._default_object_acl.bucket is bucket)
 
+    def test___iter___empty(self):
+        from gcloud.storage._testing import _monkey_defaults
+        NAME = 'name'
+        connection = _Connection({'items': []})
+        bucket = self._makeOne(NAME)
+        with _monkey_defaults(connection=connection):
+            blobs = list(bucket)
+        self.assertEqual(blobs, [])
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'GET')
+        self.assertEqual(kw['path'], '/b/%s/o' % NAME)
+        self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
+
+    def test___iter___non_empty(self):
+        from gcloud.storage._testing import _monkey_defaults
+        NAME = 'name'
+        BLOB_NAME = 'blob-name'
+        connection = _Connection({'items': [{'name': BLOB_NAME}]})
+        bucket = self._makeOne(NAME)
+        with _monkey_defaults(connection=connection):
+            blobs = list(bucket)
+        blob, = blobs
+        self.assertTrue(blob.bucket is bucket)
+        self.assertEqual(blob.name, BLOB_NAME)
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'GET')
+        self.assertEqual(kw['path'], '/b/%s/o' % NAME)
+        self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
+
+    def test___contains___miss(self):
+        from gcloud.storage._testing import _monkey_defaults
+        NAME = 'name'
+        NONESUCH = 'nonesuch'
+        connection = _Connection()
+        bucket = self._makeOne(NAME, None)
+        with _monkey_defaults(connection=connection):
+            self.assertFalse(NONESUCH in bucket)
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'GET')
+        self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
+
+    def test___contains___hit(self):
+        from gcloud.storage._testing import _monkey_defaults
+        NAME = 'name'
+        BLOB_NAME = 'blob-name'
+        connection = _Connection({'name': BLOB_NAME})
+        bucket = self._makeOne(NAME, None)
+        with _monkey_defaults(connection=connection):
+            self.assertTrue(BLOB_NAME in bucket)
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'GET')
+        self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+
     def test_exists_miss(self):
         from gcloud.exceptions import NotFound
 

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -52,7 +52,7 @@ class TestStorageBuckets(unittest2.TestCase):
     def tearDown(self):
         with storage.Batch() as batch:
             for bucket_name in self.case_buckets_to_delete:
-                storage.Bucket(bucket_name, connection=batch).delete()
+                storage.Bucket(bucket_name).delete(connection=batch)
 
     def test_create_bucket(self):
         new_bucket_name = 'a-new-bucket'
@@ -186,7 +186,7 @@ class TestStorageListFiles(TestStorageFiles):
     def setUpClass(cls):
         super(TestStorageListFiles, cls).setUpClass()
         # Make sure bucket empty before beginning.
-        for blob in cls.bucket:
+        for blob in cls.bucket.list_blobs():
             blob.delete()
 
         logo_path = cls.FILES['logo']['path']
@@ -237,7 +237,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
     def setUpClass(cls):
         super(TestStoragePseudoHierarchy, cls).setUpClass()
         # Make sure bucket empty before beginning.
-        for blob in cls.bucket:
+        for blob in cls.bucket.list_blobs():
             blob.delete()
 
         simple_path = cls.FILES['simple']['path']
@@ -337,4 +337,4 @@ class TestStorageSignURLs(TestStorageFiles):
         self.assertEqual(content, b'')
 
         # Check that the blob has actually been deleted.
-        self.assertFalse(blob.name in self.bucket)
+        self.assertFalse(blob.exists())

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -50,9 +50,9 @@ class TestStorageBuckets(unittest2.TestCase):
         self.case_buckets_to_delete = []
 
     def tearDown(self):
-        with storage.Batch() as batch:
+        with storage.Batch():
             for bucket_name in self.case_buckets_to_delete:
-                storage.Bucket(bucket_name).delete(connection=batch)
+                storage.Bucket(bucket_name).delete()
 
     def test_create_bucket(self):
         new_bucket_name = 'a-new-bucket'


### PR DESCRIPTION
Uses #873 as a diffbase.

Also, remove `Bucket.__iter__` and `Bucket.__contains__`, as they provide no means of passing an explicit connection.

See #825.