### PR TITLE
Using custom named temporary file.

### DIFF
--- a/gcloud/_testing.py
+++ b/gcloud/_testing.py
@@ -30,3 +30,19 @@ class _Monkey(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         for key, value in self.to_restore.items():
             setattr(self.module, key, value)
+
+
+class _NamedTemporaryFile(object):
+
+    def __init__(self, suffix=''):
+        import os
+        import tempfile
+        filehandle, self.name = tempfile.mkstemp(suffix=suffix)
+        os.close(filehandle)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import os
+        os.remove(self.name)

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -190,7 +190,13 @@ class TestClient(unittest2.TestCase):
                                       http=http)
 
     def test_ctor_w_dataset_id_no_environ(self):
-        self.assertRaises(EnvironmentError, self._makeOne, None)
+        from gcloud._testing import _Monkey
+        from gcloud.datastore import client as _MUT
+
+        # Some environments (e.g. AppVeyor CI) run in GCE, so
+        # this test would fail artificially.
+        with _Monkey(_MUT, _compute_engine_id=lambda: None):
+            self.assertRaises(EnvironmentError, self._makeOne, None)
 
     def test_ctor_w_implicit_inputs(self):
         from gcloud._testing import _Monkey

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -293,6 +293,7 @@ class Test__millis_from_datetime(unittest2.TestCase):
 
     def test_w_utc_datetime(self):
         import datetime
+        import six
         from gcloud._helpers import UTC
         from gcloud._helpers import _microseconds_from_datetime
 
@@ -300,11 +301,12 @@ class Test__millis_from_datetime(unittest2.TestCase):
         NOW_MICROS = _microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
         result = self._callFUT(NOW)
-        self.assertTrue(isinstance(result, int))
+        self.assertTrue(isinstance(result, six.integer_types))
         self.assertEqual(result, MILLIS)
 
     def test_w_non_utc_datetime(self):
         import datetime
+        import six
         from gcloud._helpers import _UTC
         from gcloud._helpers import _microseconds_from_datetime
 
@@ -317,11 +319,12 @@ class Test__millis_from_datetime(unittest2.TestCase):
         NOW_MICROS = _microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
         result = self._callFUT(NOW)
-        self.assertTrue(isinstance(result, int))
+        self.assertTrue(isinstance(result, six.integer_types))
         self.assertEqual(result, MILLIS)
 
     def test_w_naive_datetime(self):
         import datetime
+        import six
         from gcloud._helpers import UTC
         from gcloud._helpers import _microseconds_from_datetime
 
@@ -330,7 +333,7 @@ class Test__millis_from_datetime(unittest2.TestCase):
         UTC_NOW_MICROS = _microseconds_from_datetime(UTC_NOW)
         MILLIS = UTC_NOW_MICROS // 1000
         result = self._callFUT(NOW)
-        self.assertTrue(isinstance(result, int))
+        self.assertTrue(isinstance(result, six.integer_types))
         self.assertEqual(result, MILLIS)
 
 

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -88,17 +88,19 @@ class Test_get_for_service_account_p12(unittest2.TestCase):
                                            scope=scope)
 
     def test_it(self):
-        from tempfile import NamedTemporaryFile
         from gcloud import credentials as MUT
         from gcloud._testing import _Monkey
+        from gcloud._testing import _NamedTemporaryFile
+
         CLIENT_EMAIL = 'phred@example.com'
         PRIVATE_KEY = b'SEEkR1t'
         client = _Client()
         with _Monkey(MUT, client=client):
-            with NamedTemporaryFile() as file_obj:
-                file_obj.write(PRIVATE_KEY)
-                file_obj.flush()
-                found = self._callFUT(CLIENT_EMAIL, file_obj.name)
+            with _NamedTemporaryFile() as temp:
+                with open(temp.name, 'wb') as file_obj:
+                    file_obj.write(PRIVATE_KEY)
+                found = self._callFUT(CLIENT_EMAIL, temp.name)
+
         self.assertTrue(found is client._signed)
         expected_called_with = {
             'service_account_name': CLIENT_EMAIL,
@@ -108,18 +110,20 @@ class Test_get_for_service_account_p12(unittest2.TestCase):
         self.assertEqual(client._called_with, expected_called_with)
 
     def test_it_with_scope(self):
-        from tempfile import NamedTemporaryFile
         from gcloud import credentials as MUT
         from gcloud._testing import _Monkey
+        from gcloud._testing import _NamedTemporaryFile
+
         CLIENT_EMAIL = 'phred@example.com'
         PRIVATE_KEY = b'SEEkR1t'
         SCOPE = 'SCOPE'
         client = _Client()
         with _Monkey(MUT, client=client):
-            with NamedTemporaryFile() as file_obj:
-                file_obj.write(PRIVATE_KEY)
-                file_obj.flush()
-                found = self._callFUT(CLIENT_EMAIL, file_obj.name, SCOPE)
+            with _NamedTemporaryFile() as temp:
+                with open(temp.name, 'wb') as file_obj:
+                    file_obj.write(PRIVATE_KEY)
+                found = self._callFUT(CLIENT_EMAIL, temp.name, SCOPE)
+
         self.assertTrue(found is client._signed)
         expected_called_with = {
             'service_account_name': CLIENT_EMAIL,


### PR DESCRIPTION
This is so that tests can run successfully on Windows.

In addition, using generic integer types (from `six`) for `gcloud._helpers._millis_from_datetime` since it returns a `long` on Windows and `int` on Linux. Also monkey patching the GCE ID check in `test_ctor_w_dataset_id_no_environ` since some CI environments will give a "false positive" on that test.