### PR TITLE
#899: Harden 'Subscription.pull' against missing 'receivedMessages' in response

### DIFF
--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -188,7 +188,7 @@ class Subscription(object):
                                           path='%s:pull' % self.path,
                                           data=data)
         return [(info['ackId'], Message.from_api_repr(info['message']))
-                for info in response['receivedMessages']]
+                for info in response.get('receivedMessages', ())]
 
     def acknowledge(self, ack_ids, connection=None):
         """API call:  acknowledge retrieved messages for the subscription.

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -335,6 +335,23 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['data'],
                          {'returnImmediately': True, 'maxMessages': 3})
 
+    def test_pull_wo_receivedMessages(self):
+        PROJECT = 'PROJECT'
+        SUB_NAME = 'sub_name'
+        SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
+        TOPIC_NAME = 'topic_name'
+        conn = _Connection({})
+        topic = _Topic(TOPIC_NAME, project=PROJECT)
+        subscription = self._makeOne(SUB_NAME, topic)
+        pulled = subscription.pull(return_immediately=False, connection=conn)
+        self.assertEqual(len(pulled), 0)
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s:pull' % SUB_PATH)
+        self.assertEqual(req['data'],
+                         {'returnImmediately': False, 'maxMessages': 1})
+
     def test_acknowledge_w_implicit_connection(self):
         from gcloud.pubsub._testing import _monkey_defaults
         PROJECT = 'PROJECT'


### PR DESCRIPTION
Fixes #899.