### PR TITLE
Replace optional connection with client in storage methods and functions.

### DIFF
--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -386,16 +386,16 @@ class ACL(object):
         for entry in found.get('items', ()):
             self.add_entity(self.entity_from_dict(entry))
 
-    def save(self, acl=None, connection=None):
+    def save(self, acl=None, client=None):
         """Save this ACL for the current bucket.
 
         :type acl: :class:`gcloud.storage.acl.ACL`, or a compatible list.
         :param acl: The ACL object to save.  If left blank, this will save
                     current entries.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or None
-        :param connection: explicit connection to use for API request;
-                           defaults to instance property.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
         if acl is None:
             acl = self
@@ -405,7 +405,7 @@ class ACL(object):
 
         if save_to_backend:
             path = self.save_path
-            connection = _require_connection(connection)
+            connection = self._client_or_connection(client)
             result = connection.api_request(
                 method='PATCH',
                 path=path,
@@ -416,7 +416,7 @@ class ACL(object):
                 self.add_entity(self.entity_from_dict(entry))
             self.loaded = True
 
-    def clear(self, connection=None):
+    def clear(self, client=None):
         """Remove all ACL entries.
 
         Note that this won't actually remove *ALL* the rules, but it
@@ -424,11 +424,11 @@ class ACL(object):
         have access to a bucket that you created even after you clear
         ACL rules with this method.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or None
-        :param connection: explicit connection to use for API request;
-                           defaults to instance property.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
-        self.save([], connection)
+        self.save([], client=client)
 
 
 class BucketACL(ACL):

--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -351,15 +351,33 @@ class ACL(object):
         self._ensure_loaded()
         return list(self.entities.values())
 
-    def reload(self, connection=None):
+    @staticmethod
+    def _client_or_connection(client):
+        """Temporary method to get a connection from a client.
+
+        If the client is null, gets the connection from the environment.
+
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
+
+        :rtype: :class:`gcloud.storage.connection.Connection`
+        :returns: The connection determined from the ``client`` or environment.
+        """
+        if client is None:
+            return _require_connection()
+        else:
+            return client.connection
+
+    def reload(self, client=None):
         """Reload the ACL data from Cloud Storage.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or None
-        :param connection: explicit connection to use for API request;
-                           defaults to instance property.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
         path = self.reload_path
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
 
         self.entities.clear()
 

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -531,16 +531,15 @@ class Blob(_PropertyMixin):
                               size=len(data), content_type=content_type,
                               client=client)
 
-    def make_public(self, connection=None):
+    def make_public(self, client=None):
         """Make this blob public giving all users read access.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use. If not passed, falls back
+                       to the ``connection`` stored on the blob's bucket.
         """
         self.acl.all().grant_read()
-        self.acl.save(connection=connection)
+        self.acl.save(client=client)
 
     cache_control = _scalar_property('cacheControl')
     """HTTP 'Cache-Control' header for this object.

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -355,7 +355,7 @@ class Blob(_PropertyMixin):
         return string_buffer.getvalue()
 
     def upload_from_file(self, file_obj, rewind=False, size=None,
-                         content_type=None, num_retries=6, connection=None):
+                         content_type=None, num_retries=6, client=None):
         """Upload the contents of this blob from a file-like object.
 
         The content type of the upload will either be
@@ -393,15 +393,14 @@ class Blob(_PropertyMixin):
         :type num_retries: integer
         :param num_retries: Number of upload retries. Defaults to 6.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :raises: :class:`ValueError` if size is not passed in and can not be
                  determined
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
         content_type = (content_type or self._properties.get('contentType') or
                         'application/octet-stream')
 
@@ -464,7 +463,7 @@ class Blob(_PropertyMixin):
         self._set_properties(json.loads(response_content))
 
     def upload_from_filename(self, filename, content_type=None,
-                             connection=None):
+                             client=None):
         """Upload this blob's contents from the content of a named file.
 
         The content type of the upload will either be
@@ -489,10 +488,9 @@ class Blob(_PropertyMixin):
         :type content_type: string or ``NoneType``
         :param content_type: Optional type of content being uploaded.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
         content_type = content_type or self._properties.get('contentType')
         if content_type is None:
@@ -500,10 +498,10 @@ class Blob(_PropertyMixin):
 
         with open(filename, 'rb') as file_obj:
             self.upload_from_file(file_obj, content_type=content_type,
-                                  connection=connection)
+                                  client=client)
 
     def upload_from_string(self, data, content_type='text/plain',
-                           connection=None):
+                           client=None):
         """Upload contents of this blob from the provided string.
 
         .. note::
@@ -525,10 +523,9 @@ class Blob(_PropertyMixin):
         :param content_type: Optional type of content being uploaded. Defaults
                              to ``'text/plain'``.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
         if isinstance(data, six.text_type):
             data = data.encode('utf-8')
@@ -536,7 +533,7 @@ class Blob(_PropertyMixin):
         string_buffer.write(data)
         self.upload_from_file(file_obj=string_buffer, rewind=True,
                               size=len(data), content_type=content_type,
-                              connection=connection)
+                              client=client)
 
     def make_public(self, connection=None):
         """Make this blob public giving all users read access.

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -266,19 +266,17 @@ class Blob(_PropertyMixin):
         :rtype: :class:`Blob`
         :returns: The newly-copied blob.
         """
-        connection = self._client_or_connection(client)
         new_blob = self.bucket.copy_blob(self, self.bucket, new_name,
                                          client=client)
-        self.delete(connection=connection)
+        self.delete(client=client)
         return new_blob
 
-    def delete(self, connection=None):
+    def delete(self, client=None):
         """Deletes a blob from Cloud Storage.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`Blob`
         :returns: The blob that was just deleted.
@@ -286,8 +284,7 @@ class Blob(_PropertyMixin):
                  (propagated from
                  :meth:`gcloud.storage.bucket.Bucket.delete_blob`).
         """
-        connection = _require_connection(connection)
-        return self.bucket.delete_blob(self.name, connection=connection)
+        return self.bucket.delete_blob(self.name, client=client)
 
     def download_to_file(self, file_obj, client=None):
         """Download the contents of this blob into a file-like object.

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -245,7 +245,7 @@ class Blob(_PropertyMixin):
         except NotFound:
             return False
 
-    def rename(self, new_name, connection=None):
+    def rename(self, new_name, client=None):
         """Renames this blob using copy and delete operations.
 
         Effectively, copies blob to the same bucket with a new name, then
@@ -259,17 +259,16 @@ class Blob(_PropertyMixin):
         :type new_name: string
         :param new_name: The new name for this blob.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`Blob`
         :returns: The newly-copied blob.
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
         new_blob = self.bucket.copy_blob(self, self.bucket, new_name,
-                                         connection=connection)
+                                         client=client)
         self.delete(connection=connection)
         return new_blob
 

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -200,18 +200,20 @@ class Blob(_PropertyMixin):
             api_access_endpoint=_API_ACCESS_ENDPOINT,
             expiration=expiration, method=method)
 
-    def exists(self, connection=None):
+    def exists(self, client=None):
         """Determines whether or not this blob exists.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: boolean
         :returns: True if the blob exists in Cloud Storage.
         """
-        connection = _require_connection(connection)
+        if client is None:
+            connection = _require_connection()
+        else:
+            connection = client.connection
         try:
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -95,18 +95,35 @@ class Bucket(_PropertyMixin):
     def __repr__(self):
         return '<Bucket: %s>' % self.name
 
-    def exists(self, connection=None):
+    @staticmethod
+    def _client_or_connection(client):
+        """Temporary method to get a connection from a client.
+
+        If the client is null, gets the connection from the environment.
+
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
+
+        :rtype: :class:`gcloud.storage.connection.Connection`
+        :returns: The connection determined from the ``client`` or environment.
+        """
+        if client is None:
+            return _require_connection()
+        else:
+            return client.connection
+
+    def exists(self, client=None):
         """Determines whether or not this bucket exists.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: boolean
         :returns: True if the bucket exists in Cloud Storage.
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
         try:
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -205,7 +205,7 @@ class Bucket(_PropertyMixin):
 
         return self.path_helper(self.name)
 
-    def get_blob(self, blob_name, connection=None):
+    def get_blob(self, blob_name, client=None):
         """Get a blob object by name.
 
         This will return None if the blob doesn't exist::
@@ -221,15 +221,14 @@ class Bucket(_PropertyMixin):
         :type blob_name: string
         :param blob_name: The name of the blob to retrieve.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`gcloud.storage.blob.Blob` or None
         :returns: The blob object if it exists, otherwise None.
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
         blob = Blob(bucket=self, name=blob_name)
         try:
             response = connection.api_request(

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -438,9 +438,8 @@ class Bucket(_PropertyMixin):
                 else:
                     raise
 
-    @staticmethod
-    def copy_blob(blob, destination_bucket, new_name=None,
-                  connection=None):
+    def copy_blob(self, blob, destination_bucket, new_name=None,
+                  client=None):
         """Copy the given blob to the given bucket, optionally with a new name.
 
         :type blob: string or :class:`gcloud.storage.blob.Blob`
@@ -453,15 +452,14 @@ class Bucket(_PropertyMixin):
         :type new_name: string
         :param new_name: (optional) the new name for the copied file.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`gcloud.storage.blob.Blob`
         :returns: The new Blob.
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
         if new_name is None:
             new_name = blob.name
         new_blob = Blob(bucket=destination_bucket, name=new_name)

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -852,14 +852,14 @@ class Bucket(_PropertyMixin):
         connection = self._client_or_connection(client)
 
         self.acl.all().grant_read()
-        self.acl.save(connection=connection)
+        self.acl.save(client=client)
 
         if future:
             doa = self.default_object_acl
             if not doa.loaded:
                 doa.reload(client=client)
             doa.all().grant_read()
-            doa.save(connection=connection)
+            doa.save(client=client)
 
         if recursive:
             blobs = list(self.list_blobs(
@@ -877,4 +877,4 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().grant_read()
-                blob.acl.save(connection=connection)
+                blob.acl.save(client=client)

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -830,7 +830,7 @@ class Bucket(_PropertyMixin):
         """
         return self.configure_website(None, None)
 
-    def make_public(self, recursive=False, future=False, connection=None):
+    def make_public(self, recursive=False, future=False, client=None):
         """Make a bucket public.
 
         If ``recursive=True`` and the bucket contains more than 256
@@ -845,12 +845,11 @@ class Bucket(_PropertyMixin):
         :param future: If True, this will make all objects created in the
                        future public as well.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
         """
-        connection = _require_connection(connection)
+        connection = self._client_or_connection(client)
 
         self.acl.all().grant_read()
         self.acl.save(connection=connection)
@@ -858,7 +857,7 @@ class Bucket(_PropertyMixin):
         if future:
             doa = self.default_object_acl
             if not doa.loaded:
-                doa.reload(connection=connection)
+                doa.reload(client=client)
             doa.all().grant_read()
             doa.save(connection=connection)
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -455,7 +455,7 @@ class Bucket(_PropertyMixin):
         new_blob._set_properties(copy_result)
         return new_blob
 
-    def upload_file(self, filename, blob_name=None, connection=None):
+    def upload_file(self, filename, blob_name=None, client=None):
         """Shortcut method to upload a file into this bucket.
 
         Use this method to quickly put a local file in Cloud Storage.
@@ -488,10 +488,9 @@ class Bucket(_PropertyMixin):
                           of the bucket with the same name as on your local
                           file system.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`Blob`
         :returns: The updated Blob object.
@@ -499,10 +498,10 @@ class Bucket(_PropertyMixin):
         if blob_name is None:
             blob_name = os.path.basename(filename)
         blob = Blob(bucket=self, name=blob_name)
-        blob.upload_from_filename(filename, connection=connection)
+        blob.upload_from_filename(filename, client=client)
         return blob
 
-    def upload_file_object(self, file_obj, blob_name=None, connection=None):
+    def upload_file_object(self, file_obj, blob_name=None, client=None):
         """Shortcut method to upload a file object into this bucket.
 
         Use this method to quickly put a local file in Cloud Storage.
@@ -535,10 +534,9 @@ class Bucket(_PropertyMixin):
                           of the bucket with the same name as on your local
                           file system.
 
-        :type connection: :class:`gcloud.storage.connection.Connection` or
-                          ``NoneType``
-        :param connection: Optional. The connection to use when sending
-                           requests. If not provided, falls back to default.
+        :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to default connection.
 
         :rtype: :class:`Blob`
         :returns: The updated Blob object.
@@ -546,7 +544,7 @@ class Bucket(_PropertyMixin):
         if blob_name is None:
             blob_name = os.path.basename(file_obj.name)
         blob = Blob(bucket=self, name=blob_name)
-        blob.upload_from_file(file_obj, connection=connection)
+        blob.upload_from_file(file_obj, client=client)
         return blob
 
     @property

--- a/gcloud/storage/client.py
+++ b/gcloud/storage/client.py
@@ -68,7 +68,7 @@ class Client(JSONClient):
         :raises: :class:`gcloud.exceptions.NotFound`
         """
         bucket = Bucket(bucket_name)
-        bucket.reload(connection=self.connection)
+        bucket.reload(client=self)
         return bucket
 
     def lookup_bucket(self, bucket_name):

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -60,10 +60,11 @@ class Test_PropertyMixin(unittest2.TestCase):
 
     def test_reload_w_explicit_connection(self):
         connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
         derived = self._derivedClass('/path')()
         # Make sure changes is not a set, so we can observe a change.
         derived._changes = object()
-        derived.reload(connection)
+        derived.reload(client=client)
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -108,13 +109,14 @@ class Test_PropertyMixin(unittest2.TestCase):
 
     def test_patch_w_explicit_connection(self):
         connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
         derived = self._derivedClass('/path')()
         # Make sure changes is non-empty, so we can observe a change.
         BAR = object()
         BAZ = object()
         derived._properties = {'bar': BAR, 'baz': BAZ}
         derived._changes = set(['bar'])  # Ignore baz.
-        derived.patch(connection)
+        derived.patch(client=client)
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -301,3 +303,9 @@ class _NoCommitBatch(object):
     def __exit__(self, *args):
         from gcloud.storage.batch import _BATCHES
         _BATCHES.pop()
+
+
+class _Client(object):
+
+    def __init__(self, connection):
+        self.connection = connection

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -617,9 +617,10 @@ class Test_ACL(unittest2.TestCase):
 
     def test_save_none_set_none_passed_w_explicit_connection(self):
         connection = _Connection()
+        client = _Client(connection)
         acl = self._makeOne()
         acl.save_path = '/testing'
-        acl.save(connection=connection)
+        acl.save(client=client)
         kw = connection._requested
         self.assertEqual(len(kw), 0)
 
@@ -641,10 +642,11 @@ class Test_ACL(unittest2.TestCase):
 
     def test_save_existing_missing_none_passed_w_explicit_connection(self):
         connection = _Connection({})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.save_path = '/testing'
         acl.loaded = True
-        acl.save(connection=connection)
+        acl.save(client=client)
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -676,11 +678,12 @@ class Test_ACL(unittest2.TestCase):
         ROLE = 'role'
         AFTER = [{'entity': 'allUsers', 'role': ROLE}]
         connection = _Connection({'acl': AFTER})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers').grant(ROLE)
-        acl.save(connection=connection)
+        acl.save(client=client)
         self.assertEqual(list(acl), AFTER)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -718,10 +721,11 @@ class Test_ACL(unittest2.TestCase):
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.save_path = '/testing'
         acl.loaded = True
-        acl.save(new_acl, connection)
+        acl.save(new_acl, client=client)
         entries = list(acl)
         self.assertEqual(len(entries), 2)
         self.assertTrue(STICKY in entries)
@@ -758,11 +762,12 @@ class Test_ACL(unittest2.TestCase):
         ROLE2 = 'role2'
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
         connection = _Connection({'acl': [STICKY]})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers', ROLE1)
-        acl.clear(connection=connection)
+        acl.clear(client=client)
         self.assertEqual(list(acl), [STICKY])
         kw = connection._requested
         self.assertEqual(len(kw), 1)

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -526,11 +526,12 @@ class Test_ACL(unittest2.TestCase):
         # https://github.com/GoogleCloudPlatform/gcloud-python/issues/652
         ROLE = 'role'
         connection = _Connection({})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
-        acl.reload(connection=connection)
+        acl.reload(client=client)
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -557,11 +558,12 @@ class Test_ACL(unittest2.TestCase):
     def test_reload_empty_result_clears_local_w_explicit_connection(self):
         ROLE = 'role'
         connection = _Connection({'items': []})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
-        acl.reload(connection=connection)
+        acl.reload(client=client)
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [])
         kw = connection._requested
@@ -590,10 +592,11 @@ class Test_ACL(unittest2.TestCase):
         ROLE = 'role'
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
+        client = _Client(connection)
         acl = self._makeOne()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
-        acl.reload(connection=connection)
+        acl.reload(client=client)
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [{'entity': 'allUsers', 'role': ROLE}])
         kw = connection._requested
@@ -870,3 +873,9 @@ class _Connection(object):
             raise NotFound('miss')
         else:
             return response
+
+
+class _Client(object):
+
+    def __init__(self, connection):
+        self.connection = connection

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -296,7 +296,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(new_blob.name, NEW_NAME)
         self.assertFalse(BLOB_NAME in bucket._blobs)
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
+        self.assertEqual(bucket._deleted, [(BLOB_NAME, client)])
         self.assertTrue(NEW_NAME in bucket._blobs)
 
     def test_delete_w_implicit_connection(self):
@@ -312,7 +312,7 @@ class Test_Blob(unittest2.TestCase):
         with _monkey_defaults(connection=connection):
             blob.delete()
         self.assertFalse(blob.exists(client=client))
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
+        self.assertEqual(bucket._deleted, [(BLOB_NAME, None)])
 
     def test_delete_w_explicit_connection(self):
         from six.moves.http_client import NOT_FOUND
@@ -323,9 +323,9 @@ class Test_Blob(unittest2.TestCase):
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
-        blob.delete(connection=connection)
+        blob.delete(client=client)
         self.assertFalse(blob.exists(client=client))
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
+        self.assertEqual(bucket._deleted, [(BLOB_NAME, client)])
 
     def _download_to_file_helper(self, chunk_size=None):
         from six.moves.http_client import OK
@@ -1147,9 +1147,9 @@ class _Bucket(object):
         destination_bucket._blobs[new_name] = self._blobs[blob.name]
         return blob.__class__(new_name, bucket=destination_bucket)
 
-    def delete_blob(self, blob_name, connection=None):
+    def delete_blob(self, blob_name, client=None):
         del self._blobs[blob_name]
-        self._deleted.append((blob_name, connection))
+        self._deleted.append((blob_name, client))
 
 
 class _Signer(object):

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -434,9 +434,9 @@ class Test_Blob(unittest2.TestCase):
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         file_obj = object()
         connection = _Connection()
+        client = _Client(connection)
         with self.assertRaises(ValueError):
-            blob.upload_from_file(file_obj, size=None,
-                                  connection=connection)
+            blob.upload_from_file(file_obj, size=None, client=client)
 
     def _upload_from_file_simple_test_helper(self, properties=None,
                                              content_type_arg=None,
@@ -451,6 +451,7 @@ class Test_Blob(unittest2.TestCase):
         connection = _Connection(
             (response, b'{}'),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
@@ -460,7 +461,7 @@ class Test_Blob(unittest2.TestCase):
             fh.flush()
             blob.upload_from_file(fh, rewind=True,
                                   content_type=content_type_arg,
-                                  connection=connection)
+                                  client=client)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -521,6 +522,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b''),
             (chunk2_response, b'{}'),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
@@ -530,7 +532,7 @@ class Test_Blob(unittest2.TestCase):
             with NamedTemporaryFile() as fh:
                 fh.write(DATA)
                 fh.flush()
-                blob.upload_from_file(fh, rewind=True, connection=connection)
+                blob.upload_from_file(fh, rewind=True, client=client)
         rq = connection.http._requested
         self.assertEqual(len(rq), 3)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -579,6 +581,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
@@ -586,7 +589,7 @@ class Test_Blob(unittest2.TestCase):
         with NamedTemporaryFile() as fh:
             fh.write(DATA)
             fh.flush()
-            blob.upload_from_file(fh, rewind=True, connection=connection)
+            blob.upload_from_file(fh, rewind=True, client=client)
             self.assertEqual(fh.tell(), len(DATA))
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
@@ -626,6 +629,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket,
                              properties=properties)
@@ -635,7 +639,7 @@ class Test_Blob(unittest2.TestCase):
             fh.write(DATA)
             fh.flush()
             blob.upload_from_filename(fh.name, content_type=content_type_arg,
-                                      connection=connection)
+                                      client=client)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -692,11 +696,12 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
-        blob.upload_from_string(DATA, connection=connection)
+        blob.upload_from_string(DATA, client=client)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')
@@ -731,11 +736,12 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, ''),
             (chunk2_response, ''),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
-        blob.upload_from_string(DATA, connection=connection)
+        blob.upload_from_string(DATA, client=client)
         rq = connection.http._requested
         self.assertEqual(len(rq), 1)
         self.assertEqual(rq[0]['method'], 'POST')

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -284,30 +284,15 @@ class Test_Blob(unittest2.TestCase):
         bucket._blobs[BLOB_NAME] = 1
         self.assertTrue(blob.exists(client=client))
 
-    def test_rename_w_implicit_connection(self):
-        from gcloud.storage._testing import _monkey_defaults
+    def test_rename(self):
         BLOB_NAME = 'blob-name'
         NEW_NAME = 'new-name'
         connection = _Connection()
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
-        with _monkey_defaults(connection=connection):
-            new_blob = blob.rename(NEW_NAME)
-        self.assertEqual(blob.name, BLOB_NAME)
-        self.assertEqual(new_blob.name, NEW_NAME)
-        self.assertFalse(BLOB_NAME in bucket._blobs)
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
-        self.assertTrue(NEW_NAME in bucket._blobs)
-
-    def test_rename_w_explicit_connection(self):
-        BLOB_NAME = 'blob-name'
-        NEW_NAME = 'new-name'
-        connection = _Connection()
-        bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
-        bucket._blobs[BLOB_NAME] = 1
-        new_blob = blob.rename(NEW_NAME, connection=connection)
+        new_blob = blob.rename(NEW_NAME, client=client)
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(new_blob.name, NEW_NAME)
         self.assertFalse(BLOB_NAME in bucket._blobs)
@@ -1157,8 +1142,8 @@ class _Bucket(object):
         self._copied = []
         self._deleted = []
 
-    def copy_blob(self, blob, destination_bucket, new_name, connection=None):
-        self._copied.append((blob, destination_bucket, new_name, connection))
+    def copy_blob(self, blob, destination_bucket, new_name, client=None):
+        self._copied.append((blob, destination_bucket, new_name, client))
         destination_bucket._blobs[new_name] = self._blobs[blob.name]
         return blob.__class__(new_name, bucket=destination_bucket)
 

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -257,19 +257,32 @@ class Test_Blob(unittest2.TestCase):
         NONESUCH = 'nonesuch'
         not_found_response = {'status': NOT_FOUND}
         connection = _Connection(not_found_response)
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(NONESUCH, bucket=bucket)
-        self.assertFalse(blob.exists(connection=connection))
+        self.assertFalse(blob.exists(client=client))
+
+    def test_exists_implicit(self):
+        from gcloud.storage._testing import _monkey_defaults
+        from six.moves.http_client import NOT_FOUND
+        NONESUCH = 'nonesuch'
+        not_found_response = {'status': NOT_FOUND}
+        connection = _Connection(not_found_response)
+        bucket = _Bucket()
+        blob = self._makeOne(NONESUCH, bucket=bucket)
+        with _monkey_defaults(connection=connection):
+            self.assertFalse(blob.exists())
 
     def test_exists_hit(self):
         from six.moves.http_client import OK
         BLOB_NAME = 'blob-name'
         found_response = {'status': OK}
         connection = _Connection(found_response)
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
-        self.assertTrue(blob.exists(connection=connection))
+        self.assertTrue(blob.exists(client=client))
 
     def test_rename_w_implicit_connection(self):
         from gcloud.storage._testing import _monkey_defaults
@@ -307,12 +320,13 @@ class Test_Blob(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         not_found_response = {'status': NOT_FOUND}
         connection = _Connection(not_found_response)
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         with _monkey_defaults(connection=connection):
             blob.delete()
-        self.assertFalse(blob.exists(connection=connection))
+        self.assertFalse(blob.exists(client=client))
         self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
 
     def test_delete_w_explicit_connection(self):
@@ -320,11 +334,12 @@ class Test_Blob(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         not_found_response = {'status': NOT_FOUND}
         connection = _Connection(not_found_response)
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         blob.delete(connection=connection)
-        self.assertFalse(blob.exists(connection=connection))
+        self.assertFalse(blob.exists(client=client))
         self.assertEqual(bucket._deleted, [(BLOB_NAME, connection)])
 
     def _download_to_file_helper(self, chunk_size=None):

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -769,10 +769,11 @@ class Test_Blob(unittest2.TestCase):
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after = {'acl': permissive}
         connection = _Connection(after)
+        client = _Client(connection)
         bucket = _Bucket()
         blob = self._makeOne(BLOB_NAME, bucket=bucket)
         blob.acl.loaded = True
-        blob.make_public(connection=connection)
+        blob.make_public(client=client)
         self.assertEqual(list(blob.acl), permissive)
         kw = connection._requested
         self.assertEqual(len(kw), 1)

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -355,6 +355,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
@@ -363,7 +364,7 @@ class Test_Blob(unittest2.TestCase):
             blob._CHUNK_SIZE_MULTIPLE = 1
             blob.chunk_size = chunk_size
         fh = BytesIO()
-        blob.download_to_file(fh, connection=connection)
+        blob.download_to_file(fh, client=client)
         self.assertEqual(fh.getvalue(), b'abcdef')
 
     def test_download_to_file_default(self):
@@ -387,6 +388,7 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK,
@@ -395,7 +397,7 @@ class Test_Blob(unittest2.TestCase):
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
         with NamedTemporaryFile() as f:
-            blob.download_to_filename(f.name, connection=connection)
+            blob.download_to_filename(f.name, client=client)
             f.flush()
             with open(f.name, 'rb') as g:
                 wrote = g.read()
@@ -416,13 +418,14 @@ class Test_Blob(unittest2.TestCase):
             (chunk1_response, b'abc'),
             (chunk2_response, b'def'),
         )
+        client = _Client(connection)
         bucket = _Bucket()
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
         blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
-        fetched = blob.download_as_string(connection=connection)
+        fetched = blob.download_as_string(client=client)
         self.assertEqual(fetched, b'abcdef')
 
     def test_upload_from_file_size_failure(self):

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -1026,6 +1026,7 @@ class Test_Bucket(unittest2.TestCase):
             ],
         }
         connection = _Connection(AFTER, GET_BLOBS_RESP)
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
@@ -1033,7 +1034,7 @@ class Test_Bucket(unittest2.TestCase):
         # Make the Bucket refuse to make_public with 2 objects.
         bucket._MAX_OBJECTS_FOR_ITERATION = 1
         self.assertRaises(ValueError, bucket.make_public, recursive=True,
-                          connection=connection)
+                          client=client)
 
 
 class _Connection(object):

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -544,9 +544,9 @@ class Test_Bucket(unittest2.TestCase):
                 self._bucket = bucket
                 self._name = name
 
-            def upload_from_filename(self, filename, connection=None):
+            def upload_from_filename(self, filename, client=None):
                 _uploaded.append((self._bucket, self._name, filename,
-                                  connection))
+                                  client))
 
         bucket = self._makeOne()
         with _Monkey(MUT, Blob=_Blob):
@@ -566,9 +566,9 @@ class Test_Bucket(unittest2.TestCase):
                 self._bucket = bucket
                 self._name = name
 
-            def upload_from_filename(self, filename, connection=None):
+            def upload_from_filename(self, filename, client=None):
                 _uploaded.append((self._bucket, self._name, filename,
-                                  connection))
+                                  client))
 
         bucket = self._makeOne()
         with _Monkey(MUT, Blob=_Blob):
@@ -588,8 +588,8 @@ class Test_Bucket(unittest2.TestCase):
                 self._bucket = bucket
                 self._name = name
 
-            def upload_from_file(self, fh, connection=None):
-                _uploaded.append((self._bucket, self._name, fh, connection))
+            def upload_from_file(self, fh, client=None):
+                _uploaded.append((self._bucket, self._name, fh, client))
 
         bucket = self._makeOne()
         with _Monkey(MUT, Blob=_Blob):
@@ -613,8 +613,8 @@ class Test_Bucket(unittest2.TestCase):
                 self._bucket = bucket
                 self._name = name
 
-            def upload_from_file(self, fh, connection=None):
-                _uploaded.append((self._bucket, self._name, fh, connection))
+            def upload_from_file(self, fh, client=None):
+                _uploaded.append((self._bucket, self._name, fh, client))
 
         bucket = self._makeOne()
         with _Monkey(MUT, Blob=_Blob):

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -347,8 +347,9 @@ class Test_Bucket(unittest2.TestCase):
         from gcloud.exceptions import NotFound
         NAME = 'name'
         connection = _Connection()
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        self.assertRaises(NotFound, bucket.delete, connection=connection)
+        self.assertRaises(NotFound, bucket.delete, client=client)
         expected_cw = [{
             'method': 'DELETE',
             'path': bucket.path,
@@ -361,8 +362,9 @@ class Test_Bucket(unittest2.TestCase):
         GET_BLOBS_RESP = {'items': []}
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        result = bucket.delete(force=True, connection=connection)
+        result = bucket.delete(force=True, client=client)
         self.assertTrue(result is None)
         expected_cw = [{
             'method': 'DELETE',
@@ -385,8 +387,9 @@ class Test_Bucket(unittest2.TestCase):
         connection = _Connection(GET_BLOBS_RESP, DELETE_BLOB1_RESP,
                                  DELETE_BLOB2_RESP)
         connection._delete_bucket = True
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        result = bucket.delete(force=True, connection=connection)
+        result = bucket.delete(force=True, client=client)
         self.assertTrue(result is None)
         expected_cw = [{
             'method': 'DELETE',
@@ -402,8 +405,9 @@ class Test_Bucket(unittest2.TestCase):
         # Note the connection does not have a response for the blob.
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        result = bucket.delete(force=True, connection=connection)
+        result = bucket.delete(force=True, client=client)
         self.assertTrue(result is None)
         expected_cw = [{
             'method': 'DELETE',
@@ -424,12 +428,13 @@ class Test_Bucket(unittest2.TestCase):
         }
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
 
         # Make the Bucket refuse to delete with 2 objects.
         bucket._MAX_OBJECTS_FOR_ITERATION = 1
         self.assertRaises(ValueError, bucket.delete, force=True,
-                          connection=connection)
+                          client=client)
         self.assertEqual(connection._deleted_buckets, [])
 
     def test_delete_blob_miss(self):
@@ -437,9 +442,10 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
         self.assertRaises(NotFound, bucket.delete_blob, NONESUCH,
-                          connection=connection)
+                          client=client)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
@@ -448,8 +454,9 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        result = bucket.delete_blob(BLOB_NAME, connection=connection)
+        result = bucket.delete_blob(BLOB_NAME, client=client)
         self.assertTrue(result is None)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
@@ -458,16 +465,18 @@ class Test_Bucket(unittest2.TestCase):
     def test_delete_blobs_empty(self):
         NAME = 'name'
         connection = _Connection()
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        bucket.delete_blobs([], connection=connection)
+        bucket.delete_blobs([], client=client)
         self.assertEqual(connection._requested, [])
 
     def test_delete_blobs_hit(self):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        bucket.delete_blobs([BLOB_NAME], connection=connection)
+        bucket.delete_blobs([BLOB_NAME], client=client)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'DELETE')
@@ -479,9 +488,10 @@ class Test_Bucket(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         NONESUCH = 'nonesuch'
         connection = _Connection({})
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
         self.assertRaises(NotFound, bucket.delete_blobs, [BLOB_NAME, NONESUCH],
-                          connection=connection)
+                          client=client)
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]['method'], 'DELETE')
@@ -494,10 +504,11 @@ class Test_Bucket(unittest2.TestCase):
         BLOB_NAME = 'blob-name'
         NONESUCH = 'nonesuch'
         connection = _Connection({})
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
         errors = []
         bucket.delete_blobs([BLOB_NAME, NONESUCH], errors.append,
-                            connection=connection)
+                            client=client)
         self.assertEqual(errors, [NONESUCH])
         kw = connection._requested
         self.assertEqual(len(kw), 2)

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -516,10 +516,11 @@ class Test_Bucket(unittest2.TestCase):
             path = '/b/%s/o/%s' % (SOURCE, BLOB_NAME)
 
         connection = _Connection({})
+        client = _Client(connection)
         source = self._makeOne(SOURCE)
         dest = self._makeOne(DEST)
         blob = _Blob()
-        new_blob = source.copy_blob(blob, dest, connection=connection)
+        new_blob = source.copy_blob(blob, dest, client=client)
         self.assertTrue(new_blob.bucket is dest)
         self.assertEqual(new_blob.name, BLOB_NAME)
         kw, = connection._requested
@@ -539,11 +540,12 @@ class Test_Bucket(unittest2.TestCase):
             path = '/b/%s/o/%s' % (SOURCE, BLOB_NAME)
 
         connection = _Connection({})
+        client = _Client(connection)
         source = self._makeOne(SOURCE)
         dest = self._makeOne(DEST)
         blob = _Blob()
         new_blob = source.copy_blob(blob, dest, NEW_NAME,
-                                    connection=connection)
+                                    client=client)
         self.assertTrue(new_blob.bucket is dest)
         self.assertEqual(new_blob.name, NEW_NAME)
         kw, = connection._requested

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -261,8 +261,9 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        result = bucket.get_blob(NONESUCH, connection=connection)
+        result = bucket.get_blob(NONESUCH, client=client)
         self.assertTrue(result is None)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
@@ -272,8 +273,9 @@ class Test_Bucket(unittest2.TestCase):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         connection = _Connection({'name': BLOB_NAME})
+        client = _Client(connection)
         bucket = self._makeOne(NAME)
-        blob = bucket.get_blob(BLOB_NAME, connection=connection)
+        blob = bucket.get_blob(BLOB_NAME, client=client)
         self.assertTrue(blob.bucket is bucket)
         self.assertEqual(blob.name, BLOB_NAME)
         kw, = connection._requested

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -975,9 +975,9 @@ class Test_Bucket(unittest2.TestCase):
             def grant_read(self):
                 self._granted = True
 
-            def save(self, connection=None):
+            def save(self, client=None):
                 _saved.append(
-                    (self._bucket, self._name, self._granted, connection))
+                    (self._bucket, self._name, self._granted, client))
 
         class _Iterator(_BlobIterator):
             def get_items_from_response(self, response):
@@ -997,7 +997,7 @@ class Test_Bucket(unittest2.TestCase):
             bucket.make_public(recursive=True)
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, BLOB_NAME, True, connection)])
+        self.assertEqual(_saved, [(bucket, BLOB_NAME, True, None)])
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]['method'], 'PATCH')

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -321,7 +321,8 @@ class TestStorageSignURLs(TestStorageFiles):
     def test_create_signed_read_url(self):
         blob = storage.Blob(bucket=self.bucket, name='LogoToSign.jpg')
         expiration = int(time.time() + 5)
-        signed_url = blob.generate_signed_url(expiration, method='GET')
+        signed_url = blob.generate_signed_url(expiration, method='GET',
+                                              client=CLIENT)
 
         response, content = HTTP.request(signed_url, method='GET')
         self.assertEqual(response.status, 200)
@@ -331,7 +332,8 @@ class TestStorageSignURLs(TestStorageFiles):
         blob = storage.Blob(bucket=self.bucket, name='LogoToSign.jpg')
         expiration = int(time.time() + 283473274)
         signed_delete_url = blob.generate_signed_url(expiration,
-                                                     method='DELETE')
+                                                     method='DELETE',
+                                                     client=CLIENT)
 
         response, content = HTTP.request(signed_delete_url, method='DELETE')
         self.assertEqual(response.status, 204)


### PR DESCRIPTION
Towards #952.

Did this for all but `Bucket.create` (since it also requires a project, built for just a `client`)

Will continue to remove `connection` from the `Bucket` and `Batch` constructors in forthcoming PR.