### PR TITLE
Tagging pylint at working pre-release commit.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
     python run_pylint.py
 deps =
     pep8
-    -ehg+https://bitbucket.org/logilab/pylint#egg=pylint
+    -ehg+https://bitbucket.org/logilab/pylint@33e334be064c#egg=pylint
     unittest2
     protobuf==3.0.0-alpha-1
 passenv = {[testenv:system-tests]passenv}


### PR DESCRIPTION
Once a release comes out, will just use that version

From:
https://bitbucket.org/logilab/pylint/pull-request/143/

"My plan is to have 1.5 released on 15-17 july."

Fixes #968.