### PR TITLE
Update link to gcloud-java's landing page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -68,7 +68,7 @@
         <ul class="menu">
           <li>
             <a href="
-https://googlecloudplatform.github.io/gcloud-java/site/latest/" title="gcloud-java page">
+https://googlecloudplatform.github.io/gcloud-java/" title="gcloud-java page">
               <img src="{{ pathto('_static/images/icon-lang-java-duke.svg', 1) }}" alt="Duke icon" class="menu-icon" />
               Java
             </a>


### PR DESCRIPTION
This PR updates the links to gcloud-java (from the docs pages) to reflect gcloud-java's shorter URL.

After a build, the link from the docs pages will look like this (see bottom of screenshot):
![docs_link_update](https://cloud.githubusercontent.com/assets/5316886/9558831/6a818c4a-4d9f-11e5-88e7-dbe3e4efd63a.png)
