### PR TITLE
Fixing broken tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     Sphinx
-passenv = {[testenv:regression]passenv} SPHINX_RELEASE
+passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE
 
 [pep8]
 exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py,*.egg/,.*/


### PR DESCRIPTION
Caused by merging a rename commit (#954) and a change to
tox before the rename (#951).