### PR TITLE
Switching to readthedocs naming conventions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Google Cloud Python Client
 -  `API Documentation`_
 
 .. _Homepage: https://googlecloudplatform.github.io/gcloud-python/
-.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/latest/
+.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/stable/
 
 This client supports the following Google Cloud Platform services:
 
@@ -55,7 +55,7 @@ consistency for all other queries.
 See the ``gcloud-python`` API `datastore documentation`_ to learn how to
 interact with the Cloud Datastore using this Client Library.
 
-.. _datastore documentation: https://googlecloudplatform.github.io/gcloud-python/latest/datastore-api.html
+.. _datastore documentation: https://googlecloudplatform.github.io/gcloud-python/stable/datastore-api.html
 
 See the `official Google Cloud Datastore documentation`_ for more details on how
 to activate Cloud Datastore for your project.
@@ -90,7 +90,7 @@ be used to distribute large data objects to users via direct download.
 See the ``gcloud-python`` API `storage documentation`_ to learn how to connect
 to Cloud Storage using this Client Library.
 
-.. _storage documentation: https://googlecloudplatform.github.io/gcloud-python/latest/storage-api.html
+.. _storage documentation: https://googlecloudplatform.github.io/gcloud-python/stable/storage-api.html
 
 You need to create a Google Cloud Storage bucket to use this client library.
 Follow along with the `official Google Cloud Storage documentation`_ to learn

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -40,16 +40,16 @@ CURRENT_VERSION=$(.tox/docs/bin/python scripts/get_version.py)
 # Update gh-pages with the created docs.
 cd ${GH_PAGES_DIR}
 if [[ -z "${TRAVIS_TAG}" ]]; then
-    git rm -fr master/
-    cp -R ../docs/_build/html/ master/
+    git rm -fr latest/
+    cp -R ../docs/_build/html/ latest/
 else
     if [[ -d ${CURRENT_VERSION} ]]; then
         echo "The directory ${CURRENT_VERSION} already exists."
         exit 1
     fi
-    git rm -fr latest/
-    # Put the new release in latest and with the actual version.
-    cp -R ../docs/_build/html/ latest/
+    git rm -fr stable/
+    # Put the new release in stable and with the actual version.
+    cp -R ../docs/_build/html/ stable/
     cp -R ../docs/_build/html/ "${CURRENT_VERSION}/"
 
     # Also update the versions file.

--- a/scripts/versions.html.template
+++ b/scripts/versions.html.template
@@ -59,7 +59,7 @@ https://googlecloudplatform.github.io/gcloud-node" title="Node.js docs page">
 
       </section><!-- end of .content -->
       <nav class="side-nav">
-        <ul><li><a href="latest/index.html">Documentation</a></li></ul>
+        <ul><li><a href="stable/index.html">Documentation</a></li></ul>
         <ul class="simple">
 </ul>
 


### PR DESCRIPTION
We've noticed that "latest" is expected to be the TIP rather than the latest stable release.

As described by READTHEDOCS:
    https://docs.readthedocs.org/en/latest/versions.html
latest should indeed refer to TIP and instead of using latest for the last release, use "stable".

NOTE: This can't be merged until the docs are renamed in gh-pages branch. PR forthcoming.