### PR TITLE
Reducing datastore commit reliance on structure of response.

### DIFF
--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -185,13 +185,13 @@ class Batch(object):
         however it can be called explicitly if you don't want to use a
         context manager.
         """
-        response = self.connection.commit(
+        _, updated_keys = self.connection.commit(
             self.dataset_id, self.mutation, self._id)
         # If the back-end returns without error, we are guaranteed that
         # the response's 'insert_auto_id_key' will match (length and order)
         # the request's 'insert_auto_id` entities, which are derived from
         # our '_partial_key_entities' (no partial success).
-        for new_key_pb, entity in zip(response.insert_auto_id_key,
+        for new_key_pb, entity in zip(updated_keys,
                                       self._partial_key_entities):
             new_id = new_key_pb.path_element[-1].id
             entity.key = entity.key.completed_key(new_id)

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -351,12 +351,6 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(connection._committed, [])
 
 
-class _CommitResult(object):
-
-    def __init__(self, *new_keys):
-        self.insert_auto_id_key = [_KeyPB(key) for key in new_keys]
-
-
 class _PathElementPB(object):
 
     def __init__(self, id):
@@ -374,12 +368,13 @@ class _Connection(object):
     _save_result = (False, None)
 
     def __init__(self, *new_keys):
-        self._commit_result = _CommitResult(*new_keys)
+        self._completed_keys = [_KeyPB(key) for key in new_keys]
         self._committed = []
+        self._index_updates = 0
 
     def commit(self, dataset_id, mutation, transaction_id):
         self._committed.append((dataset_id, mutation, transaction_id))
-        return self._commit_result
+        return self._index_updates, self._completed_keys
 
 
 class _Entity(dict):

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -113,8 +113,7 @@ class TestTransaction(unittest2.TestCase):
         _KIND = 'KIND'
         _ID = 123
         connection = _Connection(234)
-        connection._commit_result = _CommitResult(
-            _make_key(_KIND, _ID, _DATASET))
+        connection._completed_keys = [_make_key(_KIND, _ID, _DATASET)]
         client = _Client(_DATASET, connection)
         xact = self._makeOne(client)
         entity = _Entity()
@@ -177,7 +176,8 @@ class _Connection(object):
 
     def __init__(self, xact_id=123):
         self._xact_id = xact_id
-        self._commit_result = _CommitResult()
+        self._completed_keys = []
+        self._index_updates = 0
 
     def begin_transaction(self, dataset_id):
         self._begun = dataset_id
@@ -188,13 +188,7 @@ class _Connection(object):
 
     def commit(self, dataset_id, mutation, transaction_id):
         self._committed = (dataset_id, mutation, transaction_id)
-        return self._commit_result
-
-
-class _CommitResult(object):
-
-    def __init__(self, *new_keys):
-        self.insert_auto_id_key = new_keys
+        return self._index_updates, self._completed_keys
 
 
 class _Entity(dict):


### PR DESCRIPTION
Also moving out the response parsing into a helper which can
be monkey-patched out during testing.

This is for the `v1beta2` to `v1beta3` change. Currently the
`CommitResponse` object contains a single `MutationResult` that holds
an integer `index_updates` field and a repeated field (`insert_auto_id_key`)
of partial `Key`s that were completed in the `commit`.

In `v1beta3`, the `CommitResponse` directly holds the integer `index_updates`
as well as a list of `MutationResult`s. Additionally, the definition of
`MutationResult` no longer has `index_updates` (obviously given the last
sentence) and no longer holds a list of `Key`s. Instead, it holds a single
`Key` in the `key` field. What's more, the list of `MutationResult`s
corresponds to every single `Entity` modified in the commit. For those
where a partial `Key` was completed, the `MutationResult.key` holds the
new key. For those were **no key was completed**, `MutationResult.key`
is empty.