### PR TITLE
Fixes #937 - Adds HTTP method and URL to exceptions.

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -391,7 +391,8 @@ class JSONConnection(Connection):
             target_object=_target_object)
 
         if not 200 <= response.status < 300:
-            raise make_exception(response, content)
+            raise make_exception(response, content,
+                                 request_string=method+' '+url)
 
         string_or_bytes = (six.binary_type, six.text_type)
         if content and expect_json and isinstance(content, string_or_bytes):

--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -157,7 +157,7 @@ class ServiceUnavailable(ServerError):
     code = 503
 
 
-def make_exception(response, content, use_json=True):
+def make_exception(response, content, request_string=None, use_json=True):
     """Factory:  create exception based on HTTP response code.
 
     :type response: :class:`httplib2.Response` or other HTTP response object
@@ -186,6 +186,9 @@ def make_exception(response, content, use_json=True):
 
     message = payload.get('error', {}).get('message', '')
     errors = payload.get('error', {}).get('errors', ())
+
+    if request_string:
+        message += ' (%s)' % request_string
 
     try:
         klass = _HTTP_CODE_TO_EXCEPTION[response.status]


### PR DESCRIPTION
Example:

Old: `gcloud.exceptions.NotFound: 404 Resource not found (resource=new).`

New: `gcloud.exceptions.NotFound: 404 Resource not found (resource=new). (DELETE https://pubsub.googleapis.com/v1beta2/projects/jjg-cloud-research/topics/new)`

---

Wasn't sure about a couple things, so wanted to ask...

1. Name of the variable (`request_string`). Seems expressive, but would rather pass a request object or something similar. Should I rename? Or pass two (`method` and `url`) on to `make_exception`?
1. Assembling the request string in the `make_exception` call (seemed like it might be better done on a separate line?)