### PR TITLE
Using caption with different toc sections instead of JS/CSS hack.

### DIFF
--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -862,6 +862,18 @@ h2 .headerlink:hover {
     margin-top: 2em;
 }
 
+.side-nav > ul > li.toctree-l1 {
+    padding-left: 2em;
+}
+
+p.caption {
+    padding-left: 2em;
+}
+
+span.caption-text {
+    font-weight: bold;
+}
+
 .external-links img {
     margin-right: 0.3em;
     opacity: 0.3;

--- a/docs/_static/js/main.js
+++ b/docs/_static/js/main.js
@@ -13,16 +13,6 @@ $('.headerlink').parent().each(function() {
   );
 });
 
-$('.side-nav').children('ul:nth-child(2)').children().each(function() {
-  var itemName = $(this).text();
-    if (itemName !== 'Datastore' &&
-        itemName !== 'Storage' &&
-        itemName !== 'Pub/Sub' &&
-        itemName !== 'BigQuery') {
-      $(this).css('padding-left','2em');
-  }
-});
-
 var apiQsSection;
 // don't even ask me why
 if ($('#cloud-datastore-in-10-seconds').length)

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -127,7 +127,6 @@ http://googlecloudplatform.github.io/gcloud-ruby/docs/latest" title="Ruby docs p
         {% block body %} {% endblock %}
       </section><!-- end of .content -->
       <nav class="side-nav">
-        <ul><li><a href="{{ pathto('index') }}">gcloud</a></li></ul>
         {{ toctree(includehidden=True, maxdepth=1, titles_only=True) }}
         <ul class="external-links">
           <li>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,12 @@ from pkg_resources import get_distribution
 import sys
 import urllib
 
+import sphinx_rtd_theme
+
+
+ON_READ_THE_DOCS = os.environ.get('READTHEDOCS', None) == 'True'
+LOCAL_READ_THE_DOCS = os.environ.get('LOCAL_RTD', None) == 'True'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -38,7 +44,10 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+if ON_READ_THE_DOCS or LOCAL_READ_THE_DOCS:
+  templates_path = []
+else:
+  templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -103,10 +112,10 @@ pygments_style = 'sphinx'
 
 html_theme = 'classic'
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-  html_style = 'default.css'
-else:
+if LOCAL_READ_THE_DOCS:
+  html_theme = 'sphinx_rtd_theme'
+  html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+elif not ON_READ_THE_DOCS:
   html_style = 'css/main.css'
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,15 @@
 .. toctree::
   :maxdepth: 0
   :hidden:
+  :caption: gcloud
 
   gcloud-api
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
+  :caption: Datastore
+
   datastore-overview
   datastore-client
   datastore-entities
@@ -10,14 +17,32 @@
   datastore-queries
   datastore-transactions
   datastore-batches
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
+  :caption: Storage
+
   storage-api
   storage-blobs
   storage-buckets
   storage-acl
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
+  :caption: Pub/Sub
+
   pubsub-api
   pubsub-usage
   pubsub-topic
   pubsub-subscription
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
+  :caption: BigQuery
+
   bigquery-usage
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     Sphinx
-passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE
+passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD
 
 [pep8]
 exclude = gcloud/datastore/_datastore_v1_pb2.py,docs/conf.py


### PR DESCRIPTION
Using caption with different toc sections instead of JS/CSS hack.
    
This fits within the Sphinx construct and would allow our docs to be built on readthedocs.org.

----

Building with `tox -e docs` we get:

![screen_shot_014](https://cloud.githubusercontent.com/assets/520669/9016262/6f8087ae-3784-11e5-996b-5a276292af6f.png)

----

Building with `LOCAL_RTD=True tox -e docs` we get:

![screen_shot_015](https://cloud.githubusercontent.com/assets/520669/9016269/82f6e832-3784-11e5-8e99-75c6dc1fde89.png)

AFAICT, by using `:titlesonly:` and some other rules we can get rid of the expandable sections (or just not use h1, or change maxdepth).