### PR TITLE
Removing wrong-import-position Pylint ignore statements.

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -27,12 +27,10 @@ from six.moves.http_client import HTTPConnection  # pylint: disable=F0401
 
 from gcloud.environment_vars import PROJECT
 
-# pylint: disable=wrong-import-position
 try:
     from google.appengine.api import app_identity
 except ImportError:
     app_identity = None
-# pylint: enable=wrong-import-position
 
 
 _NOW = datetime.datetime.utcnow  # To be replaced by tests.

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -32,7 +32,6 @@ except ImportError:
     class _GAECreds(object):
         """Dummy class if not in App Engine environment."""
 
-# pylint: disable=wrong-import-position
 try:
     from google.appengine.api import app_identity
 except ImportError:
@@ -41,7 +40,6 @@ except ImportError:
 from gcloud._helpers import UTC
 from gcloud._helpers import _NOW
 from gcloud._helpers import _microseconds_from_datetime
-# pylint: enable=wrong-import-position
 
 
 def get_credentials():

--- a/pylintrc_default
+++ b/pylintrc_default
@@ -85,6 +85,16 @@ load-plugins=pylint.extensions.check_docs
 #                          return int(value)
 #                      else:
 #                          return float(value)
+# - wrong-import-position: This error is overzealous. It assumes imports are
+#                          completed whenever something non-trivial is
+#                          defined, e.g.
+#                              try:
+#                                  from foo import Bar
+#                              except ImportError:
+#                                  class Bar(object):
+#                                      """Hi everyone"""
+#                          and thus causes subsequent imports to be
+#                          diagnosed as out-of-order.
 disable =
     maybe-no-member,
     no-member,
@@ -94,6 +104,7 @@ disable =
     star-args,
     method-hidden,
     redefined-variable-type,
+    wrong-import-position,
 
 
 [REPORTS]


### PR DESCRIPTION
Able to address by reducing the complexity of the `except` blocks to make Pylint happy.

@tseaver This was a follow up to #1248, which I realized was possible after filing some issues with the Pylint folks.