### PR TITLE
Making _BlobIterator accumulate prefixes.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -52,7 +52,8 @@ class _BlobIterator(Iterator):
     def __init__(self, bucket, extra_params=None, connection=None):
         connection = _require_connection(connection)
         self.bucket = bucket
-        self.prefixes = ()
+        self.prefixes = set()
+        self._current_prefixes = None
         super(_BlobIterator, self).__init__(
             connection=connection, path=bucket.path + '/o',
             extra_params=extra_params)
@@ -63,7 +64,8 @@ class _BlobIterator(Iterator):
         :type response: dict
         :param response: The JSON API response for a page of blobs.
         """
-        self.prefixes = tuple(response.get('prefixes', ()))
+        self._current_prefixes = tuple(response.get('prefixes', ()))
+        self.prefixes.update(self._current_prefixes)
         for item in response.get('items', []):
             name = item.get('name')
             blob = Blob(name, bucket=self.bucket)

--- a/regression/storage.py
+++ b/regression/storage.py
@@ -259,7 +259,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
         self.assertEqual([blob.name for blob in blobs], ['file01.txt'])
         self.assertEqual(iterator.page_number, 1)
         self.assertTrue(iterator.next_page_token is None)
-        self.assertEqual(iterator.prefixes, ('parent/',))
+        self.assertEqual(iterator.prefixes, set(['parent/']))
 
     def test_first_level(self):
         iterator = self.bucket.list_blobs(delimiter='/', prefix='parent/')
@@ -268,7 +268,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
         self.assertEqual([blob.name for blob in blobs], ['parent/file11.txt'])
         self.assertEqual(iterator.page_number, 1)
         self.assertTrue(iterator.next_page_token is None)
-        self.assertEqual(iterator.prefixes, ('parent/child/',))
+        self.assertEqual(iterator.prefixes, set(['parent/child/']))
 
     def test_second_level(self):
         iterator = self.bucket.list_blobs(delimiter='/',
@@ -281,7 +281,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
         self.assertEqual(iterator.page_number, 1)
         self.assertTrue(iterator.next_page_token is None)
         self.assertEqual(iterator.prefixes,
-                         ('parent/child/grand/', 'parent/child/other/'))
+                         set(['parent/child/grand/', 'parent/child/other/']))
 
     def test_third_level(self):
         # Pseudo-hierarchy can be arbitrarily deep, subject to the limit
@@ -296,7 +296,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
                          ['parent/child/grand/file31.txt'])
         self.assertEqual(iterator.page_number, 1)
         self.assertTrue(iterator.next_page_token is None)
-        self.assertEqual(iterator.prefixes, ())
+        self.assertEqual(iterator.prefixes, set())
 
 
 class TestStorageSignURLs(TestStorageFiles):


### PR DESCRIPTION
Also making some bucket tests use explicit arguments instead of monkey patching implicit settings.

Fixes #920.