### PR TITLE
Properly handling entity meanings in datastore.

### DIFF
--- a/gcloud/datastore/_datastore_pb2.py
+++ b/gcloud/datastore/_datastore_pb2.py
@@ -35,4 +35,3 @@ AllocateIdsResponse = _datastore_v1_pb2.AllocateIdsResponse
 Mutation = _datastore_v1_pb2.Mutation
 MutationResult = _datastore_v1_pb2.MutationResult
 ReadOptions = _datastore_v1_pb2.ReadOptions
-Property = _datastore_v1_pb2.Property  # Not present in v1beta3

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -229,26 +229,7 @@ def _assign_entity_to_pb(entity_pb, entity):
     :type entity: :class:`gcloud.datastore.entity.Entity`
     :param entity: The entity being updated within the batch / transaction.
     """
-    key_pb = entity.key.to_protobuf()
-    key_pb = helpers._prepare_key_for_request(key_pb)
-    entity_pb.key.CopyFrom(key_pb)
-
-    for name, value in entity.items():
-
-        value_is_list = isinstance(value, list)
-        if value_is_list and len(value) == 0:
-            continue
-
-        prop = entity_pb.property.add()
-        # Set the name of the property.
-        prop.name = name
-
-        # Set the appropriate value.
-        helpers._set_protobuf_value(prop.value, value)
-
-        if name in entity.exclude_from_indexes:
-            if not value_is_list:
-                prop.value.indexed = False
-
-            for sub_value in prop.value.list_value:
-                sub_value.indexed = False
+    bare_entity_pb = helpers.entity_to_protobuf(entity)
+    key_pb = helpers._prepare_key_for_request(bare_entity_pb.key)
+    bare_entity_pb.key.CopyFrom(key_pb)
+    entity_pb.CopyFrom(bare_entity_pb)

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -81,6 +81,9 @@ class Entity(dict):
         self.key = key
         self._exclude_from_indexes = set(_ensure_tuple_or_list(
             'exclude_from_indexes', exclude_from_indexes))
+        # NOTE: This will be populated when parsing a protobuf in
+        #       gcloud.datastore.helpers.entity_from_protobuf.
+        self._meanings = {}
 
     def __eq__(self, other):
         """Compare two entities for equality.

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -385,6 +385,7 @@ class _Connection(object):
 class _Entity(dict):
     key = None
     exclude_from_indexes = ()
+    _meanings = {}
 
 
 class _Key(object):


### PR DESCRIPTION
To do this, added `entity_to_protobuf` method that could be used recursively. Also solves #1206 since recursively serializing nested entities to protobuf was being done incorrectly.

Fixes #1065. Fixes #1206.