### PR TITLE
Pin protorpc==0.10.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 
 REQUIREMENTS = [
+    'protorpc == 0.10.0',
     'google-apitools',
     'httplib2 >= 0.9.1',
     'oauth2client >= 1.4.6',


### PR DESCRIPTION
Works around https://github.com/google/protorpc/issues/12.

Fixes: #1133.