### PR TITLE
Add 'serializable' flag to Transaction.

### DIFF
--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -440,12 +440,17 @@ class Client(_BaseClient):
         """
         return Batch(self)
 
-    def transaction(self):
+    def transaction(self, serializable=False):
         """Proxy to :class:`gcloud.datastore.transaction.Transaction`.
 
         Passes our ``dataset_id``.
+
+        :type serializable: boolean
+        :param serializable: if true, perform this transaction at
+                             ``serializable`` isolation level;  otherwise,
+                             perform it at ``snapshot`` level.
         """
-        return Transaction(self)
+        return Transaction(self, serializable=serializable)
 
     def query(self, **kwargs):
         """Proxy to :class:`gcloud.datastore.query.Query`.

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -790,7 +790,7 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(batch.args, (client,))
         self.assertEqual(batch.kwargs, {})
 
-    def test_transaction(self):
+    def test_transaction_defaults(self):
         from gcloud.datastore import client as MUT
         from gcloud._testing import _Monkey
 
@@ -802,7 +802,21 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(xact, _Dummy))
         self.assertEqual(xact.args, (client,))
-        self.assertEqual(xact.kwargs, {})
+        self.assertEqual(xact.kwargs, {'serializable': False})
+
+    def test_transaction_explicit(self):
+        from gcloud.datastore import client as MUT
+        from gcloud._testing import _Monkey
+
+        creds = object()
+        client = self._makeOne(credentials=creds)
+
+        with _Monkey(MUT, Transaction=_Dummy):
+            xact = client.transaction(serializable=True)
+
+        self.assertTrue(isinstance(xact, _Dummy))
+        self.assertEqual(xact.args, (client,))
+        self.assertEqual(xact.kwargs, {'serializable': True})
 
     def test_query_w_client(self):
         KIND = 'KIND'

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -107,8 +107,8 @@ class TestDatastoreSave(TestDatastore):
     def test_post_with_generated_id(self):
         self._generic_test_post()
 
-    def test_save_multiple(self):
-        with CLIENT.transaction() as xact:
+    def test_save_multiple_serializable(self):
+        with CLIENT.transaction(serializable=True) as xact:
             entity1 = self._get_post()
             xact.put(entity1)
             # Register entity to be deleted.


### PR DESCRIPTION
Propagate it through to `Connection.begin_transaction`.

Closes #1204.