### PR TITLE
Improve autodocs for top-level package names.

### DIFF
--- a/docs/datastore-api.rst
+++ b/docs/datastore-api.rst
@@ -10,10 +10,9 @@ Datastore
 :mod:`gcloud.datastore`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: gcloud.datastore.__init__
-  :members:
-  :undoc-members:
-  :show-inheritance:
+.. automodule:: gcloud.datastore
+  :members: get_connection, get_default_connection, get_default_dataset_id,
+            set_default_connection, set_default_dataset_id, set_defaults
 
 Connections
 ~~~~~~~~~~~

--- a/docs/pubsub-api.rst
+++ b/docs/pubsub-api.rst
@@ -8,10 +8,9 @@ Pub/Sub
 :mod:`gcloud.pubsub`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: gcloud.pubsub.__init__
-  :members:
-  :undoc-members:
-  :show-inheritance:
+.. automodule:: gcloud.pubsub
+  :members: get_connection, get_default_connection,
+            set_default_connection, set_defaults
 
 Connections
 ~~~~~~~~~~~

--- a/docs/storage-api.rst
+++ b/docs/storage-api.rst
@@ -10,10 +10,9 @@ Storage
 :mod:`gcloud.storage`
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: gcloud.storage.__init__
-  :members:
-  :undoc-members:
-  :show-inheritance:
+.. automodule:: gcloud.storage
+  :members: get_connection, get_default_connection, get_default_bucket,
+            set_default_connection, set_default_bucket, set_defaults
 
 Connections
 ~~~~~~~~~~~

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -71,10 +71,12 @@ def set_defaults(dataset_id=None, connection=None):
     """Set defaults either explicitly or implicitly as fall-back.
 
     Uses the arguments to call the individual default methods
+
     - set_default_dataset_id
     - set_default_connection
 
     In the future we will likely enable methods like
+
     - set_default_namespace
 
     :type dataset_id: string


### PR DESCRIPTION
- Drop the `__init__` from them.
- Include the ones imported from `_implicit_environ'`

Fixes #845.