### PR TITLE
Workaround tox 2.3.0 regression.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD
 
 [testenv:docs-rtd]
 setenv =
-    {[testenv]setenv}
+    PYTHONPATH = {toxinidir}/_testing
     LOCAL_RTD = True
 basepython = {[testenv:docs]basepython}
 commands =


### PR DESCRIPTION
See:
https://bitbucket.org/hpk42/tox/issues/294/tox-23-regression.