### PR TITLE
Rename 'RunQueryJob'->'RunQueryAsyncJob'.

### DIFF
--- a/gcloud/bigquery/client.py
+++ b/gcloud/bigquery/client.py
@@ -21,7 +21,7 @@ from gcloud.bigquery.dataset import Dataset
 from gcloud.bigquery.job import CopyJob
 from gcloud.bigquery.job import ExtractTableToStorageJob
 from gcloud.bigquery.job import LoadTableFromStorageJob
-from gcloud.bigquery.job import RunQueryJob
+from gcloud.bigquery.job import RunAsyncQueryJob
 
 
 class Client(JSONClient):
@@ -155,8 +155,8 @@ class Client(JSONClient):
         return ExtractTableToStorageJob(name, source, destination_uris,
                                         client=self)
 
-    def run_query(self, name, query):
-        """Construct a job for running a SQL query.
+    def run_async_query(self, name, query):
+        """Construct a job for running a SQL query asynchronously.
 
         :type name: string
         :param name: Name of the job.
@@ -164,7 +164,7 @@ class Client(JSONClient):
         :type query: string
         :param query: SQL query to be executed
 
-        :rtype: :class:`gcloud.bigquery.job.RunQueryJob`
-        :returns: a new ``RunQueryJob`` instance
+        :rtype: :class:`gcloud.bigquery.job.RunAsyncQueryJob`
+        :returns: a new ``RunAsyncQueryJob`` instance
         """
-        return RunQueryJob(name, query, client=self)
+        return RunAsyncQueryJob(name, query, client=self)

--- a/gcloud/bigquery/job.py
+++ b/gcloud/bigquery/job.py
@@ -125,7 +125,7 @@ class Encoding(_EnumProperty):
 
 
 class QueryPriority(_EnumProperty):
-    """Pseudo-enum for ``RunQueryJob.priority`` property."""
+    """Pseudo-enum for ``RunAsyncQueryJob.priority`` property."""
     INTERACTIVE = 'INTERACTIVE'
     BATCH = 'BATCH'
     ALLOWED = (INTERACTIVE, BATCH)
@@ -797,7 +797,7 @@ class _QueryConfiguration(object):
     _write_disposition = None
 
 
-class RunQueryJob(_BaseJob):
+class RunAsyncQueryJob(_BaseJob):
     """Asynchronous job: query tables.
 
     :type name: string
@@ -811,7 +811,7 @@ class RunQueryJob(_BaseJob):
                    for the dataset (which requires a project).
     """
     def __init__(self, name, query, client):
-        super(RunQueryJob, self).__init__(name, client)
+        super(RunAsyncQueryJob, self).__init__(name, client)
         self.query = query
         self._configuration = _QueryConfiguration()
 

--- a/gcloud/bigquery/test_client.py
+++ b/gcloud/bigquery/test_client.py
@@ -186,16 +186,16 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(job.source, source)
         self.assertEqual(list(job.destination_uris), [DESTINATION])
 
-    def test_run_query(self):
-        from gcloud.bigquery.job import RunQueryJob
+    def test_run_async_query(self):
+        from gcloud.bigquery.job import RunAsyncQueryJob
         PROJECT = 'PROJECT'
         JOB = 'job_name'
         QUERY = 'select count(*) from persons'
         creds = _Credentials()
         http = object()
         client = self._makeOne(project=PROJECT, credentials=creds, http=http)
-        job = client.run_query(JOB, QUERY)
-        self.assertTrue(isinstance(job, RunQueryJob))
+        job = client.run_async_query(JOB, QUERY)
+        self.assertTrue(isinstance(job, RunAsyncQueryJob))
         self.assertTrue(job._client is client)
         self.assertEqual(job.name, JOB)
         self.assertEqual(job.query, QUERY)

--- a/gcloud/bigquery/test_job.py
+++ b/gcloud/bigquery/test_job.py
@@ -1087,13 +1087,13 @@ class TestExtractTableToStorageJob(unittest2.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
-class TestRunQueryJob(unittest2.TestCase, _Base):
+class TestRunAsyncQueryJob(unittest2.TestCase, _Base):
     JOB_TYPE = 'query'
     QUERY = 'select count(*) from persons'
 
     def _getTargetClass(self):
-        from gcloud.bigquery.job import RunQueryJob
-        return RunQueryJob
+        from gcloud.bigquery.job import RunAsyncQueryJob
+        return RunAsyncQueryJob
 
     def _verifyBooleanResourceProperties(self, job, config):
 


### PR DESCRIPTION
Indicate that it fits the asynchronous query usage model, spelled out in https://cloud.google.com/bigquery/querying-data#asyncqueries

Rename the client factory method accordingly.