### PR TITLE
#847: prepare for using connection as context mgr

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -48,7 +48,6 @@ The main concepts with this API are:
   when race conditions may occur.
 """
 
-from gcloud.datastore._implicit_environ import get_connection
 from gcloud.datastore._implicit_environ import get_default_connection
 from gcloud.datastore._implicit_environ import get_default_dataset_id
 from gcloud.datastore._implicit_environ import set_default_connection
@@ -87,3 +86,23 @@ def set_defaults(dataset_id=None, connection=None):
     """
     set_default_dataset_id(dataset_id=dataset_id)
     set_default_connection(connection=connection)
+
+
+def get_connection():
+    """Shortcut method to establish a connection to the Cloud Datastore.
+
+    Use this if you are going to access several datasets
+    with the same set of credentials (unlikely):
+
+    >>> from gcloud import datastore
+
+    >>> connection = datastore.get_connection()
+    >>> key1 = datastore.Key('Kind', 1234, dataset_id='dataset1')
+    >>> key2 = datastore.Key('Kind', 1234, dataset_id='dataset2')
+    >>> entity1 = datastore.get(key1, connection=connection)
+    >>> entity2 = datastore.get(key2, connection=connection)
+
+    :rtype: :class:`gcloud.datastore.connection.Connection`
+    :returns: A connection defined with the proper credentials.
+    """
+    return Connection.from_environment()

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -24,6 +24,7 @@ from gcloud._helpers import _app_engine_id
 from gcloud._helpers import _compute_engine_id
 from gcloud._helpers import _lazy_property_deco
 from gcloud.datastore.connection import Connection
+from gcloud.datastore.connection import _CONNECTIONS
 
 
 _DATASET_ENV_VAR_NAME = 'GCLOUD_DATASET_ID'
@@ -102,6 +103,28 @@ def get_default_dataset_id():
     :returns: The default dataset ID if one has been set.
     """
     return _DEFAULTS.dataset_id
+
+
+def _require_connection(connection=None):
+    """Infer a connection from the environment, if not passed explicitly.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: Optional.
+
+    :rtype: :class:`gcloud.datastore.connection.Connection`
+    :returns: A connection based on the current environment.
+    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
+             cannot be inferred from the environment.
+    """
+    if connection is None:
+        top = _CONNECTIONS.top
+        if top is not None:
+            connection = top.connection
+        else:
+            connection = get_default_connection()
+            if connection is None:
+                raise EnvironmentError('Connection could not be inferred.')
+    return connection
 
 
 def set_default_connection(connection=None):

--- a/gcloud/datastore/_implicit_environ.py
+++ b/gcloud/datastore/_implicit_environ.py
@@ -104,34 +104,13 @@ def get_default_dataset_id():
     return _DEFAULTS.dataset_id
 
 
-def get_connection():
-    """Shortcut method to establish a connection to the Cloud Datastore.
-
-    Use this if you are going to access several datasets
-    with the same set of credentials (unlikely):
-
-    >>> from gcloud import datastore
-
-    >>> connection = datastore.get_connection()
-    >>> key1 = datastore.Key('Kind', 1234, dataset_id='dataset1')
-    >>> key2 = datastore.Key('Kind', 1234, dataset_id='dataset2')
-    >>> entity1 = datastore.get(key1, connection=connection)
-    >>> entity2 = datastore.get(key2, connection=connection)
-
-    :rtype: :class:`gcloud.datastore.connection.Connection`
-    :returns: A connection defined with the proper credentials.
-    """
-    return Connection.from_environment()
-
-
 def set_default_connection(connection=None):
     """Set default connection either explicitly or implicitly as fall-back.
 
     :type connection: :class:`gcloud.datastore.connection.Connection`
     :param connection: A connection provided to be the default.
     """
-    connection = connection or get_connection()
-    _DEFAULTS.connection = connection
+    _DEFAULTS.connection = connection or Connection.from_environment()
 
 
 def get_default_connection():
@@ -163,7 +142,7 @@ class _DefaultsContainer(object):
     @staticmethod
     def connection():
         """Return the implicit default connection.."""
-        return get_connection()
+        return Connection.from_environment()
 
     def __init__(self, connection=None, dataset_id=None, implicit=False):
         if connection is not None or not implicit:

--- a/gcloud/datastore/_testing.py
+++ b/gcloud/datastore/_testing.py
@@ -31,3 +31,36 @@ def _setup_defaults(test_case, *args, **kwargs):
 
 def _tear_down_defaults(test_case):
     _implicit_environ._DEFAULTS = test_case._replaced_defaults
+
+
+class _NoCommitBatch(object):
+
+    def __init__(self, dataset_id, connection):
+        from gcloud.datastore.batch import Batch
+        self._batch = Batch(dataset_id, connection)
+
+    def __enter__(self):
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.push(self._batch)
+        return self._batch
+
+    def __exit__(self, *args):
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.pop()
+
+
+class _NoCommitTransaction(object):
+
+    def __init__(self, dataset_id, connection, transaction_id='TRANSACTION'):
+        from gcloud.datastore.transaction import Transaction
+        xact = self._transaction = Transaction(dataset_id, connection)
+        xact._id = transaction_id
+
+    def __enter__(self):
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.push(self._transaction)
+        return self._transaction
+
+    def __exit__(self, *args):
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.pop()

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -20,6 +20,7 @@ Query objects rather than via protobufs.
 
 from gcloud.datastore import _implicit_environ
 from gcloud.datastore.batch import Batch
+from gcloud.datastore.connection import _CONNECTIONS
 from gcloud.datastore.entity import Entity
 from gcloud.datastore.transaction import Transaction
 from gcloud.datastore import helpers
@@ -53,7 +54,7 @@ def _require_dataset_id(dataset_id=None, first_key=None):
     """
     if dataset_id is not None:
         return dataset_id
-    top = Batch.current()
+    top = _CONNECTIONS.top
     if top is not None:
         return top.dataset_id
     if first_key is not None:
@@ -77,7 +78,7 @@ def _require_connection(connection=None):
              cannot be inferred from the environment.
     """
     if connection is None:
-        top = Batch.current()
+        top = _CONNECTIONS.top
         if top is not None:
             connection = top.connection
         else:
@@ -262,7 +263,7 @@ def put(entities, connection=None, dataset_id=None):
     connection = _require_connection(connection)
     dataset_id = _require_dataset_id(dataset_id, entities[0].key)
 
-    current = Batch.current()
+    current = _CONNECTIONS.top
     in_batch = current is not None
     if not in_batch:
         current = Batch(dataset_id=dataset_id, connection=connection)
@@ -298,7 +299,7 @@ def delete(keys, connection=None, dataset_id=None):
     dataset_id = _require_dataset_id(dataset_id, keys[0])
 
     # We allow partial keys to attempt a delete, the backend will fail.
-    current = Batch.current()
+    current = _CONNECTIONS.top
     in_batch = current is not None
     if not in_batch:
         current = Batch(dataset_id=dataset_id, connection=connection)

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -66,28 +66,6 @@ def _require_dataset_id(dataset_id=None, first_key=None):
     return dataset_id
 
 
-def _require_connection(connection=None):
-    """Infer a connection from the environment, if not passed explicitly.
-
-    :type connection: :class:`gcloud.datastore.connection.Connection`
-    :param connection: Optional.
-
-    :rtype: :class:`gcloud.datastore.connection.Connection`
-    :returns: A connection based on the current environment.
-    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
-             cannot be inferred from the environment.
-    """
-    if connection is None:
-        top = _CONNECTIONS.top
-        if top is not None:
-            connection = top.connection
-        else:
-            connection = _implicit_environ.get_default_connection()
-            if connection is None:
-                raise EnvironmentError('Connection could not be inferred.')
-    return connection
-
-
 def _extended_lookup(connection, dataset_id, key_pbs,
                      missing=None, deferred=None,
                      eventual=False, transaction_id=None):
@@ -201,7 +179,7 @@ def get(keys, missing=None, deferred=None, connection=None, dataset_id=None):
     if not keys:
         return []
 
-    connection = _require_connection(connection)
+    connection = _implicit_environ._require_connection(connection)
     dataset_id = _require_dataset_id(dataset_id, keys[0])
 
     if list(set([key.dataset_id for key in keys])) != [dataset_id]:
@@ -260,7 +238,7 @@ def put(entities, connection=None, dataset_id=None):
     if not entities:
         return
 
-    connection = _require_connection(connection)
+    connection = _implicit_environ._require_connection(connection)
     dataset_id = _require_dataset_id(dataset_id, entities[0].key)
 
     current = _CONNECTIONS.top
@@ -295,7 +273,7 @@ def delete(keys, connection=None, dataset_id=None):
     if not keys:
         return
 
-    connection = _require_connection(connection)
+    connection = _implicit_environ._require_connection(connection)
     dataset_id = _require_dataset_id(dataset_id, keys[0])
 
     # We allow partial keys to attempt a delete, the backend will fail.
@@ -325,7 +303,7 @@ def allocate_ids(incomplete_key, num_ids, connection=None):
     :returns: The (complete) keys allocated with ``incomplete_key`` as root.
     :raises: :class:`ValueError` if ``incomplete_key`` is not a partial key.
     """
-    connection = _require_connection(connection)
+    connection = _implicit_environ._require_connection(connection)
 
     if not incomplete_key.is_partial:
         raise ValueError(('Key is not partial.', incomplete_key))

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -21,14 +21,11 @@ See
 https://cloud.google.com/datastore/docs/concepts/entities#Datastore_Batch_operations
 """
 
-from gcloud._helpers import _LocalStack
 from gcloud.datastore import _implicit_environ
 from gcloud.datastore import helpers
+from gcloud.datastore.connection import _CONNECTIONS
 from gcloud.datastore.key import _dataset_ids_equal
 from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
-
-
-_BATCHES = _LocalStack()
 
 
 class Batch(object):
@@ -90,7 +87,7 @@ class Batch(object):
     @staticmethod
     def current():
         """Return the topmost batch / transaction, or None."""
-        return _BATCHES.top
+        return _CONNECTIONS.top
 
     @property
     def dataset_id(self):
@@ -229,7 +226,7 @@ class Batch(object):
         pass
 
     def __enter__(self):
-        _BATCHES.push(self)
+        _CONNECTIONS.push(self)
         self.begin()
         return self
 
@@ -240,7 +237,7 @@ class Batch(object):
             else:
                 self.rollback()
         finally:
-            _BATCHES.pop()
+            _CONNECTIONS.pop()
 
 
 def _assign_entity_to_mutation(mutation_pb, entity, auto_id_entities):

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -17,8 +17,12 @@
 import os
 
 from gcloud import connection
+from gcloud._helpers import _LocalStack
 from gcloud.exceptions import make_exception
 from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
+
+
+_CONNECTIONS = _LocalStack()
 
 
 SCOPE = ('https://www.googleapis.com/auth/datastore',

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -44,3 +44,25 @@ class Test_set_defaults(unittest2.TestCase):
 
         self.assertEqual(SET_DATASET_CALLED, [DATASET_ID])
         self.assertEqual(SET_CONNECTION_CALLED, [CONNECTION])
+
+
+class Test_get_connection(unittest2.TestCase):
+
+    def _callFUT(self):
+        from gcloud.datastore import get_connection
+        return get_connection()
+
+    def test_it(self):
+        from gcloud import credentials
+        from gcloud.datastore.connection import SCOPE
+        from gcloud.datastore.connection import Connection
+        from gcloud.test_credentials import _Client
+        from gcloud._testing import _Monkey
+
+        client = _Client()
+        with _Monkey(credentials, client=client):
+            found = self._callFUT()
+        self.assertTrue(isinstance(found, Connection))
+        self.assertTrue(found._credentials is client._signed)
+        self.assertEqual(found._credentials._scopes, SCOPE)
+        self.assertTrue(client._get_app_default_called)

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -925,13 +925,13 @@ class _NoCommitBatch(object):
         self._batch = Batch(dataset_id, connection)
 
     def __enter__(self):
-        from gcloud.datastore.batch import _BATCHES
-        _BATCHES.push(self._batch)
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.push(self._batch)
         return self._batch
 
     def __exit__(self, *args):
-        from gcloud.datastore.batch import _BATCHES
-        _BATCHES.pop()
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.pop()
 
 
 class _NoCommitTransaction(object):
@@ -942,13 +942,13 @@ class _NoCommitTransaction(object):
         xact._id = transaction_id
 
     def __enter__(self):
-        from gcloud.datastore.batch import _BATCHES
-        _BATCHES.push(self._transaction)
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.push(self._transaction)
         return self._transaction
 
     def __exit__(self, *args):
-        from gcloud.datastore.batch import _BATCHES
-        _BATCHES.pop()
+        from gcloud.datastore.connection import _CONNECTIONS
+        _CONNECTIONS.pop()
 
 
 class _HttpMultiple(object):

--- a/gcloud/datastore/test_api.py
+++ b/gcloud/datastore/test_api.py
@@ -41,6 +41,7 @@ class Test__require_dataset_id(unittest2.TestCase):
             self.assertEqual(self._callFUT(first_key=_Key(ID)), ID)
 
     def test_implicit_unset_w_existing_batch_wo_keys(self):
+        from gcloud.datastore._testing import _NoCommitBatch
         ID = 'DATASET'
         with self._monkey(None):
             with _NoCommitBatch(dataset_id=ID, connection=object()):
@@ -48,6 +49,7 @@ class Test__require_dataset_id(unittest2.TestCase):
 
     def test_implicit_unset_w_existing_batch_w_keys(self):
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitBatch
         ID = 'DATASET'
         OTHER = 'OTHER'
         with self._monkey(None):
@@ -55,6 +57,7 @@ class Test__require_dataset_id(unittest2.TestCase):
                 self.assertEqual(self._callFUT(first_key=_Key(OTHER)), ID)
 
     def test_implicit_unset_w_existing_transaction_wo_keys(self):
+        from gcloud.datastore._testing import _NoCommitTransaction
         ID = 'DATASET'
         with self._monkey(None):
             with _NoCommitTransaction(dataset_id=ID, connection=object()):
@@ -62,6 +65,7 @@ class Test__require_dataset_id(unittest2.TestCase):
 
     def test_implicit_unset_w_existing_transaction_w_keys(self):
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitTransaction
         ID = 'DATASET'
         OTHER = 'OTHER'
         with self._monkey(None):
@@ -106,56 +110,6 @@ class Test__require_dataset_id(unittest2.TestCase):
         OTHER = 'OTHER'
         with self._monkey(IMPLICIT_ID):
             self.assertEqual(self._callFUT(ID, first_key=_Key(OTHER)), ID)
-
-
-class Test__require_connection(unittest2.TestCase):
-
-    _MARKER = object()
-
-    def _callFUT(self, passed=_MARKER):
-        from gcloud.datastore.api import _require_connection
-        if passed is self._MARKER:
-            return _require_connection()
-        return _require_connection(passed)
-
-    def _monkey(self, connection):
-        from gcloud.datastore._testing import _monkey_defaults
-        return _monkey_defaults(connection=connection)
-
-    def test_implicit_unset(self):
-        with self._monkey(None):
-            with self.assertRaises(EnvironmentError):
-                self._callFUT()
-
-    def test_implicit_unset_w_existing_batch(self):
-        ID = 'DATASET'
-        CONNECTION = object()
-        with self._monkey(None):
-            with _NoCommitBatch(dataset_id=ID, connection=CONNECTION):
-                self.assertEqual(self._callFUT(), CONNECTION)
-
-    def test_implicit_unset_w_existing_transaction(self):
-        ID = 'DATASET'
-        CONNECTION = object()
-        with self._monkey(None):
-            with _NoCommitTransaction(dataset_id=ID, connection=CONNECTION):
-                self.assertEqual(self._callFUT(), CONNECTION)
-
-    def test_implicit_unset_passed_explicitly(self):
-        CONNECTION = object()
-        with self._monkey(None):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
-
-    def test_implicit_set(self):
-        IMPLICIT_CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
-
-    def test_implicit_set_passed_explicitly(self):
-        IMPLICIT_CONNECTION = object()
-        CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
 
 
 class Test_get_function(unittest2.TestCase):
@@ -499,6 +453,7 @@ class Test_get_function(unittest2.TestCase):
     def test_w_transaction(self):
         from gcloud.datastore.key import Key
         from gcloud.datastore.test_connection import _Connection
+        from gcloud.datastore._testing import _NoCommitTransaction
 
         DATASET_ID = 'DATASET'
         KIND = 'Kind'
@@ -661,6 +616,7 @@ class Test_put_function(unittest2.TestCase):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Entity
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitBatch
 
         # Build basic mocks needed to delete.
         _DATASET = 'DATASET'
@@ -687,6 +643,7 @@ class Test_put_function(unittest2.TestCase):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Entity
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitBatch
 
         # Build basic mocks needed to delete.
         _DATASET = 'DATASET'
@@ -804,6 +761,7 @@ class Test_delete_function(unittest2.TestCase):
     def test_w_existing_batch(self):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitBatch
 
         # Build basic mocks needed to delete.
         _DATASET = 'DATASET'
@@ -825,6 +783,7 @@ class Test_delete_function(unittest2.TestCase):
     def test_w_existing_transaction(self):
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitTransaction
 
         # Build basic mocks needed to delete.
         _DATASET = 'DATASET'
@@ -847,6 +806,7 @@ class Test_delete_function(unittest2.TestCase):
         from gcloud.datastore._testing import _monkey_defaults
         from gcloud.datastore.test_batch import _Connection
         from gcloud.datastore.test_batch import _Key
+        from gcloud.datastore._testing import _NoCommitBatch
 
         # Build basic mocks needed to delete.
         _DATASET = 'DATASET'
@@ -916,39 +876,6 @@ class Test_allocate_ids_function(unittest2.TestCase):
             COMPLETE_KEY = Key('KIND', 1234)
             self.assertRaises(ValueError, self._callFUT,
                               COMPLETE_KEY, 2)
-
-
-class _NoCommitBatch(object):
-
-    def __init__(self, dataset_id, connection):
-        from gcloud.datastore.batch import Batch
-        self._batch = Batch(dataset_id, connection)
-
-    def __enter__(self):
-        from gcloud.datastore.connection import _CONNECTIONS
-        _CONNECTIONS.push(self._batch)
-        return self._batch
-
-    def __exit__(self, *args):
-        from gcloud.datastore.connection import _CONNECTIONS
-        _CONNECTIONS.pop()
-
-
-class _NoCommitTransaction(object):
-
-    def __init__(self, dataset_id, connection, transaction_id='TRANSACTION'):
-        from gcloud.datastore.transaction import Transaction
-        xact = self._transaction = Transaction(dataset_id, connection)
-        xact._id = transaction_id
-
-    def __enter__(self):
-        from gcloud.datastore.connection import _CONNECTIONS
-        _CONNECTIONS.push(self._transaction)
-        return self._transaction
-
-    def __exit__(self, *args):
-        from gcloud.datastore.connection import _CONNECTIONS
-        _CONNECTIONS.pop()
 
 
 class _HttpMultiple(object):

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -279,21 +279,21 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(key._id, _NEW_ID)
 
     def test_as_context_mgr_wo_error(self):
-        from gcloud.datastore.batch import _BATCHES
+        from gcloud.datastore.connection import _CONNECTIONS
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         with self._makeOne(dataset_id=_DATASET,
                            connection=connection) as batch:
-            self.assertEqual(list(_BATCHES), [batch])
+            self.assertEqual(list(_CONNECTIONS), [batch])
             batch.put(entity)
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         insert_auto_ids = list(batch.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)
@@ -305,7 +305,7 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(connection._committed, [(_DATASET, batch.mutation)])
 
     def test_as_context_mgr_nested(self):
-        from gcloud.datastore.batch import _BATCHES
+        from gcloud.datastore.connection import _CONNECTIONS
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
@@ -314,20 +314,20 @@ class TestBatch(unittest2.TestCase):
         entity2 = _Entity(_PROPERTIES)
         key2 = entity2.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         with self._makeOne(dataset_id=_DATASET,
                            connection=connection) as batch1:
-            self.assertEqual(list(_BATCHES), [batch1])
+            self.assertEqual(list(_CONNECTIONS), [batch1])
             batch1.put(entity1)
             with self._makeOne(dataset_id=_DATASET,
                                connection=connection) as batch2:
-                self.assertEqual(list(_BATCHES), [batch2, batch1])
+                self.assertEqual(list(_CONNECTIONS), [batch2, batch1])
                 batch2.put(entity2)
 
-            self.assertEqual(list(_BATCHES), [batch1])
+            self.assertEqual(list(_CONNECTIONS), [batch1])
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         insert_auto_ids = list(batch1.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)
@@ -350,25 +350,25 @@ class TestBatch(unittest2.TestCase):
                           (_DATASET, batch1.mutation)])
 
     def test_as_context_mgr_w_error(self):
-        from gcloud.datastore.batch import _BATCHES
+        from gcloud.datastore.connection import _CONNECTIONS
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         try:
             with self._makeOne(dataset_id=_DATASET,
                                connection=connection) as batch:
-                self.assertEqual(list(_BATCHES), [batch])
+                self.assertEqual(list(_CONNECTIONS), [batch])
                 batch.put(entity)
                 raise ValueError("testing")
         except ValueError:
             pass
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(_CONNECTIONS), [])
 
         insert_auto_ids = list(batch.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -73,7 +73,7 @@ class TestTransaction(unittest2.TestCase):
         self.assertEqual(xact._status, self._getTargetClass()._INITIAL)
 
     def test_current(self):
-        from gcloud.datastore.test_api import _NoCommitBatch
+        from gcloud.datastore._testing import _NoCommitBatch
         _DATASET = 'DATASET'
         connection = _Connection()
         xact1 = self._makeOne(_DATASET, connection)

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -43,7 +43,6 @@ from gcloud import credentials
 from gcloud._helpers import get_default_project
 from gcloud._helpers import set_default_project
 from gcloud.storage import _implicit_environ
-from gcloud.storage._implicit_environ import get_connection
 from gcloud.storage._implicit_environ import get_default_bucket
 from gcloud.storage._implicit_environ import get_default_connection
 from gcloud.storage._implicit_environ import set_default_connection
@@ -105,3 +104,20 @@ def set_defaults(bucket=None, project=None, connection=None):
     # NOTE: `set_default_bucket` is called after `set_default_connection`
     #       since `set_default_bucket` falls back to implicit connection.
     set_default_bucket(bucket=bucket)
+
+
+def get_connection():
+    """Shortcut method to establish a connection to Cloud Storage.
+
+    Use this if you are going to access several buckets with the same
+    set of credentials:
+
+    >>> from gcloud import storage
+    >>> connection = storage.get_connection()
+    >>> bucket1 = storage.get_bucket('bucket1', connection=connection)
+    >>> bucket2 = storage.get_bucket('bucket2', connection=connection)
+
+    :rtype: :class:`gcloud.storage.connection.Connection`
+    :returns: A connection defined with the proper credentials.
+    """
+    return Connection.from_environment()

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -20,8 +20,7 @@ These are *not* part of the API.
 from Crypto.Hash import MD5
 import base64
 
-from gcloud.storage._implicit_environ import get_default_connection
-from gcloud.storage.connection import _CONNECTIONS
+from gcloud.storage._implicit_environ import _require_connection
 
 
 class _PropertyMixin(object):
@@ -111,29 +110,6 @@ class _PropertyMixin(object):
             method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
-
-
-def _require_connection(connection=None):
-    """Infer a connection from the environment, if not passed explicitly.
-
-    :type connection: :class:`gcloud.storage.connection.Connection`
-    :param connection: Optional.
-
-    :rtype: :class:`gcloud.storage.connection.Connection`
-    :returns: A connection based on the current environment.
-    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
-             cannot be inferred from the environment.
-    """
-    if connection is None:
-        connection = _CONNECTIONS.top
-
-    if connection is None:
-        connection = get_default_connection()
-
-    if connection is None:
-        raise EnvironmentError('Connection could not be inferred.')
-
-    return connection
 
 
 def _scalar_property(fieldname):

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -21,7 +21,7 @@ from Crypto.Hash import MD5
 import base64
 
 from gcloud.storage._implicit_environ import get_default_connection
-from gcloud.storage.batch import Batch
+from gcloud.storage.connection import _CONNECTIONS
 
 
 class _PropertyMixin(object):
@@ -124,9 +124,8 @@ def _require_connection(connection=None):
     :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
              cannot be inferred from the environment.
     """
-    # NOTE: We use current Batch directly since it inherits from Connection.
     if connection is None:
-        connection = Batch.current()
+        connection = _CONNECTIONS.top
 
     if connection is None:
         connection = get_default_connection()

--- a/gcloud/storage/_implicit_environ.py
+++ b/gcloud/storage/_implicit_environ.py
@@ -37,7 +37,7 @@ class _DefaultsContainer(object):
     @staticmethod
     def connection():
         """Return the implicit default connection.."""
-        return get_connection()
+        return Connection.from_environment()
 
     def __init__(self, bucket=None, connection=None, implicit=False):
         self.bucket = bucket
@@ -63,30 +63,13 @@ def get_default_connection():
     return _DEFAULTS.connection
 
 
-def get_connection():
-    """Shortcut method to establish a connection to Cloud Storage.
-
-    Use this if you are going to access several buckets with the same
-    set of credentials:
-
-    >>> from gcloud import storage
-    >>> connection = storage.get_connection()
-    >>> bucket1 = storage.get_bucket('bucket1', connection=connection)
-    >>> bucket2 = storage.get_bucket('bucket2', connection=connection)
-
-    :rtype: :class:`gcloud.storage.connection.Connection`
-    :returns: A connection defined with the proper credentials.
-    """
-    return Connection.from_environment()
-
-
 def set_default_connection(connection=None):
     """Set default connection either explicitly or implicitly as fall-back.
 
     :type connection: :class:`gcloud.storage.connection.Connection`
     :param connection: A connection provided to be the default.
     """
-    connection = connection or get_connection()
+    connection = connection or Connection.from_environment()
     _DEFAULTS.connection = connection
 
 

--- a/gcloud/storage/_implicit_environ.py
+++ b/gcloud/storage/_implicit_environ.py
@@ -21,6 +21,7 @@ from the enviroment.
 
 from gcloud._helpers import _lazy_property_deco
 from gcloud.storage.connection import Connection
+from gcloud.storage.connection import _CONNECTIONS
 
 
 class _DefaultsContainer(object):
@@ -52,6 +53,29 @@ def get_default_bucket():
     :returns: The default bucket if one has been set.
     """
     return _DEFAULTS.bucket
+
+
+def _require_connection(connection=None):
+    """Infer a connection from the environment, if not passed explicitly.
+
+    :type connection: :class:`gcloud.storage.connection.Connection`
+    :param connection: Optional.
+
+    :rtype: :class:`gcloud.storage.connection.Connection`
+    :returns: A connection based on the current environment.
+    :raises: :class:`EnvironmentError` if ``connection`` is ``None``, and
+             cannot be inferred from the environment.
+    """
+    if connection is None:
+        connection = _CONNECTIONS.top
+
+    if connection is None:
+        connection = get_default_connection()
+
+    if connection is None:
+        raise EnvironmentError('Connection could not be inferred.')
+
+    return connection
 
 
 def get_default_connection():

--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -78,7 +78,7 @@ This list of tuples can be used as the ``entity`` and ``role`` fields
 when sending metadata for ACLs to the API.
 """
 
-from gcloud.storage._helpers import _require_connection
+from gcloud.storage._implicit_environ import _require_connection
 
 
 class _ACLEntity(object):

--- a/gcloud/storage/api.py
+++ b/gcloud/storage/api.py
@@ -20,7 +20,7 @@ rather than via Connection.
 
 from gcloud.exceptions import NotFound
 from gcloud._helpers import get_default_project
-from gcloud.storage._helpers import _require_connection
+from gcloud.storage._implicit_environ import _require_connection
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.iterator import Iterator
 

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -26,13 +26,10 @@ import json
 
 import six
 
-from gcloud._helpers import _LocalStack
 from gcloud.exceptions import make_exception
 from gcloud.storage import _implicit_environ
 from gcloud.storage.connection import Connection
-
-
-_BATCHES = _LocalStack()
+from gcloud.storage.connection import _CONNECTIONS
 
 
 class MIMEApplicationHTTP(MIMEApplication):
@@ -245,10 +242,10 @@ class Batch(Connection):
     @staticmethod
     def current():
         """Return the topmost batch, or None."""
-        return _BATCHES.top
+        return _CONNECTIONS.top
 
     def __enter__(self):
-        _BATCHES.push(self)
+        _CONNECTIONS.push(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -256,7 +253,7 @@ class Batch(Connection):
             if exc_type is None:
                 self.finish()
         finally:
-            _BATCHES.pop()
+            _CONNECTIONS.pop()
 
 
 def _generate_faux_mime_message(parser, response, content):

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -32,7 +32,7 @@ from apitools.base.py import transfer
 from gcloud.credentials import generate_signed_url
 from gcloud.exceptions import NotFound
 from gcloud.storage._helpers import _PropertyMixin
-from gcloud.storage._helpers import _require_connection
+from gcloud.storage._implicit_environ import _require_connection
 from gcloud.storage._helpers import _scalar_property
 from gcloud.storage import _implicit_environ
 from gcloud.storage.acl import ObjectACL

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -24,8 +24,8 @@ import six
 from gcloud._helpers import get_default_project
 from gcloud.exceptions import NotFound
 from gcloud.storage._helpers import _PropertyMixin
-from gcloud.storage._helpers import _require_connection
 from gcloud.storage._helpers import _scalar_property
+from gcloud.storage._implicit_environ import _require_connection
 from gcloud.storage.acl import BucketACL
 from gcloud.storage.acl import DefaultObjectACL
 from gcloud.storage.iterator import Iterator

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -15,6 +15,10 @@
 """Create / interact with gcloud storage connections."""
 
 from gcloud import connection as base_connection
+from gcloud._helpers import _LocalStack
+
+
+_CONNECTIONS = _LocalStack()
 
 
 SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',

--- a/gcloud/storage/test___init__.py
+++ b/gcloud/storage/test___init__.py
@@ -153,3 +153,24 @@ class Test_set_defaults(unittest2.TestCase):
         self.assertEqual(SET_PROJECT_CALLED, [PROJECT])
         self.assertEqual(SET_CONNECTION_CALLED, [CONNECTION])
         self.assertEqual(SET_BUCKET_CALLED, [BUCKET])
+
+
+class Test_get_connection(unittest2.TestCase):
+
+    def _callFUT(self, *args, **kw):
+        from gcloud.storage import get_connection
+        return get_connection(*args, **kw)
+
+    def test_it(self):
+        from gcloud import credentials
+        from gcloud.storage import SCOPE
+        from gcloud.storage.connection import Connection
+        from gcloud.test_credentials import _Client
+        from gcloud._testing import _Monkey
+        client = _Client()
+        with _Monkey(credentials, client=client):
+            found = self._callFUT()
+        self.assertTrue(isinstance(found, Connection))
+        self.assertTrue(found._credentials is client._signed)
+        self.assertEqual(found._credentials._scopes, SCOPE)
+        self.assertTrue(client._get_app_default_called)

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -294,10 +294,10 @@ class _NoCommitBatch(object):
         self._connection = connection
 
     def __enter__(self):
-        from gcloud.storage.batch import _BATCHES
-        _BATCHES.push(self._connection)
+        from gcloud.storage.connection import _CONNECTIONS
+        _CONNECTIONS.push(self._connection)
         return self._connection
 
     def __exit__(self, *args):
-        from gcloud.storage.batch import _BATCHES
-        _BATCHES.pop()
+        from gcloud.storage.connection import _CONNECTIONS
+        _CONNECTIONS.pop()

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -155,44 +155,6 @@ class Test__scalar_property(unittest2.TestCase):
         self.assertEqual(test._patched, ('solfege', 'Latido'))
 
 
-class Test__require_connection(unittest2.TestCase):
-
-    def _callFUT(self, connection=None):
-        from gcloud.storage._helpers import _require_connection
-        return _require_connection(connection=connection)
-
-    def _monkey(self, connection):
-        from gcloud.storage._testing import _monkey_defaults
-        return _monkey_defaults(connection=connection)
-
-    def test_implicit_unset(self):
-        with self._monkey(None):
-            with self.assertRaises(EnvironmentError):
-                self._callFUT()
-
-    def test_implicit_unset_w_existing_batch(self):
-        CONNECTION = object()
-        with self._monkey(None):
-            with _NoCommitBatch(connection=CONNECTION):
-                self.assertEqual(self._callFUT(), CONNECTION)
-
-    def test_implicit_unset_passed_explicitly(self):
-        CONNECTION = object()
-        with self._monkey(None):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
-
-    def test_implicit_set(self):
-        IMPLICIT_CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT() is IMPLICIT_CONNECTION)
-
-    def test_implicit_set_passed_explicitly(self):
-        IMPLICIT_CONNECTION = object()
-        CONNECTION = object()
-        with self._monkey(IMPLICIT_CONNECTION):
-            self.assertTrue(self._callFUT(CONNECTION) is CONNECTION)
-
-
 class Test__base64_md5hash(unittest2.TestCase):
 
     def _callFUT(self, bytes_to_sign):
@@ -286,18 +248,3 @@ class _Base64(object):
     def b64encode(self, value):
         self._called_b64encode.append(value)
         return value
-
-
-class _NoCommitBatch(object):
-
-    def __init__(self, connection):
-        self._connection = connection
-
-    def __enter__(self):
-        from gcloud.storage.connection import _CONNECTIONS
-        _CONNECTIONS.push(self._connection)
-        return self._connection
-
-    def __exit__(self, *args):
-        from gcloud.storage.connection import _CONNECTIONS
-        _CONNECTIONS.pop()


### PR DESCRIPTION
Normalize patterns across three API subpackages:

- Make the threadlocal stack part of the related `connection` module.

- Move the `get_connection()` convenience API up to the base subpackage `__init__`.

- Move the implementation of `_require_connection` down into the related `_implicit_environ` module.