### PR TITLE
Implementing Bigtable Cluster.list_tables().

### DIFF
--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -55,3 +55,12 @@ class Table(object):
         :returns: A row owned by this table.
         """
         return Row(row_key, self)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return (other.table_id == self.table_id and
+                other._cluster == self._cluster)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -56,3 +56,28 @@ class TestTable(unittest2.TestCase):
         self.assertTrue(isinstance(row, Row))
         self.assertEqual(row._row_key, row_key)
         self.assertEqual(row._table, table)
+
+    def test___eq__(self):
+        table_id = 'table_id'
+        cluster = object()
+        table1 = self._makeOne(table_id, cluster)
+        table2 = self._makeOne(table_id, cluster)
+        self.assertEqual(table1, table2)
+
+    def test___eq__type_differ(self):
+        table1 = self._makeOne('table_id', None)
+        table2 = object()
+        self.assertNotEqual(table1, table2)
+
+    def test___ne__same_value(self):
+        table_id = 'table_id'
+        cluster = object()
+        table1 = self._makeOne(table_id, cluster)
+        table2 = self._makeOne(table_id, cluster)
+        comparison_val = (table1 != table2)
+        self.assertFalse(comparison_val)
+
+    def test___ne__(self):
+        table1 = self._makeOne('table_id1', 'cluster1')
+        table2 = self._makeOne('table_id2', 'cluster2')
+        self.assertNotEqual(table1, table2)


### PR DESCRIPTION
This uses the table stub instead of the cluster stub. This
method is actually talking to a different service than
every method until now.

Also implementing `Table.__eq__` so table comparison succeeds
in unit tests.