### PR TITLE
Update 'Client' to hold stack of connection/batch/transaction objects.

### DIFF
--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -135,7 +135,7 @@ class Client(object):
         "Protected", intended for use by batch / transaction context mgrs.
 
         :type connection: :class:`gcloud.datastore.connection.Connection`,
-                          or a subclass
+                          or an object implementing its API.
         :param connection: newly-active connection/batch/transaction to
                            pass to proxied API methods
         """
@@ -148,7 +148,7 @@ class Client(object):
 
         :raises: IndexError if the stack is empty.
         :rtype: :class:`gcloud.datastore.connection.Connection`, or
-                a subclass.
+                an object implementing its API.
         :returns: the top-most connection/batch/transaction, after removing it.
         """
         return self._connection_stack.pop()
@@ -158,7 +158,7 @@ class Client(object):
         """Currently-active connection.
 
         :rtype: :class:`gcloud.datastore.connection.Connection`, or
-                a subclass.
+                an object implementing its API.
         :returns: The connection/batch/transaction at the toop of the
                   connection stack.
         """

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -74,6 +74,18 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(client.dataset_id, OTHER)
         self.assertEqual(client.namespace, NAMESPACE)
         self.assertTrue(client.connection is conn)
+        self.assertEqual(list(client._connection_stack), [conn])
+
+    def test__push_connection_and__pop_connection(self):
+        conn = object()
+        new_conn = object()
+        client = self._makeOne(connection=conn)
+        client._push_connection(new_conn)
+        self.assertTrue(client.connection is new_conn)
+        self.assertEqual(list(client._connection_stack), [conn, new_conn])
+        self.assertTrue(client._pop_connection() is new_conn)
+        self.assertTrue(client.connection is conn)
+        self.assertEqual(list(client._connection_stack), [conn])
 
     def test_get_miss(self):
         _called_with = []


### PR DESCRIPTION
See #944.