### PR TITLE
Making tox lint target ignore files outside the git repo.

### DIFF
--- a/scripts/pep8_on_repo.sh
+++ b/scripts/pep8_on_repo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+pep8 $(git ls-files '*py')

--- a/tox.ini
+++ b/tox.ini
@@ -43,14 +43,14 @@ deps =
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE
 
 [pep8]
-exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py,*.egg/,.*/
+exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py
 verbose = 1
 
 [testenv:lint]
 basepython =
     python2.7
 commands =
-    pep8
+    {toxinidir}/scripts/pep8_on_repo.sh
     python run_pylint.py
 deps =
     pep8


### PR DESCRIPTION
I always end up having local Python files lying around that make `pep8` unhappy.