### PR TITLE
Manually pinning logilab-common<=0.63.0.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ commands =
 deps =
     pep8
     -ehg+https://bitbucket.org/logilab/pylint@33e334be064c#egg=pylint
+    logilab-common<=0.63.0  # Hack for pylint upstream
     unittest2
     protobuf==3.0.0-alpha-1
 passenv = {[testenv:system-tests]passenv}


### PR DESCRIPTION
This is to make it so that we have continued support of pylint upstream (hopefully they cut a release soon).

They mentioned that they'd cut a release around July 17 on the PR that added support for docstring checking.

@tseaver FYI after we merge you should rebase your PRs on top of this.