### PR TITLE
Fix #890 - Move PubSub usage doc under the right heading.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@
   storage-blobs
   storage-buckets
   storage-acl
-  pubsub-usage
   pubsub-api
+  pubsub-usage
   pubsub-subscription
   pubsub-topic
 


### PR DESCRIPTION
This just moves the heading under the right section. Not 100% certain if this is the best way to do it, let me know if it looks wrong...