### PR TITLE
Add tabledata API methods

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -558,6 +558,14 @@ class Table(object):
         See:
         https://cloud.google.com/bigquery/reference/rest/v2/tabledata/list
 
+        .. note::
+
+           This method assumes that its instance's ``schema`` attribute is
+           up-to-date with the schema as defined on the back-end:  if the
+           two schemas are not identical, the values returned may be
+           incomplete.  To ensure that the local copy of the schema is
+           up-to-date, call the table's ``reload`` method.
+
         :type max_results: integer or ``NoneType``
         :param max_results: maximum number of rows to return.
 

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -598,7 +598,7 @@ class Table(object):
                 value = cell['v']
                 converter = _CELLDATA_FROM_JSON.get(field.field_type)
                 if converter is not None:
-                    value = converter(value)
+                    value = converter(value, field)
                 row_data.append(value)
             rows_data.append(tuple(row_data))
 
@@ -676,19 +676,39 @@ class Table(object):
         return errors
 
 
-def _bool_from_json(value):
+def _int_from_json(value, field):  # pylint: disable=unused-argument
+    return int(value)
+
+
+def _float_from_json(value, field):  # pylint: disable=unused-argument
+    return float(value)
+
+
+def _bool_from_json(value, field):  # pylint: disable=unused-argument
     return value.lower() in ['t', 'true', '1']
 
 
-def _datetime_from_json(value):
+def _datetime_from_json(value, field):  # pylint: disable=unused-argument
     return _datetime_from_prop(float(value))
 
 
+def _record_from_json(value, field):
+    record = {}
+    for subfield, cell in zip(field.fields, value['f']):
+        value = cell['v']
+        converter = _CELLDATA_FROM_JSON.get(subfield.field_type)
+        if converter is not None:
+            value = converter(value, subfield)
+        record[subfield.name] = value
+    return record
+
+
 _CELLDATA_FROM_JSON = {
-    'INTEGER': int,
-    'FLOAT': float,
+    'INTEGER': _int_from_json,
+    'FLOAT': _float_from_json,
     'BOOLEAN': _bool_from_json,
     'TIMESTAMP': _datetime_from_json,
+    'RECORD': _record_from_json,
 }
 
 _JSON_FROM_CELLDATA = {

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -613,7 +613,7 @@ class Table(object):
         """API call:  insert table data via a POST request
 
         See:
-        https://cloud.google.com/bigquery/reference/rest/v2/tabledata/list
+        https://cloud.google.com/bigquery/reference/rest/v2/tabledata/insertAll
 
         :type rows: list of tuples
         :param rows: row data to be inserted

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -552,7 +552,7 @@ class Table(object):
         client = self._require_client(client)
         client.connection.api_request(method='DELETE', path=self.path)
 
-    def data(self, max_results=None, page_token=None, client=None):
+    def fetch_data(self, max_results=None, page_token=None, client=None):
         """API call:  fetch the table data via a GET request
 
         See:
@@ -604,12 +604,12 @@ class Table(object):
 
         return rows_data, total_rows, page_token
 
-    def insert_all(self,
-                   rows,
-                   row_ids=None,
-                   skip_invalid_rows=None,
-                   ignore_unknown_values=None,
-                   client=None):
+    def insert_data(self,
+                    rows,
+                    row_ids=None,
+                    skip_invalid_rows=None,
+                    ignore_unknown_values=None,
+                    client=None):
         """API call:  insert table data via a POST request
 
         See:

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -647,9 +647,8 @@ class Table(object):
             row_info = {}
 
             for field, value in zip(self._schema, row):
-                converter = _JSON_FROM_CELLDATA.get(field.field_type)
-                if converter is not None:
-                    value = converter(value)
+                if field.field_type == 'TIMESTAMP':
+                    value = _prop_from_datetime(value)
                 row_info[field.name] = value
 
             info = {'json': row_info}
@@ -725,8 +724,4 @@ _CELLDATA_FROM_JSON = {
     'TIMESTAMP': _datetime_from_json,
     'RECORD': _record_from_json,
     'STRING': _string_from_json,
-}
-
-_JSON_FROM_CELLDATA = {
-    'TIMESTAMP': _prop_from_datetime,
 }

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -676,31 +676,40 @@ class Table(object):
         return errors
 
 
-def _int_from_json(value, field):  # pylint: disable=unused-argument
-    return int(value)
+def _not_null(value, field):
+    return value is not None or field.mode != 'NULLABLE'
 
 
-def _float_from_json(value, field):  # pylint: disable=unused-argument
-    return float(value)
+def _int_from_json(value, field):
+    if _not_null(value, field):
+        return int(value)
 
 
-def _bool_from_json(value, field):  # pylint: disable=unused-argument
-    return value.lower() in ['t', 'true', '1']
+def _float_from_json(value, field):
+    if _not_null(value, field):
+        return float(value)
 
 
-def _datetime_from_json(value, field):  # pylint: disable=unused-argument
-    return _datetime_from_prop(float(value))
+def _bool_from_json(value, field):
+    if _not_null(value, field):
+        return value.lower() in ['t', 'true', '1']
+
+
+def _datetime_from_json(value, field):
+    if _not_null(value, field):
+        return _datetime_from_prop(float(value))
 
 
 def _record_from_json(value, field):
-    record = {}
-    for subfield, cell in zip(field.fields, value['f']):
-        value = cell['v']
-        converter = _CELLDATA_FROM_JSON.get(subfield.field_type)
-        if converter is not None:
-            value = converter(value, subfield)
-        record[subfield.name] = value
-    return record
+    if _not_null(value, field):
+        record = {}
+        for subfield, cell in zip(field.fields, value['f']):
+            value = cell['v']
+            converter = _CELLDATA_FROM_JSON.get(subfield.field_type)
+            if converter is not None:
+                value = converter(value, subfield)
+            record[subfield.name] = value
+        return record
 
 
 _CELLDATA_FROM_JSON = {

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -596,7 +596,11 @@ class Table(object):
             row_data = []
             for field, cell in zip(self._schema, row['f']):
                 converter = _CELLDATA_FROM_JSON[field.field_type]
-                row_data.append(converter(cell['v'], field))
+                if field.mode == 'REPEATED':
+                    row_data.append([converter(item, field)
+                                     for item in cell['v']])
+                else:
+                    row_data.append(converter(cell['v'], field))
             rows_data.append(tuple(row_data))
 
         return rows_data, total_rows, page_token
@@ -702,7 +706,11 @@ def _record_from_json(value, field):
         record = {}
         for subfield, cell in zip(field.fields, value['f']):
             converter = _CELLDATA_FROM_JSON[subfield.field_type]
-            record[subfield.name] = converter(cell['v'], subfield)
+            if field.mode == 'REPEATED':
+                value = [converter(item, field) for item in cell['v']]
+            else:
+                value = converter(cell['v'], field)
+            record[subfield.name] = value
         return record
 
 

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -850,28 +850,28 @@ class TestTable(unittest2.TestCase):
         ROWS = 1234
         TOKEN = 'TOKEN'
         DATA = {
-            "totalRows": ROWS,
-            "pageToken": TOKEN,
-            "rows": [
-                {"f": [
-                    {"v": "Phred Phlyntstone"},
-                    {"v": "32"},
-                    {"v": _prop_from_datetime(WHEN)},
+            'totalRows': ROWS,
+            'pageToken': TOKEN,
+            'rows': [
+                {'f': [
+                    {'v': 'Phred Phlyntstone'},
+                    {'v': '32'},
+                    {'v': _prop_from_datetime(WHEN)},
                 ]},
-                {"f": [
-                    {"v": "Bharney Rhubble"},
-                    {"v": "33"},
-                    {"v": _prop_from_datetime(WHEN_1)},
+                {'f': [
+                    {'v': 'Bharney Rhubble'},
+                    {'v': '33'},
+                    {'v': _prop_from_datetime(WHEN_1)},
                 ]},
-                {"f": [
-                    {"v": "Wylma Phlyntstone"},
-                    {"v": "29"},
-                    {"v": _prop_from_datetime(WHEN_2)},
+                {'f': [
+                    {'v': 'Wylma Phlyntstone'},
+                    {'v': '29'},
+                    {'v': _prop_from_datetime(WHEN_2)},
                 ]},
-                {"f": [
-                    {"v": "Bhettye Rhubble"},
-                    {"v": None},
-                    {"v": None},
+                {'f': [
+                    {'v': 'Bhettye Rhubble'},
+                    {'v': None},
+                    {'v': None},
                 ]},
             ]
         }
@@ -907,31 +907,31 @@ class TestTable(unittest2.TestCase):
         ROWS = 1234
         TOKEN = 'TOKEN'
         DATA = {
-            "totalRows": ROWS,
-            "rows": [
-                {"f": [
-                    {"v": "Phred Phlyntstone"},
-                    {"v": "32"},
-                    {"v": "true"},
-                    {"v": "3.1415926"},
+            'totalRows': ROWS,
+            'rows': [
+                {'f': [
+                    {'v': 'Phred Phlyntstone'},
+                    {'v': '32'},
+                    {'v': 'true'},
+                    {'v': '3.1415926'},
                 ]},
-                {"f": [
-                    {"v": "Bharney Rhubble"},
-                    {"v": "33"},
-                    {"v": "false"},
-                    {"v": "1.414"},
+                {'f': [
+                    {'v': 'Bharney Rhubble'},
+                    {'v': '33'},
+                    {'v': 'false'},
+                    {'v': '1.414'},
                 ]},
-                {"f": [
-                    {"v": "Wylma Phlyntstone"},
-                    {"v": "29"},
-                    {"v": "true"},
-                    {"v": "2.71828"},
+                {'f': [
+                    {'v': 'Wylma Phlyntstone'},
+                    {'v': '29'},
+                    {'v': 'true'},
+                    {'v': '2.71828'},
                 ]},
-                {"f": [
-                    {"v": "Bhettye Rhubble"},
-                    {"v": "27"},
-                    {"v": None},
-                    {"v": None},
+                {'f': [
+                    {'v': 'Bhettye Rhubble'},
+                    {'v': '27'},
+                    {'v': None},
+                    {'v': None},
                 ]},
             ]
         }
@@ -974,20 +974,20 @@ class TestTable(unittest2.TestCase):
         ROWS = 1234
         TOKEN = 'TOKEN'
         DATA = {
-            "totalRows": ROWS,
-            "pageToken": TOKEN,
-            "rows": [
-                {"f": [
-                    {"v": "Phred Phlyntstone"},
-                    {"v": {"f": [{"v": "800"}, {"v": "555-1212"}, {"v": 1}]}},
+            'totalRows': ROWS,
+            'pageToken': TOKEN,
+            'rows': [
+                {'f': [
+                    {'v': 'Phred Phlyntstone'},
+                    {'v': {'f': [{'v': '800'}, {'v': '555-1212'}, {'v': 1}]}},
                 ]},
-                {"f": [
-                    {"v": "Bharney Rhubble"},
-                    {"v": {"f": [{"v": "877"}, {"v": "768-5309"}, {"v": 2}]}},
+                {'f': [
+                    {'v': 'Bharney Rhubble'},
+                    {'v': {'f': [{'v': '877'}, {'v': '768-5309'}, {'v': 2}]}},
                 ]},
-                {"f": [
-                    {"v": "Wylma Phlyntstone"},
-                    {"v": None},
+                {'f': [
+                    {'v': 'Wylma Phlyntstone'},
+                    {'v': None},
                 ]},
             ]
         }

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -1043,10 +1043,10 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
         ROWS = [
-            ("Phred Phlyntstone", 32, WHEN),
-            ("Bharney Rhubble", 33, WHEN + datetime.timedelta(seconds=1)),
-            ("Wylma Phlyntstone", 29, WHEN + datetime.timedelta(seconds=2)),
-            ("Bhettye Rhubble", 27, None),
+            ('Phred Phlyntstone', 32, WHEN),
+            ('Bharney Rhubble', 33, WHEN + datetime.timedelta(seconds=1)),
+            ('Wylma Phlyntstone', 29, WHEN + datetime.timedelta(seconds=2)),
+            ('Bhettye Rhubble', 27, None),
         ]
 
         def _row_data(row):
@@ -1092,10 +1092,10 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, voter])
         ROWS = [
-            ("Phred Phlyntstone", 32, True),
-            ("Bharney Rhubble", 33, False),
-            ("Wylma Phlyntstone", 29, True),
-            ("Bhettye Rhubble", 27, True),
+            ('Phred Phlyntstone', 32, True),
+            ('Bharney Rhubble', 33, False),
+            ('Wylma Phlyntstone', 29, True),
+            ('Bhettye Rhubble', 27, True),
         ]
 
         def _row_data(row):
@@ -1144,13 +1144,13 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, phone])
         ROWS = [
-            ("Phred Phlyntstone", {'area_code': '800',
+            ('Phred Phlyntstone', {'area_code': '800',
                                    'local_number': '555-1212',
                                    'rank': 1}),
-            ("Bharney Rhubble", {'area_code': '877',
+            ('Bharney Rhubble', {'area_code': '877',
                                  'local_number': '768-5309',
                                  'rank': 2}),
-            ("Wylma Phlyntstone", None),
+            ('Wylma Phlyntstone', None),
         ]
 
         def _row_data(row):

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -835,7 +835,7 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(req['method'], 'DELETE')
         self.assertEqual(req['path'], '/%s' % PATH)
 
-    def test_data_w_bound_client(self):
+    def test_fetch_data_w_bound_client(self):
         import datetime
         import pytz
         from gcloud.bigquery.table import SchemaField
@@ -885,7 +885,7 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
 
-        rows, total_rows, page_token = table.data()
+        rows, total_rows, page_token = table.fetch_data()
 
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0], ('Phred Phlyntstone', 32, WHEN))
@@ -900,7 +900,7 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % PATH)
 
-    def test_data_w_alternate_client(self):
+    def test_fetch_data_w_alternate_client(self):
         from gcloud.bigquery.table import SchemaField
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
@@ -943,9 +943,9 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, voter])
 
-        rows, total_rows, page_token = table.data(client=client2,
-                                                  max_results=MAX,
-                                                  page_token=TOKEN)
+        rows, total_rows, page_token = table.fetch_data(client=client2,
+                                                        max_results=MAX,
+                                                        page_token=TOKEN)
 
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0], ('Phred Phlyntstone', 32, True))
@@ -963,7 +963,7 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(req['query_params'],
                          {'maxResults': MAX, 'pageToken': TOKEN})
 
-    def test_insert_all_w_bound_client(self):
+    def test_insert_data_w_bound_client(self):
         import datetime
         import pytz
         from gcloud.bigquery._helpers import _prop_from_datetime
@@ -997,7 +997,7 @@ class TestTable(unittest2.TestCase):
             'rows': [{'json': _row_data(row)} for row in ROWS],
         }
 
-        errors = table.insert_all(ROWS)
+        errors = table.insert_data(ROWS)
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)
@@ -1006,7 +1006,7 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
         self.assertEqual(req['data'], SENT)
 
-    def test_insert_all_w_alternate_client(self):
+    def test_insert_data_w_alternate_client(self):
         from gcloud.bigquery.table import SchemaField
         PATH = 'projects/%s/datasets/%s/tables/%s/insertAll' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
@@ -1047,7 +1047,7 @@ class TestTable(unittest2.TestCase):
                      for index, row in enumerate(ROWS)],
         }
 
-        errors = table.insert_all(
+        errors = table.insert_data(
             client=client2,
             rows=ROWS,
             row_ids=[index for index, _ in enumerate(ROWS)],

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -623,7 +623,7 @@ class TestTable(unittest2.TestCase):
         dataset = _Dataset(client1)
         table = self._makeOne(self.TABLE_NAME, dataset=dataset)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
-        age = SchemaField('age', 'INTEGER', mode='OPTIONAL')
+        age = SchemaField('age', 'INTEGER', mode='NULLABLE')
 
         table.patch(client=client2, view_query=QUERY, location=LOCATION,
                     expires=self.EXP_TIME, schema=[full_name, age])
@@ -639,7 +639,7 @@ class TestTable(unittest2.TestCase):
             'expirationTime': _millis(self.EXP_TIME),
             'schema': {'fields': [
                 {'name': 'full_name', 'type': 'STRING', 'mode': 'REQUIRED'},
-                {'name': 'age', 'type': 'INTEGER', 'mode': 'OPTIONAL'}]},
+                {'name': 'age', 'type': 'INTEGER', 'mode': 'NULLABLE'}]},
         }
         self.assertEqual(req['data'], SENT)
         self._verifyResourceProperties(table, RESOURCE)
@@ -794,6 +794,238 @@ class TestTable(unittest2.TestCase):
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'DELETE')
         self.assertEqual(req['path'], '/%s' % PATH)
+
+    def test_data_w_bound_client(self):
+        import datetime
+        import pytz
+        from gcloud.bigquery.table import SchemaField
+        from gcloud.bigquery._helpers import _prop_from_datetime
+        PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
+            self.PROJECT, self.DS_NAME, self.TABLE_NAME)
+        WHEN_TS = 1437767599.006
+        WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(
+            tzinfo=pytz.UTC)
+        WHEN_1 = WHEN + datetime.timedelta(seconds=1)
+        WHEN_2 = WHEN + datetime.timedelta(seconds=2)
+        WHEN_3 = WHEN + datetime.timedelta(seconds=3)
+        ROWS = 1234
+        TOKEN = 'TOKEN'
+        DATA = {
+            "totalRows": ROWS,
+            "pageToken": TOKEN,
+            "rows": [
+                {"f": [
+                    {"v": "Phred Phlyntstone"},
+                    {"v": "32"},
+                    {"v": _prop_from_datetime(WHEN)},
+                ]},
+                {"f": [
+                    {"v": "Bharney Rhubble"},
+                    {"v": "33"},
+                    {"v": _prop_from_datetime(WHEN_1)},
+                ]},
+                {"f": [
+                    {"v": "Wylma Phlyntstone"},
+                    {"v": "29"},
+                    {"v": _prop_from_datetime(WHEN_2)},
+                ]},
+                {"f": [
+                    {"v": "Bhettye Rhubble"},
+                    {"v": "27"},
+                    {"v": _prop_from_datetime(WHEN_3)},
+                ]},
+            ]
+        }
+        conn = _Connection(DATA)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
+        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+                              schema=[full_name, age, joined])
+
+        rows, total_rows, page_token = table.data()
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[0], ('Phred Phlyntstone', 32, WHEN))
+        self.assertEqual(rows[1], ('Bharney Rhubble', 33, WHEN_1))
+        self.assertEqual(rows[2], ('Wylma Phlyntstone', 29, WHEN_2))
+        self.assertEqual(rows[3], ('Bhettye Rhubble', 27, WHEN_3))
+        self.assertEqual(total_rows, ROWS)
+        self.assertEqual(page_token, TOKEN)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'GET')
+        self.assertEqual(req['path'], '/%s' % PATH)
+
+    def test_data_w_alternate_client(self):
+        from gcloud.bigquery.table import SchemaField
+        PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
+            self.PROJECT, self.DS_NAME, self.TABLE_NAME)
+        MAX = 10
+        ROWS = 1234
+        TOKEN = 'TOKEN'
+        DATA = {
+            "totalRows": ROWS,
+            "rows": [
+                {"f": [
+                    {"v": "Phred Phlyntstone"},
+                    {"v": "32"},
+                    {"v": "true"},
+                ]},
+                {"f": [
+                    {"v": "Bharney Rhubble"},
+                    {"v": "33"},
+                    {"v": "false"},
+                ]},
+                {"f": [
+                    {"v": "Wylma Phlyntstone"},
+                    {"v": "29"},
+                    {"v": "true"},
+                ]},
+                {"f": [
+                    {"v": "Bhettye Rhubble"},
+                    {"v": "27"},
+                    {"v": "true"},
+                ]},
+            ]
+        }
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        conn2 = _Connection(DATA)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        dataset = _Dataset(client1)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
+        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+                              schema=[full_name, age, voter])
+
+        rows, total_rows, page_token = table.data(client=client2,
+                                                  max_results=MAX,
+                                                  page_token=TOKEN)
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[0], ('Phred Phlyntstone', 32, True))
+        self.assertEqual(rows[1], ('Bharney Rhubble', 33, False))
+        self.assertEqual(rows[2], ('Wylma Phlyntstone', 29, True))
+        self.assertEqual(rows[3], ('Bhettye Rhubble', 27, True))
+        self.assertEqual(total_rows, ROWS)
+        self.assertEqual(page_token, None)
+
+        self.assertEqual(len(conn1._requested), 0)
+        self.assertEqual(len(conn2._requested), 1)
+        req = conn2._requested[0]
+        self.assertEqual(req['method'], 'GET')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['query_params'],
+                         {'maxResults': MAX, 'pageToken': TOKEN})
+
+    def test_insert_all_w_bound_client(self):
+        import datetime
+        import pytz
+        from gcloud.bigquery._helpers import _prop_from_datetime
+        from gcloud.bigquery.table import SchemaField
+        WHEN_TS = 1437767599.006
+        WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(
+            tzinfo=pytz.UTC)
+        PATH = 'projects/%s/datasets/%s/tables/%s/insertAll' % (
+            self.PROJECT, self.DS_NAME, self.TABLE_NAME)
+        conn = _Connection({})
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
+        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+                              schema=[full_name, age, joined])
+        ROWS = [
+            ("Phred Phlyntstone", 32, WHEN),
+            ("Bharney Rhubble", 33, WHEN + datetime.timedelta(seconds=1)),
+            ("Wylma Phlyntstone", 29, WHEN + datetime.timedelta(seconds=2)),
+            ("Bhettye Rhubble", 27, WHEN + datetime.timedelta(seconds=3)),
+        ]
+
+        def _row_data(row):
+            return {'full_name': row[0],
+                    'age': row[1],
+                    'joined': _prop_from_datetime(row[2])}
+
+        SENT = {
+            'rows': [{'json': _row_data(row)} for row in ROWS],
+        }
+
+        errors = table.insert_all(ROWS)
+
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['data'], SENT)
+
+    def test_insert_all_w_alternate_client(self):
+        from gcloud.bigquery.table import SchemaField
+        PATH = 'projects/%s/datasets/%s/tables/%s/insertAll' % (
+            self.PROJECT, self.DS_NAME, self.TABLE_NAME)
+        RESPONSE = {
+            'insertErrors': [
+                {'index': 1,
+                 'errors': [
+                     {'reason': 'REASON',
+                      'location': 'LOCATION',
+                      'debugInfo': 'INFO',
+                      'message': 'MESSAGE'}
+                 ]},
+            ]}
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        conn2 = _Connection(RESPONSE)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        dataset = _Dataset(client1)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
+        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+                              schema=[full_name, age, voter])
+        ROWS = [
+            ("Phred Phlyntstone", 32, True),
+            ("Bharney Rhubble", 33, False),
+            ("Wylma Phlyntstone", 29, True),
+            ("Bhettye Rhubble", 27, True),
+        ]
+
+        def _row_data(row):
+            return {'full_name': row[0], 'age': row[1], 'voter': row[2]}
+
+        SENT = {
+            'skipInvalidRows': True,
+            'ignoreUnknownValues': True,
+            'rows': [{'insertId': index, 'json': _row_data(row)}
+                     for index, row in enumerate(ROWS)],
+        }
+
+        errors = table.insert_all(
+            client=client2,
+            rows=ROWS,
+            row_ids=[index for index, _ in enumerate(ROWS)],
+            skip_invalid_rows=True,
+            ignore_unknown_values=True)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['index'], 1)
+        self.assertEqual(len(errors[0]['errors']), 1)
+        self.assertEqual(errors[0]['errors'][0],
+                         RESPONSE['insertErrors'][0]['errors'][0])
+
+        self.assertEqual(len(conn1._requested), 0)
+        self.assertEqual(len(conn2._requested), 1)
+        req = conn2._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['data'], SENT)
 
 
 class _Client(object):


### PR DESCRIPTION
- Add `Table.insert_all()` and `Table.data` for synchronous load / browse.
- Ensure that `Table.schema` is re-populated from server responses.
