### PR TITLE
Put finishing touches on Bigtable Cluster.

### DIFF
--- a/gcloud/bigtable/cluster.py
+++ b/gcloud/bigtable/cluster.py
@@ -227,6 +227,19 @@ class Operation(object):
 class Cluster(object):
     """Representation of a Google Cloud Bigtable Cluster.
 
+    We can use a :class:`Cluster` to:
+
+    * :meth:`reload` itself
+    * :meth:`create` itself
+    * :meth:`update` itself
+    * :meth:`delete` itself
+    * :meth:`undelete` itself
+
+    .. note::
+
+        For now, we leave out the ``default_storage_type`` (an enum)
+        which if not sent will end up as :data:`.data_pb2.STORAGE_SSD`.
+
     :type zone: str
     :param zone: The name of the zone where the cluster resides.
 
@@ -386,7 +399,7 @@ class Cluster(object):
             request_pb, self._client.timeout_seconds)
 
         op_id, op_begin = _process_operation(cluster_pb.current_operation)
-        return Operation('create', op_id, op_begin)
+        return Operation('create', op_id, op_begin, cluster=self)
 
     def update(self):
         """Update this cluster.
@@ -417,7 +430,7 @@ class Cluster(object):
             request_pb, self._client.timeout_seconds)
 
         op_id, op_begin = _process_operation(cluster_pb.current_operation)
-        return Operation('update', op_id, op_begin)
+        return Operation('update', op_id, op_begin, cluster=self)
 
     def delete(self):
         """Delete this cluster.
@@ -480,7 +493,7 @@ class Cluster(object):
             request_pb, self._client.timeout_seconds)
 
         op_id, op_begin = _process_operation(operation_pb2)
-        return Operation('undelete', op_id, op_begin)
+        return Operation('undelete', op_id, op_begin, cluster=self)
 
     def list_tables(self):
         """List the tables in this cluster.

--- a/gcloud/bigtable/test_cluster.py
+++ b/gcloud/bigtable/test_cluster.py
@@ -384,7 +384,8 @@ class TestCluster(unittest2.TestCase):
         client._cluster_stub = stub = _FakeStub(response_pb)
 
         # Create expected_result.
-        expected_result = MUT.Operation('create', op_id, op_begin)
+        expected_result = MUT.Operation('create', op_id, op_begin,
+                                        cluster=cluster)
 
         # Create the mocks.
         prep_create_called = []
@@ -452,7 +453,8 @@ class TestCluster(unittest2.TestCase):
         # Create expected_result.
         op_id = 5678
         op_begin = object()
-        expected_result = MUT.Operation('update', op_id, op_begin)
+        expected_result = MUT.Operation('update', op_id, op_begin,
+                                        cluster=cluster)
 
         # Create mocks
         process_operation_called = []
@@ -541,7 +543,8 @@ class TestCluster(unittest2.TestCase):
         # Create expected_result.
         op_id = 5678
         op_begin = object()
-        expected_result = MUT.Operation('undelete', op_id, op_begin)
+        expected_result = MUT.Operation('undelete', op_id, op_begin,
+                                        cluster=cluster)
 
         # Create the mocks.
         process_operation_called = []


### PR DESCRIPTION
In particular, updating the class docstring and passing the current cluster in when creating a new `Operation` from a cluster operation.

These were noticed when updating the system tests in the `gcloud-python-bigtable` project.