### PR TITLE
#1054: Set query cursor to 'None' when returned as empty string.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -418,7 +418,10 @@ class Iterator(object):
         #       for discussion.
         entity_pbs, cursor_as_bytes, more_results_enum = query_results[:3]
 
-        self._start_cursor = base64.b64encode(cursor_as_bytes)
+        if cursor_as_bytes == b'':
+            self._start_cursor = None
+        else:
+            self._start_cursor = base64.b64encode(cursor_as_bytes)
         self._end_cursor = None
 
         if more_results_enum == self._NOT_FINISHED:

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -363,16 +363,15 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(iterator._offset, 29)
 
     def test_next_page_no_cursors_no_more(self):
-        from base64 import b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
         query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
-        self._addQueryResults(connection)
+        self._addQueryResults(connection, cursor=b'')
         iterator = self._makeOne(query, client)
         entities, more_results, cursor = iterator.next_page()
 
-        self.assertEqual(cursor, b64encode(self._END))
+        self.assertEqual(cursor, None)
         self.assertFalse(more_results)
         self.assertFalse(iterator._more_results)
         self.assertEqual(len(entities), 1)
@@ -390,16 +389,15 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(connection._called_with, [EXPECTED])
 
     def test_next_page_no_cursors_no_more_w_offset_and_limit(self):
-        from base64 import b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
         query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
-        self._addQueryResults(connection)
+        self._addQueryResults(connection, cursor=b'')
         iterator = self._makeOne(query, client, 13, 29)
         entities, more_results, cursor = iterator.next_page()
 
-        self.assertEqual(cursor, b64encode(self._END))
+        self.assertEqual(cursor, None)
         self.assertFalse(more_results)
         self.assertFalse(iterator._more_results)
         self.assertEqual(len(entities), 1)


### PR DESCRIPTION
See #1054.