### PR TITLE
Refresh #955:  make datastore.Client derive from base client.

### DIFF
--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -18,6 +18,7 @@ import os
 from gcloud._helpers import _LocalStack
 from gcloud._helpers import _app_engine_id
 from gcloud._helpers import _compute_engine_id
+from gcloud.client import Client as _BaseClient
 from gcloud.datastore import helpers
 from gcloud.datastore.connection import Connection
 from gcloud.datastore.batch import Batch
@@ -158,7 +159,7 @@ def _extended_lookup(connection, dataset_id, key_pbs,
     return results
 
 
-class Client(object):
+class Client(_BaseClient):
     """Convenience wrapper for invoking APIs/factories w/ a dataset ID.
 
     :type dataset_id: string
@@ -167,20 +168,29 @@ class Client(object):
     :type namespace: string
     :param namespace: (optional) namespace to pass to proxied API methods.
 
-    :type connection: :class:`gcloud.datastore.connection.Connection`, or None
-    :param connection: (optional) connection to pass to proxied API methods
-    """
+    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
+                       :class:`NoneType`
+    :param credentials: The OAuth2 Credentials to use for the connection
+                        owned by this client. If not passed (and if no ``http``
+                        object is passed), falls back to the default inferred
+                        from the environment.
 
-    def __init__(self, dataset_id=None, namespace=None, connection=None):
+    :type http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param http: An optional HTTP object to make requests. If not passed, an
+                 ``http`` object is created that is bound to the
+                 ``credentials`` for the current object.
+    """
+    _connection_class = Connection
+
+    def __init__(self, dataset_id=None, namespace=None,
+                 credentials=None, http=None):
         dataset_id = _determine_default_dataset_id(dataset_id)
         if dataset_id is None:
             raise EnvironmentError('Dataset ID could not be inferred.')
         self.dataset_id = dataset_id
-        if connection is None:
-            connection = Connection.from_environment()
-        self.connection = connection
-        self._batch_stack = _LocalStack()
         self.namespace = namespace
+        self._batch_stack = _LocalStack()
+        super(Client, self).__init__(credentials, http)
 
     def _push_batch(self, batch):
         """Push a batch/transaction onto our stack.

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -861,24 +861,6 @@ def _compare_key_pb_after_request(test, key_before, key_after):
         test.assertEqual(elt1, elt2)
 
 
-class _Connection(object):
-    _called_with = None
-    _missing = _deferred = ()
-
-    def __init__(self, *result):
-        self._result = list(result)
-
-    def lookup(self, **kw):
-        self._called_with = kw
-        return self._result, self._missing[:], self._deferred[:]
-
-    def allocate_ids(self, dataset_id, key_pbs):
-        self._called_dataset_id = dataset_id
-        self._called_key_pbs = key_pbs
-        num_pbs = len(key_pbs)
-        return [_KeyProto(i) for i in list(range(num_pbs))]
-
-
 class _PathElementProto(object):
 
     def __init__(self, _id):


### PR DESCRIPTION
Supersedes #955.