### PR TITLE
Moving self._create_scoped_credentials call to base Connection.__init__.

### DIFF
--- a/gcloud/bigquery/__init__.py
+++ b/gcloud/bigquery/__init__.py
@@ -22,7 +22,10 @@ The main concepts with this API are:
 """
 
 from gcloud.bigquery.client import Client
-from gcloud.bigquery.connection import SCOPE
+from gcloud.bigquery.connection import Connection
 from gcloud.bigquery.dataset import Dataset
 from gcloud.bigquery.table import SchemaField
 from gcloud.bigquery.table import Table
+
+
+SCOPE = Connection.SCOPE

--- a/gcloud/bigquery/connection.py
+++ b/gcloud/bigquery/connection.py
@@ -17,11 +17,6 @@
 from gcloud import connection as base_connection
 
 
-SCOPE = ('https://www.googleapis.com/auth/bigquery',
-         'https://www.googleapis.com/auth/cloud-platform')
-"""The scopes required for authenticating as a Cloud BigQuery consumer."""
-
-
 class Connection(base_connection.JSONConnection):
     """A connection to Google Cloud Pubsub via the JSON REST API."""
 
@@ -34,6 +29,6 @@ class Connection(base_connection.JSONConnection):
     API_URL_TEMPLATE = '{api_base_url}/bigquery/{api_version}{path}'
     """A template for the URL of a particular API call."""
 
-    def __init__(self, credentials=None, http=None):
-        credentials = self._create_scoped_credentials(credentials, SCOPE)
-        super(Connection, self).__init__(credentials=credentials, http=http)
+    SCOPE = ('https://www.googleapis.com/auth/bigquery',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a Cloud BigQuery consumer."""

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -69,9 +69,16 @@ class Connection(object):
     USER_AGENT = "gcloud-python/{0}".format(get_distribution('gcloud').version)
     """The user agent for gcloud-python requests."""
 
+    SCOPE = None
+    """The scopes required for authenticating with a service.
+
+    Needs to be set by subclasses.
+    """
+
     def __init__(self, credentials=None, http=None):
         self._http = http
-        self._credentials = credentials
+        self._credentials = self._create_scoped_credentials(
+            credentials, self.SCOPE)
 
     @property
     def credentials(self):

--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -51,10 +51,12 @@ The main concepts with this API are:
 """
 
 from gcloud.datastore.batch import Batch
-from gcloud.datastore.connection import SCOPE
 from gcloud.datastore.connection import Connection
 from gcloud.datastore.client import Client
 from gcloud.datastore.entity import Entity
 from gcloud.datastore.key import Key
 from gcloud.datastore.query import Query
 from gcloud.datastore.transaction import Transaction
+
+
+SCOPE = Connection.SCOPE

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -22,11 +22,6 @@ from gcloud.exceptions import make_exception
 from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
 
 
-SCOPE = ('https://www.googleapis.com/auth/datastore',
-         'https://www.googleapis.com/auth/userinfo.email')
-"""The scopes required for authenticating as a Cloud Datastore consumer."""
-
-
 class Connection(connection.Connection):
     """A connection to the Google Cloud Datastore via the Protobuf API.
 
@@ -51,8 +46,11 @@ class Connection(connection.Connection):
                         '/datasets/{dataset_id}/{method}')
     """A template for the URL of a particular API call."""
 
+    SCOPE = ('https://www.googleapis.com/auth/datastore',
+             'https://www.googleapis.com/auth/userinfo.email')
+    """The scopes required for authenticating as a Cloud Datastore consumer."""
+
     def __init__(self, credentials=None, http=None, api_base_url=None):
-        credentials = self._create_scoped_credentials(credentials, SCOPE)
         super(Connection, self).__init__(credentials=credentials, http=http)
         if api_base_url is None:
             api_base_url = os.getenv(GCD_HOST,

--- a/gcloud/pubsub/__init__.py
+++ b/gcloud/pubsub/__init__.py
@@ -24,6 +24,9 @@ The main concepts with this API are:
 """
 
 from gcloud.pubsub.client import Client
-from gcloud.pubsub.connection import SCOPE
+from gcloud.pubsub.connection import Connection
 from gcloud.pubsub.subscription import Subscription
 from gcloud.pubsub.topic import Topic
+
+
+SCOPE = Connection.SCOPE

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -17,13 +17,16 @@
 from gcloud import connection as base_connection
 
 
-SCOPE = ('https://www.googleapis.com/auth/pubsub',
-         'https://www.googleapis.com/auth/cloud-platform')
-"""The scopes required for authenticating as a Cloud Pub/Sub consumer."""
-
-
 class Connection(base_connection.JSONConnection):
-    """A connection to Google Cloud Pubsub via the JSON REST API."""
+    """A connection to Google Cloud Pubsub via the JSON REST API.
+
+    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        connection.
+
+    :type http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param http: (Optional) HTTP object to make requests.
+    """
 
     API_BASE_URL = 'https://pubsub.googleapis.com'
     """The base of the API call URL."""
@@ -34,6 +37,6 @@ class Connection(base_connection.JSONConnection):
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
 
-    def __init__(self, credentials=None, http=None):
-        credentials = self._create_scoped_credentials(credentials, SCOPE)
-        super(Connection, self).__init__(credentials=credentials, http=http)
+    SCOPE = ('https://www.googleapis.com/auth/pubsub',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a Cloud Pub/Sub consumer."""

--- a/gcloud/resource_manager/__init__.py
+++ b/gcloud/resource_manager/__init__.py
@@ -15,5 +15,8 @@
 """Google Cloud Resource Manager API wrapper."""
 
 from gcloud.resource_manager.client import Client
-from gcloud.resource_manager.connection import SCOPE
+from gcloud.resource_manager.connection import Connection
 from gcloud.resource_manager.project import Project
+
+
+SCOPE = Connection.SCOPE

--- a/gcloud/resource_manager/connection.py
+++ b/gcloud/resource_manager/connection.py
@@ -20,12 +20,16 @@ from oauth2client.client import AssertionCredentials
 from gcloud import connection as base_connection
 
 
-SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-"""The scopes required for authenticating as a Resouce Manager consumer."""
-
-
 class Connection(base_connection.JSONConnection):
-    """A connection to Google Cloud Resource Manager via the JSON REST API."""
+    """A connection to Google Cloud Resource Manager via the JSON REST API.
+
+    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        connection.
+
+    :type http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param http: (Optional) HTTP object to make requests.
+    """
 
     API_BASE_URL = 'https://cloudresourcemanager.googleapis.com'
     """The base of the API call URL."""
@@ -36,6 +40,9 @@ class Connection(base_connection.JSONConnection):
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
 
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating as a Resouce Manager consumer."""
+
     def __init__(self, credentials=None, http=None):
         if isinstance(credentials, AssertionCredentials):
             message = ('credentials (%r) inherits from '
@@ -43,5 +50,4 @@ class Connection(base_connection.JSONConnection):
                        'used with the Resource Manager API. ' % (credentials,))
             raise TypeError(message)
 
-        credentials = self._create_scoped_credentials(credentials, SCOPE)
         super(Connection, self).__init__(credentials=credentials, http=http)

--- a/gcloud/storage/__init__.py
+++ b/gcloud/storage/__init__.py
@@ -43,5 +43,7 @@ from gcloud.storage.batch import Batch
 from gcloud.storage.blob import Blob
 from gcloud.storage.bucket import Bucket
 from gcloud.storage.client import Client
-from gcloud.storage.connection import SCOPE
 from gcloud.storage.connection import Connection
+
+
+SCOPE = Connection.SCOPE

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -17,14 +17,16 @@
 from gcloud import connection as base_connection
 
 
-SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
-         'https://www.googleapis.com/auth/devstorage.read_only',
-         'https://www.googleapis.com/auth/devstorage.read_write')
-"""The scopes required for authenticating as a Cloud Storage consumer."""
-
-
 class Connection(base_connection.JSONConnection):
-    """A connection to Google Cloud Storage via the JSON REST API."""
+    """A connection to Google Cloud Storage via the JSON REST API.
+
+    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        connection.
+
+    :type http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param http: (Optional) HTTP object to make requests.
+    """
 
     API_BASE_URL = base_connection.API_BASE_URL
     """The base of the API call URL."""
@@ -35,6 +37,7 @@ class Connection(base_connection.JSONConnection):
     API_URL_TEMPLATE = '{api_base_url}/storage/{api_version}{path}'
     """A template for the URL of a particular API call."""
 
-    def __init__(self, credentials=None, http=None):
-        credentials = self._create_scoped_credentials(credentials, SCOPE)
-        super(Connection, self).__init__(credentials=credentials, http=http)
+    SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
+             'https://www.googleapis.com/auth/devstorage.read_only',
+             'https://www.googleapis.com/auth/devstorage.read_write')
+    """The scopes required for authenticating as a Cloud Storage consumer."""


### PR DESCRIPTION
Every package's subclass calls this method, so we just moved it to the parent.

Fixes #974.