### PR TITLE
Refactor 'gcloud.streaming.http_wrapper' exception handling

### DIFF
--- a/gcloud/streaming/http_wrapper.py
+++ b/gcloud/streaming/http_wrapper.py
@@ -24,12 +24,27 @@ from gcloud.streaming.util import calculate_wait_for_retry
 # 308 and 429 don't have names in httplib.
 RESUME_INCOMPLETE = 308
 TOO_MANY_REQUESTS = 429
+
+
 _REDIRECT_STATUS_CODES = (
     http_client.MOVED_PERMANENTLY,
     http_client.FOUND,
     http_client.SEE_OTHER,
     http_client.TEMPORARY_REDIRECT,
     RESUME_INCOMPLETE,
+)
+
+
+_RETRYABLE_EXCEPTIONS = (
+    http_client.BadStatusLine,
+    http_client.IncompleteRead,
+    http_client.ResponseNotReady,
+    socket.error,
+    httplib2.ServerNotFoundError,
+    ValueError,
+    RequestError,
+    BadStatusCodeError,
+    RetryAfterError,
 )
 
 
@@ -343,19 +358,6 @@ def _make_api_request_no_retry(http, http_request, redirections=5,
     response = Response(info, content, http_request.url)
     check_response_func(response)
     return response
-
-
-_RETRYABLE_EXCEPTIONS = (
-    http_client.BadStatusLine,
-    http_client.IncompleteRead,
-    http_client.ResponseNotReady,
-    socket.error,
-    httplib2.ServerNotFoundError,
-    ValueError,
-    RequestError,
-    BadStatusCodeError,
-    RetryAfterError,
-)
 
 
 def make_api_request(http, http_request,

--- a/gcloud/streaming/http_wrapper.py
+++ b/gcloud/streaming/http_wrapper.py
@@ -411,10 +411,10 @@ def make_api_request(http, http_request,
             if retry_after is None:
                 retry_after = calculate_wait_for_retry(retry, max_retry_wait)
 
-        _reset_http_connections(http)
-        logging.debug('Retrying request to url %s after exception %s',
-                      http_request.url, exc)
-        time.sleep(retry_after)
+            _reset_http_connections(http)
+            logging.debug('Retrying request to url %s after exception %s',
+                          http_request.url, type(exc).__name__)
+            time.sleep(retry_after)
 
 
 _HTTP_FACTORIES = []

--- a/gcloud/streaming/transfer.py
+++ b/gcloud/streaming/transfer.py
@@ -15,7 +15,6 @@ from gcloud.streaming.exceptions import HttpError
 from gcloud.streaming.exceptions import TransferInvalidError
 from gcloud.streaming.exceptions import TransferRetryError
 from gcloud.streaming.http_wrapper import get_http
-from gcloud.streaming.http_wrapper import handle_http_exceptions
 from gcloud.streaming.http_wrapper import make_api_request
 from gcloud.streaming.http_wrapper import Request
 from gcloud.streaming.http_wrapper import RESUME_INCOMPLETE
@@ -65,7 +64,6 @@ class _Transfer(object):
         # Let the @property do validation
         self.num_retries = num_retries
 
-        self.retry_func = handle_http_exceptions
         self.auto_transfer = auto_transfer
         self.chunksize = chunksize
 
@@ -467,8 +465,7 @@ class Download(_Transfer):
         request = Request(url=self.url)
         self._set_range_header(request, start, end=end)
         return make_api_request(
-            self.bytes_http, request, retry_func=self.retry_func,
-            retries=self.num_retries)
+            self.bytes_http, request, retries=self.num_retries)
 
     def _process_response(self, response):
         """Update attribtes and writing stream, based on response.
@@ -1060,8 +1057,7 @@ class Upload(_Transfer):
                  code from the response indicates an error.
         """
         response = make_api_request(
-            self.bytes_http, request, retry_func=self.retry_func,
-            retries=self.num_retries)
+            self.bytes_http, request, retries=self.num_retries)
         if response.status_code not in (http_client.OK, http_client.CREATED,
                                         RESUME_INCOMPLETE):
             # We want to reset our state to wherever the server left us


### PR DESCRIPTION
- Catch only explicitly retryable exceptions, and handle retry count /  interval explicitly in `make_api_request`.
- Delete the `handle_heep_exceptions` helper, and the `retry_func` argument which used it as a default.
- Rename `_rebuild_http_connections` -> `_reset_http_connections` for clarity.

Closes #1223.