### PR TITLE
Update batch/transaction/query to hold client.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -85,8 +85,8 @@ class Query(object):
 
         self._client = client
         self._kind = kind
-        self._dataset_id = dataset_id
-        self._namespace = namespace
+        self._dataset_id = dataset_id or client.dataset_id
+        self._namespace = namespace or client.namespace
         self._ancestor = ancestor
         self._filters = []
         # Verify filters passed in.
@@ -102,7 +102,7 @@ class Query(object):
 
         :rtype: str
         """
-        return self._dataset_id or self._client.dataset_id
+        return self._dataset_id
 
     @property
     def namespace(self):
@@ -111,7 +111,7 @@ class Query(object):
         :rtype: string or None
         :returns: the namespace assigned to this query
         """
-        return self._namespace or self._client.namespace
+        return self._namespace
 
     @namespace.setter
     def namespace(self, value):

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -22,41 +22,20 @@ class TestBatch(unittest2.TestCase):
 
         return Batch
 
-    def _makeOne(self, dataset_id=None, connection=None):
-        return self._getTargetClass()(dataset_id=dataset_id,
-                                      connection=connection)
+    def _makeOne(self, client):
+        return self._getTargetClass()(client)
 
-    def test_ctor_missing_required(self):
-        from gcloud.datastore._testing import _monkey_defaults
-
-        with _monkey_defaults():
-            self.assertRaises(ValueError, self._makeOne)
-            self.assertRaises(ValueError, self._makeOne, dataset_id=object())
-            self.assertRaises(ValueError, self._makeOne, connection=object())
-
-    def test_ctor_explicit(self):
+    def test_ctor(self):
         from gcloud.datastore._datastore_v1_pb2 import Mutation
         _DATASET = 'DATASET'
+        _NAMESPACE = 'NAMESPACE'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection, _NAMESPACE)
+        batch = self._makeOne(client)
 
         self.assertEqual(batch.dataset_id, _DATASET)
         self.assertEqual(batch.connection, connection)
-        self.assertTrue(batch._id is None)
-        self.assertTrue(isinstance(batch.mutation, Mutation))
-        self.assertEqual(batch._auto_id_entities, [])
-
-    def test_ctor_implicit(self):
-        from gcloud.datastore._testing import _monkey_defaults
-        from gcloud.datastore._datastore_v1_pb2 import Mutation
-        _DATASET = 'DATASET'
-        CONNECTION = _Connection()
-
-        with _monkey_defaults(connection=CONNECTION, dataset_id=_DATASET):
-            batch = self._makeOne()
-
-        self.assertEqual(batch.dataset_id, _DATASET)
-        self.assertEqual(batch.connection, CONNECTION)
+        self.assertEqual(batch.namespace, _NAMESPACE)
         self.assertTrue(batch._id is None)
         self.assertTrue(isinstance(batch.mutation, Mutation))
         self.assertEqual(batch._auto_id_entities, [])
@@ -64,8 +43,9 @@ class TestBatch(unittest2.TestCase):
     def test_current(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch1 = self._makeOne(_DATASET, connection)
-        batch2 = self._makeOne(_DATASET, connection)
+        client = _Client(_DATASET, connection)
+        batch1 = self._makeOne(client)
+        batch2 = self._makeOne(client)
         self.assertTrue(batch1.current() is None)
         self.assertTrue(batch2.current() is None)
         with batch1:
@@ -82,7 +62,8 @@ class TestBatch(unittest2.TestCase):
     def test_add_auto_id_entity_w_partial_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity()
         key = entity.key = _Key(_DATASET)
         key._id = None
@@ -94,7 +75,8 @@ class TestBatch(unittest2.TestCase):
     def test_add_auto_id_entity_w_completed_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity()
         entity.key = _Key(_DATASET)
 
@@ -103,14 +85,16 @@ class TestBatch(unittest2.TestCase):
     def test_put_entity_wo_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
 
         self.assertRaises(ValueError, batch.put, _Entity())
 
     def test_put_entity_w_key_wrong_dataset_id(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity()
         entity.key = _Key('OTHER')
 
@@ -120,7 +104,8 @@ class TestBatch(unittest2.TestCase):
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_DATASET)
         key._id = None
@@ -145,7 +130,8 @@ class TestBatch(unittest2.TestCase):
             'frotz': [],  # will be ignored
             }
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
         entity.exclude_from_indexes = ('baz', 'spam')
         key = entity.key = _Key(_DATASET)
@@ -180,7 +166,8 @@ class TestBatch(unittest2.TestCase):
             'frotz': [],  # will be ignored
             }
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
         entity.exclude_from_indexes = ('baz', 'spam')
         key = entity.key = _Key('s~' + _DATASET)
@@ -209,7 +196,8 @@ class TestBatch(unittest2.TestCase):
     def test_delete_w_partial_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         key = _Key(_DATASET)
         key._id = None
 
@@ -218,7 +206,8 @@ class TestBatch(unittest2.TestCase):
     def test_delete_w_key_wrong_dataset_id(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         key = _Key('OTHER')
 
         self.assertRaises(ValueError, batch.delete, key)
@@ -226,7 +215,8 @@ class TestBatch(unittest2.TestCase):
     def test_delete_w_completed_key(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         key = _Key(_DATASET)
 
         batch.delete(key)
@@ -242,7 +232,8 @@ class TestBatch(unittest2.TestCase):
     def test_delete_w_completed_key_w_prefixed_dataset_id(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         key = _Key('s~' + _DATASET)
 
         batch.delete(key)
@@ -258,7 +249,8 @@ class TestBatch(unittest2.TestCase):
     def test_commit(self):
         _DATASET = 'DATASET'
         connection = _Connection()
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
 
         batch.commit()
 
@@ -269,7 +261,8 @@ class TestBatch(unittest2.TestCase):
         _DATASET = 'DATASET'
         _NEW_ID = 1234
         connection = _Connection(_NEW_ID)
-        batch = self._makeOne(dataset_id=_DATASET, connection=connection)
+        client = _Client(_DATASET, connection)
+        batch = self._makeOne(client)
         entity = _Entity({})
         key = entity.key = _Key(_DATASET)
         key._id = None
@@ -283,21 +276,20 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(entity.key._id, _NEW_ID)
 
     def test_as_context_mgr_wo_error(self):
-        from gcloud.datastore.batch import _BATCHES
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        client = _Client(_DATASET, connection)
+        self.assertEqual(list(client._batches), [])
 
-        with self._makeOne(dataset_id=_DATASET,
-                           connection=connection) as batch:
-            self.assertEqual(list(_BATCHES), [batch])
+        with self._makeOne(client) as batch:
+            self.assertEqual(list(client._batches), [batch])
             batch.put(entity)
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(client._batches), [])
 
         insert_auto_ids = list(batch.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)
@@ -310,7 +302,6 @@ class TestBatch(unittest2.TestCase):
                          [(_DATASET, batch.mutation, None)])
 
     def test_as_context_mgr_nested(self):
-        from gcloud.datastore.batch import _BATCHES
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
@@ -319,20 +310,19 @@ class TestBatch(unittest2.TestCase):
         entity2 = _Entity(_PROPERTIES)
         key2 = entity2.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        client = _Client(_DATASET, connection)
+        self.assertEqual(list(client._batches), [])
 
-        with self._makeOne(dataset_id=_DATASET,
-                           connection=connection) as batch1:
-            self.assertEqual(list(_BATCHES), [batch1])
+        with self._makeOne(client) as batch1:
+            self.assertEqual(list(client._batches), [batch1])
             batch1.put(entity1)
-            with self._makeOne(dataset_id=_DATASET,
-                               connection=connection) as batch2:
-                self.assertEqual(list(_BATCHES), [batch2, batch1])
+            with self._makeOne(client) as batch2:
+                self.assertEqual(list(client._batches), [batch2, batch1])
                 batch2.put(entity2)
 
-            self.assertEqual(list(_BATCHES), [batch1])
+            self.assertEqual(list(client._batches), [batch1])
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(client._batches), [])
 
         insert_auto_ids = list(batch1.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)
@@ -355,25 +345,24 @@ class TestBatch(unittest2.TestCase):
                           (_DATASET, batch1.mutation, None)])
 
     def test_as_context_mgr_w_error(self):
-        from gcloud.datastore.batch import _BATCHES
         _DATASET = 'DATASET'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_DATASET)
 
-        self.assertEqual(list(_BATCHES), [])
+        client = _Client(_DATASET, connection)
+        self.assertEqual(list(client._batches), [])
 
         try:
-            with self._makeOne(dataset_id=_DATASET,
-                               connection=connection) as batch:
-                self.assertEqual(list(_BATCHES), [batch])
+            with self._makeOne(client) as batch:
+                self.assertEqual(list(client._batches), [batch])
                 batch.put(entity)
                 raise ValueError("testing")
         except ValueError:
             pass
 
-        self.assertEqual(list(_BATCHES), [])
+        self.assertEqual(list(client._batches), [])
 
         insert_auto_ids = list(batch.mutation.insert_auto_id)
         self.assertEqual(len(insert_auto_ids), 0)
@@ -454,3 +443,27 @@ class _Key(object):
         new_key = self.__class__(self.dataset_id)
         new_key._id = new_id
         return new_key
+
+
+class _Client(object):
+
+    def __init__(self, dataset_id, connection, namespace=None):
+        self.dataset_id = dataset_id
+        self.connection = connection
+        self.namespace = namespace
+        self._batches = []
+
+    def _push_batch(self, batch):
+        self._batches.insert(0, batch)
+
+    def _pop_batch(self):
+        return self._batches.pop(0)
+
+    @property
+    def current_batch(self):
+        if self._batches:
+            return self._batches[0]
+
+    @property
+    def current_transaction(self):
+        pass

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -463,7 +463,3 @@ class _Client(object):
     def current_batch(self):
         if self._batches:
             return self._batches[0]
-
-    @property
-    def current_transaction(self):
-        pass

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -27,7 +27,6 @@ class TestQuery(unittest2.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def _makeClient(self, connection=None):
-        from gcloud.datastore.test_batch import _Client
         if connection is None:
             connection = _Connection()
         return _Client(self._DATASET, connection)
@@ -358,7 +357,6 @@ class TestIterator(unittest2.TestCase):
             ([entity_pb], cursor, MORE if more else NO_MORE))
 
     def _makeClient(self, connection=None):
-        from gcloud.datastore.test_batch import _Client
         if connection is None:
             connection = _Connection()
         return _Client(self._DATASET, connection)
@@ -671,3 +669,15 @@ class _Connection(object):
         self._called_with.append(kw)
         result, self._results = self._results[0], self._results[1:]
         return result
+
+
+class _Client(object):
+
+    def __init__(self, dataset_id, connection, namespace=None):
+        self.dataset_id = dataset_id
+        self.connection = connection
+        self.namespace = namespace
+
+    @property
+    def current_transaction(self):
+        pass

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -288,7 +288,7 @@ class TestQuery(unittest2.TestCase):
         query.group_by = _GROUP_BY2
         self.assertEqual(query.group_by, _GROUP_BY2)
 
-    def test_fetch_defaults_w_implicit_client(self):
+    def test_fetch_defaults_w_client_attr(self):
         connection = _Connection()
         client = self._makeClient(connection)
         query = self._makeOne(client)

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -31,33 +31,18 @@ class TestQuery(unittest2.TestCase):
             connection = _Connection()
         return _Client(self._DATASET, connection)
 
-    def test_ctor_implicit(self):
-        from gcloud.datastore.key import Key
-        _KIND = 'KIND'
+    def test_ctor_defaults(self):
         client = self._makeClient()
-        ancestor = Key('ANCESTOR', 123, dataset_id=self._DATASET)
-        FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
-        PROJECTION = ['foo', 'bar', 'baz']
-        ORDER = ['foo', 'bar']
-        GROUP_BY = ['foo']
-        query = self._makeOne(
-            client,
-            kind=_KIND,
-            ancestor=ancestor,
-            filters=FILTERS,
-            projection=PROJECTION,
-            order=ORDER,
-            group_by=GROUP_BY,
-            )
+        query = self._makeOne(client)
         self.assertTrue(query._client is client)
-        self.assertEqual(query.dataset_id, self._DATASET)
-        self.assertEqual(query.kind, _KIND)
-        self.assertEqual(query.namespace, None)
-        self.assertEqual(query.ancestor.path, ancestor.path)
-        self.assertEqual(query.filters, FILTERS)
-        self.assertEqual(query.projection, PROJECTION)
-        self.assertEqual(query.order, ORDER)
-        self.assertEqual(query.group_by, GROUP_BY)
+        self.assertEqual(query.dataset_id, client.dataset_id)
+        self.assertEqual(query.kind, None)
+        self.assertEqual(query.namespace, client.namespace)
+        self.assertEqual(query.ancestor, None)
+        self.assertEqual(query.filters, [])
+        self.assertEqual(query.projection, [])
+        self.assertEqual(query.order, [])
+        self.assertEqual(query.group_by, [])
 
     def test_ctor_explicit(self):
         from gcloud.datastore.key import Key

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -17,13 +17,7 @@ import unittest2
 
 class TestQuery(unittest2.TestCase):
 
-    def setUp(self):
-        from gcloud.datastore._testing import _setup_defaults
-        _setup_defaults(self)
-
-    def tearDown(self):
-        from gcloud.datastore._testing import _tear_down_defaults
-        _tear_down_defaults(self)
+    _DATASET = 'DATASET'
 
     def _getTargetClass(self):
         from gcloud.datastore.query import Query
@@ -32,35 +26,53 @@ class TestQuery(unittest2.TestCase):
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
-    def test_ctor_defaults_wo_implicit_dataset_id(self):
-        self.assertRaises(ValueError, self._makeOne)
+    def _makeClient(self, connection=None):
+        from gcloud.datastore.test_batch import _Client
+        if connection is None:
+            connection = _Connection()
+        return _Client(self._DATASET, connection)
 
-    def test_ctor_defaults_w_implicit_dataset_id(self):
-        from gcloud.datastore._testing import _monkey_defaults
-
-        _DATASET = 'DATASET'
-        with _monkey_defaults(dataset_id=_DATASET):
-            query = self._makeOne()
-        self.assertEqual(query.dataset_id, _DATASET)
-        self.assertEqual(query.kind, None)
+    def test_ctor_implicit(self):
+        from gcloud.datastore.key import Key
+        _KIND = 'KIND'
+        client = self._makeClient()
+        ancestor = Key('ANCESTOR', 123, dataset_id=self._DATASET)
+        FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
+        PROJECTION = ['foo', 'bar', 'baz']
+        ORDER = ['foo', 'bar']
+        GROUP_BY = ['foo']
+        query = self._makeOne(
+            client,
+            kind=_KIND,
+            ancestor=ancestor,
+            filters=FILTERS,
+            projection=PROJECTION,
+            order=ORDER,
+            group_by=GROUP_BY,
+            )
+        self.assertTrue(query._client is client)
+        self.assertEqual(query.dataset_id, self._DATASET)
+        self.assertEqual(query.kind, _KIND)
         self.assertEqual(query.namespace, None)
-        self.assertEqual(query.ancestor, None)
-        self.assertEqual(query.filters, [])
-        self.assertEqual(query.projection, [])
-        self.assertEqual(query.order, [])
-        self.assertEqual(query.group_by, [])
+        self.assertEqual(query.ancestor.path, ancestor.path)
+        self.assertEqual(query.filters, FILTERS)
+        self.assertEqual(query.projection, PROJECTION)
+        self.assertEqual(query.order, ORDER)
+        self.assertEqual(query.group_by, GROUP_BY)
 
     def test_ctor_explicit(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'DATASET'
+        _DATASET = 'OTHER_DATASET'
         _KIND = 'KIND'
-        _NAMESPACE = 'NAMESPACE'
+        _NAMESPACE = 'OTHER_NAMESPACE'
+        client = self._makeClient()
         ancestor = Key('ANCESTOR', 123, dataset_id=_DATASET)
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
         GROUP_BY = ['foo']
         query = self._makeOne(
+            client,
             kind=_KIND,
             dataset_id=_DATASET,
             namespace=_NAMESPACE,
@@ -70,6 +82,7 @@ class TestQuery(unittest2.TestCase):
             order=ORDER,
             group_by=GROUP_BY,
             )
+        self.assertTrue(query._client is client)
         self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, _KIND)
         self.assertEqual(query.namespace, _NAMESPACE)
@@ -80,36 +93,27 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.group_by, GROUP_BY)
 
     def test_ctor_bad_projection(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         BAD_PROJECTION = object()
-        self.assertRaises(TypeError, self._makeOne, _KIND, _DATASET,
+        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
                           projection=BAD_PROJECTION)
 
     def test_ctor_bad_order(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         BAD_ORDER = object()
-        self.assertRaises(TypeError, self._makeOne, _KIND, _DATASET,
+        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
                           order=BAD_ORDER)
 
     def test_ctor_bad_group_by(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         BAD_GROUP_BY = object()
-        self.assertRaises(TypeError, self._makeOne, _KIND, _DATASET,
+        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
                           group_by=BAD_GROUP_BY)
 
     def test_ctor_bad_filters(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         FILTERS_CANT_UNPACK = [('one', 'two')]
-        self.assertRaises(ValueError, self._makeOne, _KIND, _DATASET,
+        self.assertRaises(ValueError, self._makeOne, self._makeClient(),
                           filters=FILTERS_CANT_UNPACK)
 
     def test_namespace_setter_w_non_string(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
 
         def _assign(val):
             query.namespace = val
@@ -117,16 +121,13 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(ValueError, _assign, object())
 
     def test_namespace_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        query = self._makeOne(dataset_id=_DATASET)
+        _NAMESPACE = 'OTHER_NAMESPACE'
+        query = self._makeOne(self._makeClient())
         query.namespace = _NAMESPACE
-        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.namespace, _NAMESPACE)
 
     def test_kind_setter_w_non_string(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
 
         def _assign(val):
             query.kind = val
@@ -134,26 +135,22 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(TypeError, _assign, object())
 
     def test_kind_setter_wo_existing(self):
-        _DATASET = 'DATASET'
         _KIND = 'KIND'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         query.kind = _KIND
-        self.assertEqual(query.dataset_id, _DATASET)
         self.assertEqual(query.kind, _KIND)
 
     def test_kind_setter_w_existing(self):
-        _DATASET = 'DATASET'
         _KIND_BEFORE = 'KIND_BEFORE'
         _KIND_AFTER = 'KIND_AFTER'
-        query = self._makeOne(_KIND_BEFORE, _DATASET)
+        query = self._makeOne(self._makeClient(), kind=_KIND_BEFORE)
         self.assertEqual(query.kind, _KIND_BEFORE)
         query.kind = _KIND_AFTER
-        self.assertEqual(query.dataset_id, _DATASET)
+        self.assertEqual(query.dataset_id, self._DATASET)
         self.assertEqual(query.kind, _KIND_AFTER)
 
     def test_ancestor_setter_w_non_key(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
 
         def _assign(val):
             query.ancestor = val
@@ -163,37 +160,32 @@ class TestQuery(unittest2.TestCase):
 
     def test_ancestor_setter_w_key(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'DATASET'
         _NAME = u'NAME'
-        key = Key('KIND', 123, dataset_id='DATASET')
-        query = self._makeOne(dataset_id=_DATASET)
+        key = Key('KIND', 123, dataset_id=self._DATASET)
+        query = self._makeOne(self._makeClient())
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
         self.assertEqual(query.ancestor.path, key.path)
 
     def test_ancestor_deleter_w_key(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'DATASET'
-        key = Key('KIND', 123, dataset_id='DATASET')
-        query = self._makeOne(dataset_id=_DATASET, ancestor=key)
+        key = Key('KIND', 123, dataset_id=self._DATASET)
+        query = self._makeOne(client=self._makeClient(), ancestor=key)
         del query.ancestor
         self.assertTrue(query.ancestor is None)
 
     def test_add_filter_setter_w_unknown_operator(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         self.assertRaises(ValueError, query.add_filter,
                           'firstname', '~~', 'John')
 
     def test_add_filter_w_known_operator(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         query.add_filter('firstname', '=', u'John')
         self.assertEqual(query.filters, [('firstname', '=', u'John')])
 
     def test_add_filter_w_all_operators(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         query.add_filter('leq_prop', '<=', u'val1')
         query.add_filter('geq_prop', '>=', u'val2')
         query.add_filter('lt_prop', '<', u'val3')
@@ -208,8 +200,7 @@ class TestQuery(unittest2.TestCase):
 
     def test_add_filter_w_known_operator_and_entity(self):
         from gcloud.datastore.entity import Entity
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         other = Entity()
         other['firstname'] = u'John'
         other['lastname'] = u'Smith'
@@ -217,159 +208,120 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.filters, [('other', '=', other)])
 
     def test_add_filter_w_whitespace_property_name(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         PROPERTY_NAME = '  property with lots of space '
         query.add_filter(PROPERTY_NAME, '=', u'John')
         self.assertEqual(query.filters, [(PROPERTY_NAME, '=', u'John')])
 
     def test_add_filter___key__valid_key(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         key = Key('Foo', dataset_id='DATASET')
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
     def test_filter___key__not_equal_operator(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'DATASET'
         key = Key('Foo', dataset_id='DATASET')
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])
 
     def test_filter___key__invalid_value(self):
-        _DATASET = 'DATASET'
-        query = self._makeOne(dataset_id=_DATASET)
+        query = self._makeOne(self._makeClient())
         self.assertRaises(ValueError, query.add_filter, '__key__', '=', None)
 
     def test_projection_setter_empty(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.projection = []
         self.assertEqual(query.projection, [])
 
     def test_projection_setter_string(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.projection = 'field1'
         self.assertEqual(query.projection, ['field1'])
 
     def test_projection_setter_non_empty(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.projection = ['field1', 'field2']
         self.assertEqual(query.projection, ['field1', 'field2'])
 
     def test_projection_setter_multiple_calls(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         _PROJECTION1 = ['field1', 'field2']
         _PROJECTION2 = ['field3']
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.projection = _PROJECTION1
         self.assertEqual(query.projection, _PROJECTION1)
         query.projection = _PROJECTION2
         self.assertEqual(query.projection, _PROJECTION2)
 
     def test_keys_only(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.keys_only()
         self.assertEqual(query.projection, ['__key__'])
 
     def test_order_setter_empty(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET, order=['foo', '-bar'])
+        query = self._makeOne(self._makeClient(), order=['foo', '-bar'])
         query.order = []
         self.assertEqual(query.order, [])
 
     def test_order_setter_string(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.order = 'field'
         self.assertEqual(query.order, ['field'])
 
     def test_order_setter_single_item_list_desc(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.order = ['-field']
         self.assertEqual(query.order, ['-field'])
 
     def test_order_setter_multiple(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.order = ['foo', '-bar']
         self.assertEqual(query.order, ['foo', '-bar'])
 
     def test_group_by_setter_empty(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET, group_by=['foo', 'bar'])
+        query = self._makeOne(self._makeClient(), group_by=['foo', 'bar'])
         query.group_by = []
         self.assertEqual(query.group_by, [])
 
     def test_group_by_setter_string(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.group_by = 'field1'
         self.assertEqual(query.group_by, ['field1'])
 
     def test_group_by_setter_non_empty(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.group_by = ['field1', 'field2']
         self.assertEqual(query.group_by, ['field1', 'field2'])
 
     def test_group_by_multiple_calls(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
         _GROUP_BY1 = ['field1', 'field2']
         _GROUP_BY2 = ['field3']
-        query = self._makeOne(_KIND, _DATASET)
+        query = self._makeOne(self._makeClient())
         query.group_by = _GROUP_BY1
         self.assertEqual(query.group_by, _GROUP_BY1)
         query.group_by = _GROUP_BY2
         self.assertEqual(query.group_by, _GROUP_BY2)
 
-    def test_fetch_defaults_wo_implicit_connection(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
-        query = self._makeOne(_KIND, _DATASET)
-        self.assertRaises(ValueError, query.fetch)
-
-    def test_fetch_defaults_w_implicit_connection(self):
-        from gcloud.datastore._testing import _monkey_defaults
-
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
+    def test_fetch_defaults_w_implicit_client(self):
         connection = _Connection()
-        query = self._makeOne(_KIND, _DATASET)
-
-        with _monkey_defaults(connection=connection):
-            iterator = query.fetch()
+        client = self._makeClient(connection)
+        query = self._makeOne(client)
+        iterator = query.fetch()
         self.assertTrue(iterator._query is query)
+        self.assertTrue(iterator._client is client)
         self.assertEqual(iterator._limit, None)
         self.assertEqual(iterator._offset, 0)
 
-    def test_fetch_explicit(self):
-        _DATASET = 'DATASET'
-        _KIND = 'KIND'
+    def test_fetch_w_explicit_client(self):
         connection = _Connection()
-        query = self._makeOne(_KIND, _DATASET)
-        iterator = query.fetch(limit=7, offset=8, connection=connection)
+        client = self._makeClient(connection)
+        other_client = self._makeClient(connection)
+        query = self._makeOne(client)
+        iterator = query.fetch(limit=7, offset=8, client=other_client)
         self.assertTrue(iterator._query is query)
+        self.assertTrue(iterator._client is other_client)
         self.assertEqual(iterator._limit, 7)
         self.assertEqual(iterator._offset, 8)
 
@@ -405,6 +357,12 @@ class TestIterator(unittest2.TestCase):
         connection._results.append(
             ([entity_pb], cursor, MORE if more else NO_MORE))
 
+    def _makeClient(self, connection=None):
+        from gcloud.datastore.test_batch import _Client
+        if connection is None:
+            connection = _Connection()
+        return _Client(self._DATASET, connection)
+
     def test_ctor_defaults(self):
         connection = _Connection()
         query = object()
@@ -414,9 +372,9 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(iterator._offset, 0)
 
     def test_ctor_explicit(self):
-        connection = _Connection()
-        query = _Query()
-        iterator = self._makeOne(query, connection, 13, 29)
+        client = self._makeClient()
+        query = _Query(client)
+        iterator = self._makeOne(query, client, 13, 29)
         self.assertTrue(iterator._query is query)
         self.assertEqual(iterator._limit, 13)
         self.assertEqual(iterator._offset, 29)
@@ -425,9 +383,10 @@ class TestIterator(unittest2.TestCase):
         from base64 import b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection)
-        iterator = self._makeOne(query, connection)
+        iterator = self._makeOne(query, client)
         entities, more_results, cursor = iterator.next_page()
 
         self.assertEqual(cursor, b64encode(self._END))
@@ -451,9 +410,10 @@ class TestIterator(unittest2.TestCase):
         from base64 import b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection)
-        iterator = self._makeOne(query, connection, 13, 29)
+        iterator = self._makeOne(query, client, 13, 29)
         entities, more_results, cursor = iterator.next_page()
 
         self.assertEqual(cursor, b64encode(self._END))
@@ -479,9 +439,10 @@ class TestIterator(unittest2.TestCase):
         from base64 import b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
-        iterator = self._makeOne(query, connection)
+        iterator = self._makeOne(query, client)
         iterator._start_cursor = self._START
         iterator._end_cursor = self._END
         entities, more_results, cursor = iterator.next_page()
@@ -509,19 +470,21 @@ class TestIterator(unittest2.TestCase):
 
     def test_next_page_w_cursors_w_bogus_more(self):
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
         epb, cursor, _ = connection._results.pop()
         connection._results.append((epb, cursor, 4))  # invalid enum
-        iterator = self._makeOne(query, connection)
+        iterator = self._makeOne(query, client)
         self.assertRaises(ValueError, iterator.next_page)
 
     def test___iter___no_more(self):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection)
-        iterator = self._makeOne(query, connection)
+        iterator = self._makeOne(query, client)
         entities = list(iterator)
 
         self.assertFalse(iterator._more_results)
@@ -542,10 +505,11 @@ class TestIterator(unittest2.TestCase):
     def test___iter___w_more(self):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
-        query = _Query(self._DATASET, self._KIND, self._NAMESPACE)
+        client = self._makeClient(connection)
+        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
         self._addQueryResults(connection)
-        iterator = self._makeOne(query, connection)
+        iterator = self._makeOne(query, client)
         entities = list(iterator)
 
         self.assertFalse(iterator._more_results)
@@ -673,16 +637,18 @@ class Test__pb_from_query(unittest2.TestCase):
 class _Query(object):
 
     def __init__(self,
-                 dataset_id=None,
+                 client=object(),
                  kind=None,
+                 dataset_id=None,
                  namespace=None,
                  ancestor=None,
                  filters=(),
                  projection=(),
                  order=(),
                  group_by=()):
-        self.dataset_id = dataset_id
+        self._client = client
         self.kind = kind
+        self.dataset_id = dataset_id
         self.namespace = namespace
         self.ancestor = ancestor
         self.filters = filters

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -200,13 +200,13 @@ class TestQuery(unittest2.TestCase):
     def test_add_filter___key__valid_key(self):
         from gcloud.datastore.key import Key
         query = self._makeOne(self._makeClient())
-        key = Key('Foo', dataset_id='DATASET')
+        key = Key('Foo', dataset_id=self._DATASET)
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
     def test_filter___key__not_equal_operator(self):
         from gcloud.datastore.key import Key
-        key = Key('Foo', dataset_id='DATASET')
+        key = Key('Foo', dataset_id=self._DATASET)
         query = self._makeOne(self._makeClient())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])


### PR DESCRIPTION
Update batch/transaction to push themselves onto client's stack, rather
than batches.

Updated API-invoking methods to take 'client', rather than 'connection',
falling back to the client held by self.

See #944.