### PR TITLE
Adding property to get a table identifier for a query.

### DIFF
--- a/docs/bigquery-usage.rst
+++ b/docs/bigquery-usage.rst
@@ -281,7 +281,7 @@ Run a query which can be expected to complete within bounded time:
    >>> from gcloud import bigquery
    >>> client = bigquery.Client()
    >>> query = """\
-   SELECT count(*) AS age_count FROM dataset_name.person_ages
+   SELECT count(*) AS age_count FROM [project-name:dataset_name.person_ages]
    """
    >>> results = client.run_sync_query(query, timeout_ms=1000)
    >>> retry_count = 100
@@ -311,7 +311,7 @@ Background a query, loading the results into a table:
    >>> query = """\
    SELECT firstname + ' ' + last_name AS full_name,
           FLOOR(DATEDIFF(CURRENT_DATE(), birth_date) / 365) AS age
-    FROM dataset_name.persons
+    FROM [project-name:dataset_name.person_ages]
    """
    >>> dataset = client.dataset('dataset_name')
    >>> table = dataset.table(name='person_ages')

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -133,6 +133,33 @@ class Table(object):
         self._schema = tuple(value)
 
     @property
+    def query_id(self):
+        """The identifier for the table to be used in a query.
+
+        This is of the form
+
+            ``"{project_name}:{dataset_name}.{table_name}"``
+
+        and brackets will be added if the project name includes a
+        dash. For reference, see:
+
+        https://cloud.google.com/bigquery/query-reference#from
+
+        .. note::
+
+            This is identical to the ID (``table_id``) returned from the
+            server, but that value from the server will not have the
+            square brackets added.
+
+        :rtype: string
+        :returns: The table identifier to be used in a query.
+        """
+        query_parts = [self.project, ':', self.dataset_name, '.', self.name]
+        if '-' in self.project:
+            query_parts = ['['] + query_parts + [']']
+        return ''.join(query_parts)
+
+    @property
     def created(self):
         """Datetime at which the table was created.
 

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -216,6 +216,23 @@ class TestTable(unittest2.TestCase, _SchemaBase):
                               schema=[full_name, age])
         self.assertEqual(table.schema, [full_name, age])
 
+    def test_query_id_property(self):
+        client = _Client(self.PROJECT)
+        dataset = _Dataset(client)
+        table = self._makeOne(self.TABLE_NAME, dataset)
+        expected_result = ''.join([self.PROJECT, ':', self.DS_NAME,
+                                   '.', self.TABLE_NAME])
+        self.assertEqual(table.query_id, expected_result)
+
+    def test_query_id_property_with_hyphen(self):
+        curr_project = self.PROJECT + '-extra'
+        client = _Client(curr_project)
+        dataset = _Dataset(client)
+        table = self._makeOne(self.TABLE_NAME, dataset)
+        expected_result = ''.join(['[', curr_project, ':', self.DS_NAME,
+                                   '.', self.TABLE_NAME, ']'])
+        self.assertEqual(table.query_id, expected_result)
+
     def test_num_bytes_getter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)


### PR DESCRIPTION
Also updating BigQuery usage docs to use the correct form of table identifier in a query string.