### PR TITLE
Adding auto create to pub/sub topic.

### DIFF
--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -18,6 +18,7 @@ import base64
 import datetime
 
 from gcloud._helpers import _RFC3339_MICROS
+from gcloud.exceptions import Conflict
 from gcloud.exceptions import NotFound
 
 _NOW = datetime.datetime.utcnow
@@ -42,11 +43,24 @@ class Topic(object):
     :param timestamp_messages: If true, the topic will add a ``timestamp`` key
                                to the attributes of each published message:
                                the value will be an RFC 3339 timestamp.
+
+    :type auto_create: boolean
+    :param auto_create: If true, will attempt to create the topic on
+    :param auto_create: If true, will attempt to create the topic on
+                        instantiation. If the topic already exists, we'll
+                        catch and ignore a 409 error (Conflict). Any other
+                        errors will not be caught.
     """
-    def __init__(self, name, client, timestamp_messages=False):
+    def __init__(self, name, client, timestamp_messages=False,
+                 auto_create=False):
         self.name = name
         self._client = client
         self.timestamp_messages = timestamp_messages
+        if auto_create:
+            try:
+                self.create()
+            except Conflict:
+                pass
 
     @classmethod
     def from_api_repr(cls, resource, client):


### PR DESCRIPTION
Fixes #905.

---

This is labelled `don't merge` because it doesn't adhere to the truly optimal case described in #905 by @jonparrott. I sent the PR just to have more discussion here (now that @tseaver is back in the US).

I'm worried that implementing the method used by node will be painful. I suppose we could do it with something like a custom class that is just bound to the `topic` and calls made for it

```python
class CustomHttp(object):

    def __init__(self, http, object_to_create):
        self._http = http
        self._object_to_create = object_to_create
        self._creation_checked = False

    def request(self, method, uri=None, headers=None, body=None):
        # Just do the request
        try:
            self._http(method, uri=uri, headers=headers, body=body)
        except:
            # Do some other stuff
```

----

**BUT**, no matter how I slice it, the added complexity doesn't seem to be worth it for a measly feature like `auto_create`. But maybe I am undervaluing it?