### PR TITLE
Adding remaining Bigtable regex row filters.

### DIFF
--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -124,3 +124,63 @@ class FamilyNameRegexFilter(_RegexFilter):
         :returns: The converted current object.
         """
         return data_pb2.RowFilter(family_name_regex_filter=self.regex)
+
+
+class ColumnQualifierRegexFilter(_RegexFilter):
+    """Row filter for a column qualifier regular expression.
+
+    The ``regex`` must be valid RE2 patterns. See Google's
+    `RE2 reference`_ for the accepted syntax.
+
+    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
+
+    .. note::
+
+        Special care need be used with the expression used. Since
+        each of these properties can contain arbitrary bytes, the ``\\C``
+        escape sequence must be used if a true wildcard is desired. The ``.``
+        character will not match the new line character ``\\n``, which may be
+        present in a binary value.
+
+    :type regex: bytes
+    :param regex: A regular expression (RE2) to match cells from column that
+                  match this regex (irrespective of column family).
+    """
+
+    def to_pb(self):
+        """Converts the row filter to a protobuf.
+
+        :rtype: :class:`.data_pb2.RowFilter`
+        :returns: The converted current object.
+        """
+        return data_pb2.RowFilter(column_qualifier_regex_filter=self.regex)
+
+
+class ValueRegexFilter(_RegexFilter):
+    """Row filter for a value regular expression.
+
+    The ``regex`` must be valid RE2 patterns. See Google's
+    `RE2 reference`_ for the accepted syntax.
+
+    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
+
+    .. note::
+
+        Special care need be used with the expression used. Since
+        each of these properties can contain arbitrary bytes, the ``\\C``
+        escape sequence must be used if a true wildcard is desired. The ``.``
+        character will not match the new line character ``\\n``, which may be
+        present in a binary value.
+
+    :type regex: bytes
+    :param regex: A regular expression (RE2) to match cells with values that
+                  match this regex.
+    """
+
+    def to_pb(self):
+        """Converts the row filter to a protobuf.
+
+        :rtype: :class:`.data_pb2.RowFilter`
+        :returns: The converted current object.
+        """
+        return data_pb2.RowFilter(value_regex_filter=self.regex)

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -118,3 +118,41 @@ class TestFamilyNameRegexFilter(unittest2.TestCase):
         pb_val = row_filter.to_pb()
         expected_pb = data_pb2.RowFilter(family_name_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
+
+
+class TestColumnQualifierRegexFilter(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud.bigtable.row import ColumnQualifierRegexFilter
+        return ColumnQualifierRegexFilter
+
+    def _makeOne(self, *args, **kwargs):
+        return self._getTargetClass()(*args, **kwargs)
+
+    def test_to_pb(self):
+        from gcloud.bigtable._generated import bigtable_data_pb2 as data_pb2
+
+        regex = b'column-regex'
+        row_filter = self._makeOne(regex)
+        pb_val = row_filter.to_pb()
+        expected_pb = data_pb2.RowFilter(column_qualifier_regex_filter=regex)
+        self.assertEqual(pb_val, expected_pb)
+
+
+class TestValueRegexFilter(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud.bigtable.row import ValueRegexFilter
+        return ValueRegexFilter
+
+    def _makeOne(self, *args, **kwargs):
+        return self._getTargetClass()(*args, **kwargs)
+
+    def test_to_pb(self):
+        from gcloud.bigtable._generated import bigtable_data_pb2 as data_pb2
+
+        regex = b'value-regex'
+        row_filter = self._makeOne(regex)
+        pb_val = row_filter.to_pb()
+        expected_pb = data_pb2.RowFilter(value_regex_filter=regex)
+        self.assertEqual(pb_val, expected_pb)


### PR DESCRIPTION
Row filter for a column name (irrespective of column family)
and a value (in any cell).