### PR TITLE
Shorten the link to gcloud-java from the landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div class="nav-current">Python</div>
     <ul class="menu">
       <li>
-        <a href="https://googlecloudplatform.github.io/gcloud-java/site/latest/" title="gcloud-java">
+        <a href="https://googlecloudplatform.github.io/gcloud-java/" title="gcloud-java">
           <img src="_landing-page-static/images/icon-lang-java-duke.svg" alt="Duke icon" class="menu-icon">
           Java
         </a>


### PR DESCRIPTION
The link to gcloud-java's landing page has been shortened, and the longer URL will be removed (after all references to it are removed).  This PR shortens the link on the landing page.  

Note: links to gcloud-java in the docs pages in the "latest" folder haven't been updated.  Can these can be updated by rebuilding the docs (once the link is updated in `master`)?

You can see the updated link at the bottom of this screenshot: 
![landing_page_shortened_link](https://cloud.githubusercontent.com/assets/5316886/9558811/2fee78b8-4d9f-11e5-9420-5c09a2305de3.png)
