### PR TITLE
Returning ints from BigQuery Table.num_rows/num_bytes.

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -171,7 +171,9 @@ class Table(object):
         :rtype: integer, or ``NoneType``
         :returns: the byte count (None until set from the server).
         """
-        return self._properties.get('numBytes')
+        num_bytes_as_str = self._properties.get('numBytes')
+        if num_bytes_as_str is not None:
+            return int(num_bytes_as_str)
 
     @property
     def num_rows(self):
@@ -180,7 +182,9 @@ class Table(object):
         :rtype: integer, or ``NoneType``
         :returns: the row count (None until set from the server).
         """
-        return self._properties.get('numRows')
+        num_rows_as_str = self._properties.get('numRows')
+        if num_rows_as_str is not None:
+            return int(num_rows_as_str)
 
     @property
     def self_link(self):
@@ -247,7 +251,7 @@ class Table(object):
 
     @expires.setter
     def expires(self, value):
-        """Update atetime at which the table will be removed.
+        """Update datetime at which the table will be removed.
 
         :type value: ``datetime.datetime``, or ``NoneType``
         :param value: the new expiration time, or None

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -216,6 +216,50 @@ class TestTable(unittest2.TestCase, _SchemaBase):
                               schema=[full_name, age])
         self.assertEqual(table.schema, [full_name, age])
 
+    def test_num_bytes_getter(self):
+        client = _Client(self.PROJECT)
+        dataset = _Dataset(client)
+        table = self._makeOne(self.TABLE_NAME, dataset)
+
+        # Check with no value set.
+        self.assertEqual(table.num_bytes, None)
+
+        num_bytes = 1337
+        # Check with integer value set.
+        table._properties = {'numBytes': num_bytes}
+        self.assertEqual(table.num_bytes, num_bytes)
+
+        # Check with a string value set.
+        table._properties = {'numBytes': str(num_bytes)}
+        self.assertEqual(table.num_bytes, num_bytes)
+
+        # Check with invalid int value.
+        table._properties = {'numBytes': 'x'}
+        with self.assertRaises(ValueError):
+            getattr(table, 'num_bytes')
+
+    def test_num_rows_getter(self):
+        client = _Client(self.PROJECT)
+        dataset = _Dataset(client)
+        table = self._makeOne(self.TABLE_NAME, dataset)
+
+        # Check with no value set.
+        self.assertEqual(table.num_rows, None)
+
+        num_rows = 42
+        # Check with integer value set.
+        table._properties = {'numRows': num_rows}
+        self.assertEqual(table.num_rows, num_rows)
+
+        # Check with a string value set.
+        table._properties = {'numRows': str(num_rows)}
+        self.assertEqual(table.num_rows, num_rows)
+
+        # Check with invalid int value.
+        table._properties = {'numRows': 'x'}
+        with self.assertRaises(ValueError):
+            getattr(table, 'num_rows')
+
     def test_schema_setter_non_list(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)


### PR DESCRIPTION
Also fixing `Table.expires` docstring typo.