### PR TITLE
Fixing pub/sub link in resource manager.

### DIFF
--- a/gcloud/resource_manager/project.py
+++ b/gcloud/resource_manager/project.py
@@ -167,7 +167,7 @@ class Project(object):
         """API call:  test the existence of a project via a ``GET`` request.
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/projects/get
+        https://cloud.google.com/resource-manager/reference/rest/v1beta1/projects/get
 
         :type client: :class:`gcloud.resource_manager.client.Client` or
                       :data:`NoneType <types.NoneType>`


### PR DESCRIPTION
Link currently points to a non-existent page in the pub/sub docs.