### PR TITLE
Adding passenv for tox -e docs.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     Sphinx
+passenv = {[testenv:regression]passenv} SPHINX_RELEASE
 
 [pep8]
 exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py,*.egg/,.*/


### PR DESCRIPTION
Without it, the `master` docs just show the last version rather than the last commit.

See #880 for context.