### PR TITLE
Add wheels to Travis deploy step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ deploy:
     repo: GoogleCloudPlatform/gcloud-python
     # until this is fixed: https://github.com/travis-ci/travis-ci/issues/1675
     all_branches: true
+  distributions: "sdist bdist_wheel"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [nosetests]
 ignore-files = run_system_test\.py
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
We use `universal = 1` in `setup.cfg` since our codebase works without change in both Python 2 and Python 3.

Change inspired by reading http://docs.travis-ci.com/user/deployment/pypi/ and http://pythonwheels.com/