### PR TITLE
Removing serializable option from datastore Transaction.

### DIFF
--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -442,17 +442,12 @@ class Client(_BaseClient):
         """
         return Batch(self)
 
-    def transaction(self, serializable=False):
+    def transaction(self):
         """Proxy to :class:`gcloud.datastore.transaction.Transaction`.
 
         Passes our ``dataset_id``.
-
-        :type serializable: boolean
-        :param serializable: if true, perform this transaction at
-                             ``serializable`` isolation level;  otherwise,
-                             perform it at ``snapshot`` level.
         """
-        return Transaction(self, serializable=serializable)
+        return Transaction(self)
 
     def query(self, **kwargs):
         """Proxy to :class:`gcloud.datastore.query.Query`.

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -270,7 +270,7 @@ class Connection(connection.Connection):
             response.batch.skipped_results,
         )
 
-    def begin_transaction(self, dataset_id, serializable=False):
+    def begin_transaction(self, dataset_id):
         """Begin a transaction.
 
         Maps the ``DatastoreService.BeginTransaction`` protobuf RPC.
@@ -278,26 +278,14 @@ class Connection(connection.Connection):
         :type dataset_id: string
         :param dataset_id: The ID dataset to which the transaction applies.
 
-        :type serializable: boolean
-        :param serializable: Boolean indicating if the isolation level of the
-                             transaction should be SERIALIZABLE (True) or
-                             SNAPSHOT (False).
-
         :rtype: :class:`._datastore_v1_pb2.BeginTransactionResponse`
         :returns': the result protobuf for the begin transaction request.
         """
         request = datastore_pb.BeginTransactionRequest()
-
-        if serializable:
-            request.isolation_level = (
-                datastore_pb.BeginTransactionRequest.SERIALIZABLE)
-        else:
-            request.isolation_level = (
-                datastore_pb.BeginTransactionRequest.SNAPSHOT)
-
+        request.isolation_level = (
+            datastore_pb.BeginTransactionRequest.SERIALIZABLE)
         response = self._rpc(dataset_id, 'beginTransaction', request,
                              datastore_pb.BeginTransactionResponse)
-
         return response.transaction
 
     def commit(self, dataset_id, mutation_pb, transaction_id):

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -858,21 +858,7 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(xact, _Dummy))
         self.assertEqual(xact.args, (client,))
-        self.assertEqual(xact.kwargs, {'serializable': False})
-
-    def test_transaction_explicit(self):
-        from gcloud.datastore import client as MUT
-        from gcloud._testing import _Monkey
-
-        creds = object()
-        client = self._makeOne(credentials=creds)
-
-        with _Monkey(MUT, Transaction=_Dummy):
-            xact = client.transaction(serializable=True)
-
-        self.assertTrue(isinstance(xact, _Dummy))
-        self.assertEqual(xact.args, (client,))
-        self.assertEqual(xact.kwargs, {'serializable': True})
+        self.assertEqual(xact.kwargs, {})
 
     def test_query_w_client(self):
         KIND = 'KIND'

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -635,7 +635,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(request.partition_id.namespace, 'NS')
         self.assertEqual(request.query, q_pb)
 
-    def test_begin_transaction_default_serialize(self):
+    def test_begin_transaction(self):
         from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
 
         DATASET_ID = 'DATASET'
@@ -653,31 +653,6 @@ class TestConnection(unittest2.TestCase):
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         self.assertEqual(conn.begin_transaction(DATASET_ID), TRANSACTION)
-        cw = http._called_with
-        self._verifyProtobufCall(cw, URI, conn)
-        rq_class = datastore_pb.BeginTransactionRequest
-        request = rq_class()
-        request.ParseFromString(cw['body'])
-        self.assertEqual(request.isolation_level, rq_class.SNAPSHOT)
-
-    def test_begin_transaction_explicit_serialize(self):
-        from gcloud.datastore import _datastore_v1_pb2 as datastore_pb
-
-        DATASET_ID = 'DATASET'
-        TRANSACTION = b'TRANSACTION'
-        rsp_pb = datastore_pb.BeginTransactionResponse()
-        rsp_pb.transaction = TRANSACTION
-        conn = self._makeOne()
-        URI = '/'.join([
-            conn.api_base_url,
-            'datastore',
-            conn.API_VERSION,
-            'datasets',
-            DATASET_ID,
-            'beginTransaction',
-        ])
-        http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
-        self.assertEqual(conn.begin_transaction(DATASET_ID, True), TRANSACTION)
         cw = http._called_with
         self._verifyProtobufCall(cw, URI, conn)
         rq_class = datastore_pb.BeginTransactionRequest

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -37,22 +37,6 @@ class TestTransaction(unittest2.TestCase):
         self.assertEqual(xact._status, self._getTargetClass()._INITIAL)
         self.assertTrue(isinstance(xact.mutation, Mutation))
         self.assertEqual(len(xact._auto_id_entities), 0)
-        self.assertFalse(xact.serializable)
-
-    def test_ctor_explicit(self):
-        from gcloud.datastore._datastore_v1_pb2 import Mutation
-
-        _DATASET = 'DATASET'
-        connection = _Connection()
-        client = _Client(_DATASET, connection)
-        xact = self._makeOne(client, serializable=True)
-        self.assertEqual(xact.dataset_id, _DATASET)
-        self.assertEqual(xact.connection, connection)
-        self.assertEqual(xact.id, None)
-        self.assertEqual(xact._status, self._getTargetClass()._INITIAL)
-        self.assertTrue(isinstance(xact.mutation, Mutation))
-        self.assertEqual(len(xact._auto_id_entities), 0)
-        self.assertTrue(xact.serializable)
 
     def test_current(self):
         from gcloud.datastore.test_client import _NoCommitBatch
@@ -80,25 +64,14 @@ class TestTransaction(unittest2.TestCase):
         self.assertTrue(xact1.current() is None)
         self.assertTrue(xact2.current() is None)
 
-    def test_begin_wo_serializable(self):
+    def test_begin(self):
         _DATASET = 'DATASET'
         connection = _Connection(234)
         client = _Client(_DATASET, connection)
         xact = self._makeOne(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
-        self.assertEqual(connection._begun[0], _DATASET)
-        self.assertFalse(connection._begun[1])
-
-    def test_begin_w_serializable(self):
-        _DATASET = 'DATASET'
-        connection = _Connection(234)
-        client = _Client(_DATASET, connection)
-        xact = self._makeOne(client, serializable=True)
-        xact.begin()
-        self.assertEqual(xact.id, 234)
-        self.assertEqual(connection._begun[0], _DATASET)
-        self.assertTrue(connection._begun[1])
+        self.assertEqual(connection._begun, _DATASET)
 
     def test_begin_tombstoned(self):
         _DATASET = 'DATASET'
@@ -107,8 +80,7 @@ class TestTransaction(unittest2.TestCase):
         xact = self._makeOne(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
-        self.assertEqual(connection._begun[0], _DATASET)
-        self.assertFalse(connection._begun[1])
+        self.assertEqual(connection._begun, _DATASET)
 
         xact.rollback()
         self.assertEqual(xact.id, None)
@@ -162,8 +134,7 @@ class TestTransaction(unittest2.TestCase):
         xact._mutation = mutation = object()
         with xact:
             self.assertEqual(xact.id, 234)
-            self.assertEqual(connection._begun[0], _DATASET)
-            self.assertFalse(connection._begun[1])
+            self.assertEqual(connection._begun, _DATASET)
         self.assertEqual(connection._committed, (_DATASET, mutation, 234))
         self.assertEqual(xact.id, None)
 
@@ -175,13 +146,12 @@ class TestTransaction(unittest2.TestCase):
         _DATASET = 'DATASET'
         connection = _Connection(234)
         client = _Client(_DATASET, connection)
-        xact = self._makeOne(client, serializable=True)
+        xact = self._makeOne(client)
         xact._mutation = object()
         try:
             with xact:
                 self.assertEqual(xact.id, 234)
-                self.assertEqual(connection._begun[0], _DATASET)
-                self.assertTrue(connection._begun[1])
+                self.assertEqual(connection._begun, _DATASET)
                 raise Foo()
         except Foo:
             self.assertEqual(xact.id, None)
@@ -209,8 +179,8 @@ class _Connection(object):
         self._xact_id = xact_id
         self._commit_result = _CommitResult()
 
-    def begin_transaction(self, dataset_id, serializable):
-        self._begun = (dataset_id, serializable)
+    def begin_transaction(self, dataset_id):
+        self._begun = dataset_id
         return self._xact_id
 
     def rollback(self, dataset_id, transaction_id):

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -107,8 +107,8 @@ class TestDatastoreSave(TestDatastore):
     def test_post_with_generated_id(self):
         self._generic_test_post()
 
-    def test_save_multiple_serializable(self):
-        with CLIENT.transaction(serializable=True) as xact:
+    def test_save_multiple(self):
+        with CLIENT.transaction() as xact:
             entity1 = self._get_post()
             xact.put(entity1)
             # Register entity to be deleted.


### PR DESCRIPTION
This is in advance of the option being removed in v1beta3. Since in v1beta3:
    
> All transactions are now serializable
    
we set the isolation to always be serializable.

-----

@pcostell Is this "safe" to do as prep for the version upgrade?

Also, is there an equivalent replacement in `v1beta3`? AFAICT the isolation level is just gone.