### PR TITLE
Putting external links in toctree.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -128,32 +128,6 @@ http://googlecloudplatform.github.io/gcloud-ruby/docs/latest" title="Ruby docs p
       </section><!-- end of .content -->
       <nav class="side-nav">
         {{ toctree(includehidden=True, maxdepth=1, titles_only=True) }}
-        <ul class="external-links">
-          <li>
-            <a href="https://github.com/GoogleCloudPlatform/gcloud-python/" title="Python on Github">
-              <img src="{{ pathto('_static/images/icon-link-github.svg', 1) }}" alt="Github icon" />
-              Github
-            </a>
-          </li>
-          <li>
-            <a href="https://github.com/GoogleCloudPlatform/gcloud-python/issues" title="Python issues on Github">
-              <img src="{{ pathto('_static/images/icon-link-github.svg', 1) }}" alt="Github icon" />
-              Issues
-            </a>
-          </li>
-          <li>
-            <a href="http://stackoverflow.com/questions/tagged/gcloud-python" title="gcloud on StackOverflow">
-              <img src="{{ pathto('_static/images/icon-link-stackoverflow.svg', 1) }}" alt="StackOverflow icon" />
-              gcloud
-            </a>
-          </li>
-          <li>
-            <a href="https://pypi.python.org/pypi/gcloud" title="Python package manager">
-              <img src="{{ pathto('_static/images/icon-link-package-manager.svg', 1) }}" alt="Package Manager icon" />
-              Package Manager
-            </a>
-          </li>
-        </ul>
       </nav><!-- end of .side-nav -->
     </article><!-- end of .main -->
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,15 @@
 
   bigquery-usage
 
+.. toctree::
+  :maxdepth: 0
+  :hidden:
+  :caption: External Links
+
+  GitHub <https://github.com/GoogleCloudPlatform/gcloud-python/>
+  Issues <https://github.com/GoogleCloudPlatform/gcloud-python/issues>
+  Stack Overflow <http://stackoverflow.com/questions/tagged/gcloud-python>
+  PyPI <https://pypi.python.org/pypi/gcloud>
 
 Getting started
 ---------------


### PR DESCRIPTION
This is to bring the readthedocs version and custom layout closer together. (Maybe they can converge?)

Before:

![screen_shot_005](https://cloud.githubusercontent.com/assets/520669/9103385/9f71d706-3bb2-11e5-8519-44053a8cb6e0.png)

After:

![screen_shot_004](https://cloud.githubusercontent.com/assets/520669/9103377/8bc828f4-3bb2-11e5-9b8c-aafbdd0fc179.png)
