### PR TITLE
Drops unnecessary "Python" title in docs.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -107,8 +107,6 @@ http://googlecloudplatform.github.io/gcloud-ruby/docs/latest" title="Ruby docs p
       <article class="main lang-page" role="main">
 
       <header class="docs-header">
-        <h1 class="page-title">Python</h1>
-
           <div class="versions">
             <a href="/gcloud-python/versions.html" class="v-btn">
               <img src="_static/images/icon-arrow-bullet.svg" />


### PR DESCRIPTION
Fixes #538.