### PR TITLE
Explicitly using API_BASE_URL from current connection in datastore.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -39,6 +39,9 @@ class Connection(connection.Connection):
                          from :mod:`gcloud.connection`.
     """
 
+    API_BASE_URL = 'https://www.googleapis.com'
+    """The base of the API call URL."""
+
     API_VERSION = 'v1beta2'
     """The version of the API, used in building the API call's URL."""
 
@@ -54,7 +57,7 @@ class Connection(connection.Connection):
         super(Connection, self).__init__(credentials=credentials, http=http)
         if api_base_url is None:
             api_base_url = os.getenv(GCD_HOST,
-                                     connection.API_BASE_URL)
+                                     self.__class__.API_BASE_URL)
         self.api_base_url = api_base_url
 
     def _request(self, dataset_id, method, data):


### PR DESCRIPTION
This can be seen as a bug-fix where a sub-class may not be able to impact the URIs generated.

In addition, we added the (repeated) value of the base connection's `API_BASE_URL` in advance of swapping it out for `v1beta3`.