### PR TITLE
Removing non-existent storage module from autodocs.

### DIFF
--- a/docs/storage-api.rst
+++ b/docs/storage-api.rst
@@ -21,11 +21,3 @@ Connections
   :members:
   :undoc-members:
   :show-inheritance:
-
-Iterators
-~~~~~~~~~
-
-.. automodule:: gcloud.storage.iterator
-  :members:
-  :undoc-members:
-  :show-inheritance:


### PR DESCRIPTION
Error was introduced in #941 mistakenly.