### PR TITLE
Adding the ability to set Subscription path

### DIFF
--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -45,6 +45,7 @@ class Subscription(object):
         self.topic = topic
         self.ack_deadline = ack_deadline
         self.push_endpoint = push_endpoint
+        self._path = None
 
     @classmethod
     def from_api_repr(cls, resource, topics=None):
@@ -76,16 +77,14 @@ class Subscription(object):
         """URL path for the subscription's APIs"""
         project = self.topic.project
         path = '/projects/%s/subscriptions/%s' % (project, self.name)
-        if hasattr(self,"_path"):
-            path = '/projects/%s/subscriptions/%s' % (project, self.name)
+        if self._path is not None:
+            path = self._path
         return path
-
 
     @path.setter
     def path(self, project):
         """URL path setter"""
         self._path = '/projects/%s/subscriptions/%s' % (project, self.name)
-
 
     def create(self, connection=None):
         """API call:  create the subscription via a PUT request

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -75,7 +75,17 @@ class Subscription(object):
     def path(self):
         """URL path for the subscription's APIs"""
         project = self.topic.project
-        return '/projects/%s/subscriptions/%s' % (project, self.name)
+        path = '/projects/%s/subscriptions/%s' % (project, self.name)
+        if hasattr(self,"_path"):
+            path = '/projects/%s/subscriptions/%s' % (project, self.name)
+        return path
+
+
+    @path.setter
+    def path(self, project):
+        """URL path setter"""
+        self._path = '/projects/%s/subscriptions/%s' % (project, self.name)
+
 
     def create(self, connection=None):
         """API call:  create the subscription via a PUT request

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -456,6 +456,20 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['method'], 'DELETE')
         self.assertEqual(req['path'], '/%s' % SUB_PATH)
 
+    def test_set_path_property(self):
+        PROJECT = 'PROJECT'
+        NEW_PROJECT = 'NEW_PROJECT'
+        SUB_NAME = 'sub_name'
+        SUB_PATH = '/projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
+        NEW_SUB_PATH = '/projects/%s/subscriptions/%s' % (NEW_PROJECT, SUB_NAME)
+        TOPIC_NAME = 'topic_name'
+        conn = _Connection({})
+        topic = _Topic(TOPIC_NAME, project=PROJECT)
+        subscription = self._makeOne(SUB_NAME, topic)
+        self.assertEqual(SUB_PATH ,subscription.path)
+        subscription.path = NEW_PROJECT
+        self.assertEqual(NEW_SUB_PATH, subscription.path)
+
 
 class _Connection(object):
 

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -458,17 +458,16 @@ class TestSubscription(unittest2.TestCase):
 
     def test_set_path_property(self):
         PROJECT = 'PROJECT'
-        NEW_PROJECT = 'NEW_PROJECT'
+        PROJECT2 = 'PROJECT2'
         SUB_NAME = 'sub_name'
         SUB_PATH = '/projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
-        NEW_SUB_PATH = '/projects/%s/subscriptions/%s' % (NEW_PROJECT, SUB_NAME)
+        SUB_PATH2 = '/projects/%s/subscriptions/%s' % (PROJECT2, SUB_NAME)
         TOPIC_NAME = 'topic_name'
-        conn = _Connection({})
         topic = _Topic(TOPIC_NAME, project=PROJECT)
         subscription = self._makeOne(SUB_NAME, topic)
-        self.assertEqual(SUB_PATH ,subscription.path)
-        subscription.path = NEW_PROJECT
-        self.assertEqual(NEW_SUB_PATH, subscription.path)
+        self.assertEqual(SUB_PATH, subscription.path)
+        subscription.path = PROJECT2
+        self.assertEqual(SUB_PATH2, subscription.path)
 
 
 class _Connection(object):


### PR DESCRIPTION
A user should be able to set the path of the subscription, so it isn't always set to the topics project.

This allow users to subscribe to topics in other projects (if they have edit rights to said project).
