### PR TITLE
Fix 'Client.list_jobs' to use 'full' projection.

### DIFF
--- a/gcloud/bigquery/client.py
+++ b/gcloud/bigquery/client.py
@@ -159,7 +159,7 @@ class Client(JSONClient):
                   retrieved with another call, passing that value as
                   ``page_token``).
         """
-        params = {}
+        params = {'projection': 'full'}
 
         if max_results is not None:
             params['maxResults'] = max_results

--- a/gcloud/bigquery/test_client.py
+++ b/gcloud/bigquery/test_client.py
@@ -260,7 +260,7 @@ class TestClient(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['query_params'], {})
+        self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_explicit_empty(self):
         PROJECT = 'PROJECT'
@@ -282,7 +282,8 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % PATH)
         self.assertEqual(req['query_params'],
-                         {'maxResults': 1000,
+                         {'projection': 'full',
+                          'maxResults': 1000,
                           'pageToken': TOKEN,
                           'allUsers': True,
                           'stateFilter': 'done'})


### PR DESCRIPTION
We can't parse/create job instances w/o full configuration.