### PR TITLE
Add 'sphinx.ext.coverage' to the 'tox -e docs' build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -294,3 +295,15 @@ intersphinx_mapping = {
     'oauth2client': ('http://oauth2client.readthedocs.org/en/latest/', None),
     'python': ('https://docs.python.org/', None),
 }
+
+# Configuration for coverage:
+# See:  http://sphinx-doc.org/ext/coverage.html
+
+coverage_ignore_modules = ['test_.*.py', '.*_pb2.py']
+#coverage_ignore_functions = ()
+#coverage_ignore_classes = ()
+coverage_c_path = ['../gcloud/*.py', '../gcloud/*/*.py']
+#coverage_c_regexes
+#coverage_ignore_c_items
+#coverage_write_headline
+coverage_skip_undoc_in_source = True

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ basepython =
 commands =
     python -c "import shutil; shutil.rmtree('docs/_build', ignore_errors=True)"
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -W -E -b coverage -d docs/_build/doctrees docs docs/_build/coverage
 deps =
     Sphinx
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD


### PR DESCRIPTION
See:  #714

Note that this PR does *not* auto-close the issue, as I have been unable to verify that the extension can be configured to generate the error we would want for missing coverage.