### PR TITLE
Switching datastore cursors to URLsafe base64 encoding.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -388,11 +388,11 @@ class Iterator(object):
 
         start_cursor = self._start_cursor
         if start_cursor is not None:
-            pb.start_cursor = base64.b64decode(start_cursor)
+            pb.start_cursor = base64.urlsafe_b64decode(start_cursor)
 
         end_cursor = self._end_cursor
         if end_cursor is not None:
-            pb.end_cursor = base64.b64decode(end_cursor)
+            pb.end_cursor = base64.urlsafe_b64decode(end_cursor)
 
         if self._limit is not None:
             pb.limit = self._limit
@@ -421,7 +421,7 @@ class Iterator(object):
         if cursor_as_bytes == b'':
             self._start_cursor = None
         else:
-            self._start_cursor = base64.b64encode(cursor_as_bytes)
+            self._start_cursor = base64.urlsafe_b64encode(cursor_as_bytes)
         self._end_cursor = None
 
         if more_results_enum == self._NOT_FINISHED:

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -416,8 +416,8 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(connection._called_with, [EXPECTED])
 
     def test_next_page_w_cursors_w_more(self):
-        from base64 import b64decode
-        from base64 import b64encode
+        from base64 import urlsafe_b64decode
+        from base64 import urlsafe_b64encode
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
@@ -428,19 +428,19 @@ class TestIterator(unittest2.TestCase):
         iterator._end_cursor = self._END
         entities, more_results, cursor = iterator.next_page()
 
-        self.assertEqual(cursor, b64encode(self._END))
+        self.assertEqual(cursor, urlsafe_b64encode(self._END))
         self.assertTrue(more_results)
         self.assertTrue(iterator._more_results)
         self.assertEqual(iterator._end_cursor, None)
-        self.assertEqual(b64decode(iterator._start_cursor), self._END)
+        self.assertEqual(urlsafe_b64decode(iterator._start_cursor), self._END)
         self.assertEqual(len(entities), 1)
         self.assertEqual(entities[0].key.path,
                          [{'kind': self._KIND, 'id': self._ID}])
         self.assertEqual(entities[0]['foo'], u'Foo')
         qpb = _pb_from_query(query)
         qpb.offset = 0
-        qpb.start_cursor = b64decode(self._START)
-        qpb.end_cursor = b64decode(self._END)
+        qpb.start_cursor = urlsafe_b64decode(self._START)
+        qpb.end_cursor = urlsafe_b64decode(self._END)
         EXPECTED = {
             'dataset_id': self._DATASET,
             'query_pb': qpb,


### PR DESCRIPTION
Fixes [getting-started-python#8](https://github.com/GoogleCloudPlatform/getting-started-python/issues/8)