### PR TITLE
Implementing get_multi in datastore.

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -56,6 +56,7 @@ from gcloud.datastore._implicit_environ import set_default_dataset_id
 from gcloud.datastore.api import allocate_ids
 from gcloud.datastore.api import delete
 from gcloud.datastore.api import get
+from gcloud.datastore.api import get_multi
 from gcloud.datastore.api import put
 from gcloud.datastore.batch import Batch
 from gcloud.datastore.connection import SCOPE

--- a/gcloud/datastore/api.py
+++ b/gcloud/datastore/api.py
@@ -166,7 +166,8 @@ def _extended_lookup(connection, dataset_id, key_pbs,
     return results
 
 
-def get(keys, missing=None, deferred=None, connection=None, dataset_id=None):
+def get_multi(keys, missing=None, deferred=None,
+              connection=None, dataset_id=None):
     """Retrieves entities, along with their attributes.
 
     :type keys: list of :class:`gcloud.datastore.key.Key`
@@ -232,6 +233,45 @@ def get(keys, missing=None, deferred=None, connection=None, dataset_id=None):
         entities.append(helpers.entity_from_protobuf(entity_pb))
 
     return entities
+
+
+def get(key, missing=None, deferred=None, connection=None, dataset_id=None):
+    """Retrieves entity from a single key (if it exists).
+
+    .. note::
+
+       This is just a thin wrapper over :func:`gcloud.datastore.get_multi`.
+       The backend API does not make a distinction between a single key or
+       multiple keys in a lookup request.
+
+    :type key: :class:`gcloud.datastore.key.Key`
+    :param key: The key to be retrieved from the datastore.
+
+    :type missing: an empty list or None.
+    :param missing: If a list is passed, the key-only entities returned
+                    by the backend as "missing" will be copied into it.
+                    Use only as a keyword param.
+
+    :type deferred: an empty list or None.
+    :param deferred: If a list is passed, the keys returned
+                     by the backend as "deferred" will be copied into it.
+                     Use only as a keyword param.
+
+    :type connection: :class:`gcloud.datastore.connection.Connection`
+    :param connection: Optional. The connection used to connect to datastore.
+                       If not passed, inferred from the environment.
+
+    :type dataset_id: :class:`gcloud.datastore.connection.Connection`
+    :param dataset_id: Optional. The dataset ID used to connect to datastore.
+                       If not passed, inferred from the environment.
+
+    :rtype: :class:`gcloud.datastore.entity.Entity` or ``NoneType``
+    :returns: The requested entity if it exists.
+    """
+    entities = get_multi([key], missing=missing, deferred=deferred,
+                         connection=connection, dataset_id=dataset_id)
+    if entities:
+        return entities[0]
 
 
 def put(entities, connection=None, dataset_id=None):

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -153,7 +153,7 @@ class Connection(connection.Connection):
 
         >>> from gcloud import datastore
         >>> key = datastore.Key('MyKind', 1234, dataset_id='dataset-id')
-        >>> datastore.get([key])
+        >>> datastore.get(key)
         [<Entity object>]
 
         Using the ``connection`` class directly:

--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -15,6 +15,7 @@
 
 from gcloud.datastore.api import delete
 from gcloud.datastore.api import get
+from gcloud.datastore.api import get_multi
 from gcloud.datastore.api import put
 from gcloud.datastore.batch import Batch
 from gcloud.datastore.key import Key
@@ -38,13 +39,22 @@ class Dataset(object):
         self.dataset_id = dataset_id
         self.connection = connection
 
-    def get(self, keys, missing=None, deferred=None):
+    def get(self, key, missing=None, deferred=None):
         """Proxy to :func:`gcloud.datastore.api.get`.
 
         Passes our ``dataset_id``.
         """
-        return get(keys, missing=missing, deferred=deferred,
+        return get(key, missing=missing, deferred=deferred,
                    connection=self.connection, dataset_id=self.dataset_id)
+
+    def get_multi(self, keys, missing=None, deferred=None):
+        """Proxy to :func:`gcloud.datastore.api.get_multi`.
+
+        Passes our ``dataset_id``.
+        """
+        return get_multi(keys, missing=missing, deferred=deferred,
+                         connection=self.connection,
+                         dataset_id=self.dataset_id)
 
     def put(self, entities):
         """Proxy to :func:`gcloud.datastore.api.put`.

--- a/gcloud/datastore/demo/demo.py
+++ b/gcloud/datastore/demo/demo.py
@@ -33,13 +33,13 @@ toy.update({'name': 'Toy'})
 datastore.put([toy])
 
 # If we look it up by its key, we should find it...
-print(datastore.get([toy.key]))
+print(datastore.get(toy.key))
 
 # And we should be able to delete it...
 datastore.delete([toy.key])
 
 # Since we deleted it, if we do another lookup it shouldn't be there again:
-print(datastore.get([toy.key]))
+print(datastore.get(toy.key))
 
 # Now let's try a more advanced query.
 # First, let's create some entities.
@@ -104,7 +104,7 @@ with datastore.Transaction() as xact:
     xact.rollback()
 
 # Let's check if the entity was actually created:
-created = datastore.get([key])
+created = datastore.get(key)
 print('yes' if created else 'no')
 
 # Remember, a key won't be complete until the transaction is commited.

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -52,9 +52,9 @@ class TestDataset(unittest2.TestCase):
         key = object()
 
         with _Monkey(MUT, get=_get):
-            dataset.get([key])
+            dataset.get(key)
 
-        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertEqual(_called_with[0][0], (key,))
         self.assertTrue(_called_with[0][1]['missing'] is None)
         self.assertTrue(_called_with[0][1]['deferred'] is None)
         self.assertTrue(_called_with[0][1]['connection'] is None)
@@ -74,7 +74,50 @@ class TestDataset(unittest2.TestCase):
         key, missing, deferred = object(), [], []
 
         with _Monkey(MUT, get=_get):
-            dataset.get([key], missing, deferred)
+            dataset.get(key, missing, deferred)
+
+        self.assertEqual(_called_with[0][0], (key,))
+        self.assertTrue(_called_with[0][1]['missing'] is missing)
+        self.assertTrue(_called_with[0][1]['deferred'] is deferred)
+        self.assertTrue(_called_with[0][1]['connection'] is conn)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
+
+    def test_get_multi_defaults(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _get_multi(*args, **kw):
+            _called_with.append((args, kw))
+
+        dataset = self._makeOne()
+        key = object()
+
+        with _Monkey(MUT, get_multi=_get_multi):
+            dataset.get_multi([key])
+
+        self.assertEqual(_called_with[0][0], ([key],))
+        self.assertTrue(_called_with[0][1]['missing'] is None)
+        self.assertTrue(_called_with[0][1]['deferred'] is None)
+        self.assertTrue(_called_with[0][1]['connection'] is None)
+        self.assertEqual(_called_with[0][1]['dataset_id'], self.DATASET_ID)
+
+    def test_get_multi_explicit(self):
+        from gcloud.datastore import dataset as MUT
+        from gcloud._testing import _Monkey
+
+        _called_with = []
+
+        def _get_multi(*args, **kw):
+            _called_with.append((args, kw))
+
+        conn = object()
+        dataset = self._makeOne(connection=conn)
+        key, missing, deferred = object(), [], []
+
+        with _Monkey(MUT, get_multi=_get_multi):
+            dataset.get_multi([key], missing, deferred)
 
         self.assertEqual(_called_with[0][0], ([key],))
         self.assertTrue(_called_with[0][1]['missing'] is missing)

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -91,7 +91,7 @@ class TestDatastoreSave(TestDatastore):
             self.assertEqual(entity.key.name, name)
         if key_id is not None:
             self.assertEqual(entity.key.id, key_id)
-        retrieved_entity, = datastore.get([entity.key])
+        retrieved_entity = datastore.get(entity.key)
         # Check the given and retrieved are the the same.
         self.assertEqual(retrieved_entity, entity)
 
@@ -126,7 +126,7 @@ class TestDatastoreSave(TestDatastore):
             self.case_entities_to_delete.append(entity2)
 
         keys = [entity1.key, entity2.key]
-        matches = datastore.get(keys)
+        matches = datastore.get_multi(keys)
         self.assertEqual(len(matches), 2)
 
     def test_empty_kind(self):
@@ -330,12 +330,12 @@ class TestDatastoreTransaction(TestDatastore):
         entity['url'] = u'www.google.com'
 
         with datastore.Transaction() as xact:
-            results = datastore.get([entity.key])
-            if len(results) == 0:
+            result = datastore.get(entity.key)
+            if result is None:
                 xact.put(entity)
                 self.case_entities_to_delete.append(entity)
 
         # This will always return after the transaction.
-        retrieved_entity, = datastore.get([entity.key])
+        retrieved_entity = datastore.get(entity.key)
         self.case_entities_to_delete.append(retrieved_entity)
         self.assertEqual(retrieved_entity, entity)


### PR DESCRIPTION
Makes distinction between an iterable of keys and a single
key for get requests and re-purposes the get() name for the
single key case.

Fixes #701.