### PR TITLE
Allow for 'sourceUris' to be missing in load job config.

### DIFF
--- a/gcloud/bigquery/client.py
+++ b/gcloud/bigquery/client.py
@@ -159,7 +159,7 @@ class Client(JSONClient):
                   retrieved with another call, passing that value as
                   ``page_token``).
         """
-        params = {}
+        params = {'projection': 'full'}
 
         if max_results is not None:
             params['maxResults'] = max_results

--- a/gcloud/bigquery/job.py
+++ b/gcloud/bigquery/job.py
@@ -615,7 +615,7 @@ class LoadTableFromStorageJob(_AsyncJob):
         dest_config = config['destinationTable']
         dataset = Dataset(dest_config['datasetId'], client)
         destination = Table(dest_config['tableId'], dataset)
-        source_urls = config['sourceUris']
+        source_urls = config.get('sourceUris', ())
         job = cls(name, destination, source_urls, client=client)
         job._set_properties(resource)
         return job

--- a/gcloud/bigquery/test_client.py
+++ b/gcloud/bigquery/test_client.py
@@ -260,7 +260,7 @@ class TestClient(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['query_params'], {})
+        self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_explicit_empty(self):
         PROJECT = 'PROJECT'
@@ -282,7 +282,8 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/%s' % PATH)
         self.assertEqual(req['query_params'],
-                         {'maxResults': 1000,
+                         {'projection': 'full',
+                          'maxResults': 1000,
                           'pageToken': TOKEN,
                           'allUsers': True,
                           'stateFilter': 'done'})


### PR DESCRIPTION
Uses #1311 as a base.

E.g., the jobs created via 'Table.upload_from_file' do not have source URIs.