### PR TITLE
Using standard nose coverage instead of xcover.

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -16,6 +16,12 @@
 
 set -ev
 
-nosetests --ignore-files=run_system_test\.py \
---with-xunit --with-xcoverage --cover-package=gcloud \
---nocapture --cover-erase --cover-tests --cover-branches ${@}
+nosetests \
+  --ignore-files=run_system_test\.py \
+  --with-coverage \
+  --cover-package=gcloud \
+  --cover-erase \
+  --cover-tests \
+  --cover-branches \
+  --nocapture \
+  ${@}

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ commands =
 deps =
     {[testenv]deps}
     coverage
-    nosexcover
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}


### PR DESCRIPTION
We realized we didn't need xcover recently in a PR over on oauth2client.

H/T to @jonparrott