### PR TITLE
Missing 'mode' in table scheme

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -700,7 +700,7 @@ def _parse_schema_resource(info):
     for r_field in info['fields']:
         name = r_field['name']
         field_type = r_field['type']
-        mode = r_field['mode']
+        mode = r_field.get('mode', 'NULLABLE')
         description = r_field.get('description')
         sub_fields = _parse_schema_resource(r_field)
         schema.append(

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -67,7 +67,7 @@ class _SchemaBase(object):
     def _verify_field(self, field, r_field):
         self.assertEqual(field.name, r_field['name'])
         self.assertEqual(field.field_type, r_field['type'])
-        self.assertEqual(field.mode, r_field['mode'])
+        self.assertEqual(field.mode, r_field.get('mode', 'NULLABLE'))
 
     def _verifySchema(self, schema, resource):
         r_fields = resource['schema']['fields']
@@ -1271,6 +1271,15 @@ class Test_parse_schema_resource(unittest2.TestCase, _SchemaBase):
                         {'name': 'number',
                          'type': 'STRING',
                          'mode': 'REQUIRED'}]})
+        schema = self._callFUT(RESOURCE['schema'])
+        self._verifySchema(schema, RESOURCE)
+
+    def test__parse_schema_resource_fields_without_mode(self):
+        RESOURCE = self._makeResource()
+        RESOURCE['schema']['fields'].append(
+            {'name': 'phone',
+             'type': 'STRING'})
+
         schema = self._callFUT(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 


### PR DESCRIPTION
If the table has been created through the web UI and set mode for field `NULLABLE `, the `mode` in API will not be returned

Request:

```
GET https://www.googleapis.com/bigquery/v2/projects/test-project/datasets/test-dataset/tables/test-table?fields=schema&key={API_KEY}
```

Response:

```json
{
    "schema": {
        "fields": [{
            "name": "redate",
            "type": "TIMESTAMP"
        }, {
            "name": "bar",
            "type": "RECORD",
            "fields": [{
                "name": "foo",
                "type": "STRING"
            }]
        }]
    }
}
```

