### PR TITLE
Removing datastore key query filter restriction.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -90,7 +90,10 @@ class Query(object):
         self._kind = kind
         self._namespace = namespace
         self._ancestor = ancestor
-        self._filters = list(filters)
+        self._filters = []
+        # Verify filters passed in.
+        for property_name, operator, value in filters:
+            self.add_filter(property_name, operator, value)
         self._projection = _ensure_tuple_or_list('projection', projection)
         self._order = _ensure_tuple_or_list('order', order)
         self._group_by = _ensure_tuple_or_list('group_by', group_by)
@@ -216,11 +219,8 @@ class Query(object):
             choices_message = 'Please use one of: =, <, <=, >, >=.'
             raise ValueError(error_message, choices_message)
 
-        if property_name == '__key__':
-            if not isinstance(value, Key):
-                raise ValueError('Invalid key: "%s"' % value)
-            if operator != '=':
-                raise ValueError('Invalid operator for key: "%s"' % operator)
+        if property_name == '__key__' and not isinstance(value, Key):
+            raise ValueError('Invalid key: "%s"' % value)
 
         self._filters.append((property_name, operator, value))
 

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -100,6 +100,13 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(TypeError, self._makeOne, _KIND, _DATASET,
                           group_by=BAD_GROUP_BY)
 
+    def test_ctor_bad_filters(self):
+        _DATASET = 'DATASET'
+        _KIND = 'KIND'
+        FILTERS_CANT_UNPACK = [('one', 'two')]
+        self.assertRaises(ValueError, self._makeOne, _KIND, _DATASET,
+                          filters=FILTERS_CANT_UNPACK)
+
     def test_namespace_setter_w_non_string(self):
         _DATASET = 'DATASET'
         query = self._makeOne(dataset_id=_DATASET)
@@ -224,12 +231,13 @@ class TestQuery(unittest2.TestCase):
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
-    def test_filter___key__invalid_operator(self):
+    def test_filter___key__not_equal_operator(self):
         from gcloud.datastore.key import Key
         _DATASET = 'DATASET'
         key = Key('Foo', dataset_id='DATASET')
         query = self._makeOne(dataset_id=_DATASET)
-        self.assertRaises(ValueError, query.add_filter, '__key__', '<', key)
+        query.add_filter('__key__', '<', key)
+        self.assertEqual(query.filters, [('__key__', '<', key)])
 
     def test_filter___key__invalid_value(self):
         _DATASET = 'DATASET'


### PR DESCRIPTION
Also checking in `Query` constructor that all the filters are valid.

Fixes #917.

----

@pcostell Can you verify that key inequality filters work? (The docs clearly state they do, just want to be careful.) This has been in the codebase longer than I've been working on the project, so maybe it was introduced before inequality filters were allowed?