### PR TITLE
Add Dataset access support

### DIFF
--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -278,7 +278,7 @@ class Dataset(object):
         return client
 
     def _parse_access_grants(self, access):
-        """Parse a resource fragment into a schema field.
+        """Parse a resource fragment into a set of access grants.
 
         :type access: list of mappings
         :param access: each mapping represents a single access grant

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -38,7 +38,7 @@ class AccessGrant(object):
         self.entity_type = entity_type
         self.entity_id = entity_id
 
-    def __repr__(self):  # pragma: NO COVER
+    def __repr__(self):
         return '<AccessGrant: role=%s, %s=%s>' % (
             self.role, self.entity_type, self.entity_id)
 

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -290,9 +290,9 @@ class Dataset(object):
         for grant in access:
             grant = grant.copy()
             role = grant.pop('role')
-            entity_type, entity_id = grant.items()[0]
+            entity_type, entity_id = list(grant.items())[0]
             result.append(
-                AccessGrant(role, entity_type, grant[entity_type]))
+                AccessGrant(role, entity_type, entity_id))
         return result
 
     def _set_properties(self, api_response):

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -288,13 +288,9 @@ class Dataset(object):
         """
         result = []
         for grant in access:
-            role = grant['role']
-            if 'specialGroup' in grant:
-                entity_type = 'specialGroup'
-            elif 'groupByEmail' in grant:
-                entity_type = 'groupByEmail'
-            else:
-                entity_type = 'userByEmail'
+            grant = grant.copy()
+            role = grant.pop('role')
+            entity_type, entity_id = grant.items()[0]
             result.append(
                 AccessGrant(role, entity_type, grant[entity_type]))
         return result

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -290,9 +290,12 @@ class Dataset(object):
         for grant in access:
             grant = grant.copy()
             role = grant.pop('role')
-            entity_type, entity_id = list(grant.items())[0]
-            result.append(
-                AccessGrant(role, entity_type, entity_id))
+            # Hypothetical case:  we don't know that the back-end will ever
+            # return such structures, but they are logical.  See:
+            #https://github.com/GoogleCloudPlatform/gcloud-python/pull/1046#discussion_r36687769
+            for entity_type, entity_id in grant.items():
+                result.append(
+                    AccessGrant(role, entity_type, entity_id))
         return result
 
     def _set_properties(self, api_response):

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -91,7 +91,7 @@ class Dataset(object):
         :rtype: list of :class:`AccessGrant`
         :returns: roles granted to entities for this dataset
         """
-        return list(self._access_roles)
+        return list(self._access_grants)
 
     @access_grants.setter
     def access_grants(self, value):
@@ -105,7 +105,7 @@ class Dataset(object):
         """
         if not all(isinstance(field, AccessGrant) for field in value):
             raise ValueError('Values must be AccessGrant instances')
-        self._access_roles = tuple(value)
+        self._access_grants = tuple(value)
 
     @property
     def created(self):

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -292,8 +292,8 @@ class Dataset(object):
             role = grant.pop('role')
             # Hypothetical case:  we don't know that the back-end will ever
             # return such structures, but they are logical.  See:
-            #https://github.com/GoogleCloudPlatform/gcloud-python/pull/1046#discussion_r36687769
-            for entity_type, entity_id in grant.items():
+            # https://github.com/GoogleCloudPlatform/gcloud-python/pull/1046#discussion_r36687769
+            for entity_type, entity_id in sorted(grant.items()):
                 result.append(
                     AccessGrant(role, entity_type, entity_id))
         return result

--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -77,7 +77,7 @@ class TestDataset(unittest2.TestCase):
         r_grants = []
         for r_grant in resource['access']:
             role = r_grant.pop('role')
-            for entity_type, entity_id in r_grant.items():
+            for entity_type, entity_id in sorted(r_grant.items()):
                 r_grants.append({'role': role,
                                  'entity_type': entity_type,
                                  'entity_id': entity_id})
@@ -266,7 +266,7 @@ class TestDataset(unittest2.TestCase):
     def test__parse_access_grants_w_multiple_entity_types(self):
         # Hypothetical case:  we don't know that the back-end will ever
         # return such structures, but they are logical.  See:
-        #https://github.com/GoogleCloudPlatform/gcloud-python/pull/1046#discussion_r36687769
+        # https://github.com/GoogleCloudPlatform/gcloud-python/pull/1046#discussion_r36687769
         USER_EMAIL = 'phred@example.com'
         OTHER_EMAIL = 'bharney@example.com'
         GROUP_EMAIL = 'group-name@lists.example.com'

--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -78,19 +78,11 @@ class TestDataset(unittest2.TestCase):
         self.assertEqual(len(access_grants), len(r_grants))
 
         for a_grant, r_grant in zip(access_grants, r_grants):
-
-            self.assertEqual(a_grant.role, r_grant['role'])
-
-            if 'specialGroup' in r_grant:
-                self.assertEqual(a_grant.entity_type, 'specialGroup')
-                entity_id = r_grant['specialGroup']
-            elif 'groupByEmail' in r_grant:
-                self.assertEqual(a_grant.entity_type, 'groupByEmail')
-                entity_id = r_grant['groupByEmail']
-            else:
-                self.assertEqual(a_grant.entity_type, 'userByEmail')
-                entity_id = r_grant['userByEmail']
-
+            role = r_grant.pop('role')
+            self.assertEqual(a_grant.role, role)
+            self.assertEqual(len(r_grant), 1)
+            entity_type, entity_id = r_grant.items()[0]
+            self.assertEqual(a_grant.entity_type, entity_type)
             self.assertEqual(a_grant.entity_id, entity_id)
 
     def _verifyReadonlyResourceProperties(self, dataset, resource):
@@ -252,6 +244,21 @@ class TestDataset(unittest2.TestCase):
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertTrue(dataset._client is client)
         self._verifyResourceProperties(dataset, RESOURCE)
+
+    def test__parse_access_grants_w_unknown_entity_type(self):
+        USER_EMAIL = 'phred@example.com'
+        GROUP_EMAIL = 'group-name@lists.example.com'
+        RESOURCE = {
+            'access': [
+                {'role': 'OWNER', 'userByEmail': USER_EMAIL},
+                {'role': 'WRITER', 'groupByEmail': GROUP_EMAIL},
+                {'role': 'READER', 'specialGroup': 'projectReaders'},
+                {'role': 'READER', 'unknown': 'UNKNOWN'}]
+        }
+        client = _Client(self.PROJECT)
+        dataset = self._makeOne(self.DS_NAME, client=client)
+        grants = dataset._parse_access_grants(RESOURCE['access'])
+        self._verifyAccessGrants(grants, RESOURCE)
 
     def test_create_w_bound_client(self):
         PATH = 'projects/%s/datasets' % self.PROJECT

--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -15,7 +15,7 @@
 import unittest2
 
 
-class TestAccessRole(unittest2.TestCase):
+class TestAccessGrant(unittest2.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.dataset import AccessGrant

--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -81,7 +81,7 @@ class TestDataset(unittest2.TestCase):
             role = r_grant.pop('role')
             self.assertEqual(a_grant.role, role)
             self.assertEqual(len(r_grant), 1)
-            entity_type, entity_id = r_grant.items()[0]
+            entity_type, entity_id = list(r_grant.items())[0]
             self.assertEqual(a_grant.entity_type, entity_type)
             self.assertEqual(a_grant.entity_id, entity_id)
 


### PR DESCRIPTION
~~Uses #1045 as a base.~~

- Adds `Dataset.access_grants` property.
- Marshals values to/from that property in `Dataset` API requests/responses.