### PR TITLE
Removing classic theme from Sphinx conf.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,8 +110,6 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'classic'
-
 if LOCAL_READ_THE_DOCS:
   html_theme = 'sphinx_rtd_theme'
   html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
This was preventing readthedocs.org from using the latest theme.

See #1025 for some context.