### PR TITLE
Adding gcloud.bigtable package.

### DIFF
--- a/_testing/grpc/__init__.py
+++ b/_testing/grpc/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/_adapter/__init__.py
+++ b/_testing/grpc/_adapter/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/_adapter/_c.py
+++ b/_testing/grpc/_adapter/_c.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/early_adopter/__init__.py
+++ b/_testing/grpc/early_adopter/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/early_adopter/implementations.py
+++ b/_testing/grpc/early_adopter/implementations.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/framework/__init__.py
+++ b/_testing/grpc/framework/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/framework/alpha/__init__.py
+++ b/_testing/grpc/framework/alpha/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/framework/alpha/utilities.py
+++ b/_testing/grpc/framework/alpha/utilities.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/gcloud/bigtable/__init__.py
+++ b/gcloud/bigtable/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google Cloud Bigtable API package."""
+
+
+from __future__ import print_function
+import sys
+
+try:
+    from grpc._adapter import _c
+except ImportError as exc:  # pragma: NO COVER
+    if 'libgrpc.so' in str(exc):
+        print('gRPC libraries could not be located. Please see '
+              'instructions to locate these files. You\'ll want '
+              'to set your LD_LIBRARY_PATH variable to help '
+              'Python locate the libraries.', file=sys.stderr)
+    raise

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps =
     nose
     unittest2
     protobuf==3.0.0-alpha-1
+setenv =
+    PYTHONPATH = {toxinidir}/_testing
 
 [testenv:cover]
 basepython =
@@ -43,6 +45,7 @@ passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD
 
 [testenv:docs-rtd]
 setenv =
+    {[testenv]setenv}
     LOCAL_RTD = True
 basepython = {[testenv:docs]basepython}
 commands =


### PR DESCRIPTION
Initial commit just adds the basic import time check for gRPC and testing for all possible install states. It also adds a shadowed _testing/grpc that we can use to mock the installed library for tests.

----

We can discuss alternatives to mocking out `grpc` imports in dhermes/gcloud-python-bigtable#10 or right here. As far as I know, there is no way to globally (i.e. between / before modules) step in front of `__import__` without doing some serious engineering.

----

@nathanielmanistaatgoogle Any better ideas than this one for allowing unit tests that "depend" on grpc to run? (None of the gRPC code is ever called in unit tests, just in system tests. Though the gRPC objects get mocked out, the imports need to work so `nose` doesn't get angry.)