### PR TITLE
Speling: pass 'ack_deadline' as 'ackDeadlineSeconds' everywhere.

### DIFF
--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -112,7 +112,7 @@ class Subscription(object):
         data = {'topic': self.topic.full_name}
 
         if self.ack_deadline is not None:
-            data['ackDeadline'] = self.ack_deadline
+            data['ackDeadlineSeconds'] = self.ack_deadline
 
         if self.push_endpoint is not None:
             data['pushConfig'] = {'pushEndpoint': self.push_endpoint}
@@ -150,7 +150,7 @@ class Subscription(object):
         """
         client = self._require_client(client)
         data = client.connection.api_request(method='GET', path=self.path)
-        self.ack_deadline = data.get('ackDeadline')
+        self.ack_deadline = data.get('ackDeadlineSeconds')
         push_config = data.get('pushConfig', {})
         self.push_endpoint = push_config.get('pushEndpoint')
 

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -143,7 +143,7 @@ class TestSubscription(unittest2.TestCase):
         DEADLINE = 42
         ENDPOINT = 'https://api.example.com/push'
         BODY = {'topic': TOPIC_PATH,
-                'ackDeadline': DEADLINE,
+                'ackDeadlineSeconds': DEADLINE,
                 'pushConfig': {'pushEndpoint': ENDPOINT}}
         conn1 = _Connection({'name': SUB_PATH})
         CLIENT1 = _Client(project=PROJECT, connection=conn1)
@@ -205,7 +205,7 @@ class TestSubscription(unittest2.TestCase):
         ENDPOINT = 'https://api.example.com/push'
         conn = _Connection({'name': SUB_PATH,
                             'topic': TOPIC_PATH,
-                            'ackDeadline': DEADLINE,
+                            'ackDeadlineSeconds': DEADLINE,
                             'pushConfig': {'pushEndpoint': ENDPOINT}})
         CLIENT = _Client(project=PROJECT, connection=conn)
         topic = _Topic(TOPIC_NAME, client=CLIENT)
@@ -230,7 +230,7 @@ class TestSubscription(unittest2.TestCase):
         CLIENT1 = _Client(project=PROJECT, connection=conn1)
         conn2 = _Connection({'name': SUB_PATH,
                              'topic': TOPIC_PATH,
-                             'ackDeadline': DEADLINE,
+                             'ackDeadlineSeconds': DEADLINE,
                              'pushConfig': {'pushEndpoint': ENDPOINT}})
         CLIENT2 = _Client(project=PROJECT, connection=conn2)
         topic = _Topic(TOPIC_NAME, client=CLIENT1)

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -61,7 +61,7 @@ class TestPubsub(unittest2.TestCase):
                    topic.project == CLIENT.project]
         self.assertEqual(len(created), len(topics_to_create))
 
-    def test_create_subscription(self):
+    def test_create_subscription_defaults(self):
         TOPIC_NAME = 'subscribe-me'
         topic = CLIENT.topic(TOPIC_NAME)
         self.assertFalse(topic.exists())
@@ -74,6 +74,22 @@ class TestPubsub(unittest2.TestCase):
         self.to_delete.append(subscription)
         self.assertTrue(subscription.exists())
         self.assertEqual(subscription.name, SUBSCRIPTION_NAME)
+        self.assertTrue(subscription.topic is topic)
+
+    def test_create_subscription_w_ack_deadline(self):
+        TOPIC_NAME = 'subscribe-me'
+        topic = CLIENT.topic(TOPIC_NAME)
+        self.assertFalse(topic.exists())
+        topic.create()
+        self.to_delete.append(topic)
+        SUBSCRIPTION_NAME = 'subscribing-now'
+        subscription = topic.subscription(SUBSCRIPTION_NAME, ack_deadline=120)
+        self.assertFalse(subscription.exists())
+        subscription.create()
+        self.to_delete.append(subscription)
+        self.assertTrue(subscription.exists())
+        self.assertEqual(subscription.name, SUBSCRIPTION_NAME)
+        self.assertEqual(subscription.ack_deadline, 120)
         self.assertTrue(subscription.topic is topic)
 
     def test_list_subscriptions(self):


### PR DESCRIPTION
May fix #1169.