### PR TITLE
Remove 'Bucket.__iter__' and 'Bucket.__contains__'.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -112,13 +112,6 @@ class Bucket(_PropertyMixin):
     def __repr__(self):
         return '<Bucket: %s>' % self.name
 
-    def __iter__(self):
-        return iter(self.list_blobs())
-
-    def __contains__(self, blob_name):
-        blob = Blob(blob_name, bucket=self)
-        return blob.exists()
-
     def exists(self, connection=None):
         """Determines whether or not this bucket exists.
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -12,26 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Create / interact with gcloud storage buckets.
-
-If you want to check whether a blob exists, you can use the ``in`` operator
-in Python::
-
-  >>> print 'kitten.jpg' in bucket
-  True
-  >>> print 'does-not-exist' in bucket
-  False
-
-If you want to get all the blobs in the bucket, you can use
-:func:`list_blobs <gcloud.storage.bucket.Bucket.list_blobs>`::
-
-  >>> blobs = bucket.list_blobs()
-
-You can also use the bucket as an iterator::
-
-  >>> for blob in bucket:
-  ...   print blob
-"""
+"""Create / interact with gcloud storage buckets."""
 
 import datetime
 import copy
@@ -56,7 +37,7 @@ class _BlobIterator(Iterator):
     """An iterator listing blobs in a bucket
 
     You shouldn't have to use this directly, but instead should use the
-    helper methods on :class:`gcloud.storage.blob.Bucket` objects.
+    :class:`gcloud.storage.blob.Bucket.list_blobs` method.
 
     :type bucket: :class:`gcloud.storage.bucket.Bucket`
     :param bucket: The bucket from which to list blobs.

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -106,59 +106,6 @@ class Test_Bucket(unittest2.TestCase):
         self.assertFalse(bucket._default_object_acl.loaded)
         self.assertTrue(bucket._default_object_acl.bucket is bucket)
 
-    def test___iter___empty(self):
-        from gcloud.storage._testing import _monkey_defaults
-        NAME = 'name'
-        connection = _Connection({'items': []})
-        bucket = self._makeOne(NAME)
-        with _monkey_defaults(connection=connection):
-            blobs = list(bucket)
-        self.assertEqual(blobs, [])
-        kw, = connection._requested
-        self.assertEqual(kw['method'], 'GET')
-        self.assertEqual(kw['path'], '/b/%s/o' % NAME)
-        self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
-
-    def test___iter___non_empty(self):
-        from gcloud.storage._testing import _monkey_defaults
-        NAME = 'name'
-        BLOB_NAME = 'blob-name'
-        connection = _Connection({'items': [{'name': BLOB_NAME}]})
-        bucket = self._makeOne(NAME)
-        with _monkey_defaults(connection=connection):
-            blobs = list(bucket)
-        blob, = blobs
-        self.assertTrue(blob.bucket is bucket)
-        self.assertEqual(blob.name, BLOB_NAME)
-        kw, = connection._requested
-        self.assertEqual(kw['method'], 'GET')
-        self.assertEqual(kw['path'], '/b/%s/o' % NAME)
-        self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
-
-    def test___contains___miss(self):
-        from gcloud.storage._testing import _monkey_defaults
-        NAME = 'name'
-        NONESUCH = 'nonesuch'
-        connection = _Connection()
-        bucket = self._makeOne(NAME)
-        with _monkey_defaults(connection=connection):
-            self.assertFalse(NONESUCH in bucket)
-        kw, = connection._requested
-        self.assertEqual(kw['method'], 'GET')
-        self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
-
-    def test___contains___hit(self):
-        from gcloud.storage._testing import _monkey_defaults
-        NAME = 'name'
-        BLOB_NAME = 'blob-name'
-        connection = _Connection({'name': BLOB_NAME})
-        bucket = self._makeOne(NAME)
-        with _monkey_defaults(connection=connection):
-            self.assertTrue(BLOB_NAME in bucket)
-        kw, = connection._requested
-        self.assertEqual(kw['method'], 'GET')
-        self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
-
     def test_exists_miss(self):
         from gcloud.exceptions import NotFound
 


### PR DESCRIPTION
Both are "sugar" over other methods, but do not allow passing an explicit connection.

In addition, `Bucket.__iter__` has scaling issues, which cannot be mitigated using the filtering parameters accepted by `Bucket.list_blobs`.

Moved to a new PR from #876.