### PR TITLE
Bringing auto-gen import re-writing up to date with files.

### DIFF
--- a/scripts/rewrite_imports.py
+++ b/scripts/rewrite_imports.py
@@ -49,8 +49,10 @@ def transform_old_to_new(line, old_module, new_module,
         "from {old_module} import ..."
     then checks if the line contains
         "import {old_module} ..."
-    and finally checks if the line starts with (ignoring whitespace)
+    then checks if the line starts with (ignoring whitespace)
         "{old_module} ..."
+    and finally checks if the line contians
+        "'some-dict-key': {old_module} ..."
 
     In any of these cases, "{old_module}" is replaced with "{new_module}".
     If none match, nothing is returned.
@@ -95,6 +97,11 @@ def transform_old_to_new(line, old_module, new_module,
     if line.lstrip().startswith(old_module):
         # Only replace the first instance of the old_module.
         return line.replace(old_module, new_module, 1)
+
+    # Finally check for usage in dictionaries.
+    if ': ' + old_module in line:
+        # Only replace the first instance of the old_module.
+        return line.replace(': ' + old_module, ': ' + new_module, 1)
 
 
 def transform_line(line):


### PR DESCRIPTION
There were some manual (via `sed` with the command line) edits made for certain gRPC related parts of `*_pb2.py` files that used dispatch tables to map service names onto request/response protobuf types. For example

```python
  request_deserializers = {
    ('google.longrunning.Operations', 'CancelOperation'): google.longrunning.operations_pb2.CancelOperationRequest.FromString,
    ('google.longrunning.Operations', 'DeleteOperation'): google.longrunning.operations_pb2.DeleteOperationRequest.FromString,
    ('google.longrunning.Operations', 'GetOperation'): google.longrunning.operations_pb2.GetOperationRequest.FromString,
    ('google.longrunning.Operations', 'ListOperations'): google.longrunning.operations_pb2.ListOperationsRequest.FromString,
  }
```

needed to be transformed into

```python
  request_deserializers = {
    ('google.longrunning.Operations', 'CancelOperation'): gcloud.bigtable._generated.operations_pb2.CancelOperationRequest.FromString,
    ('google.longrunning.Operations', 'DeleteOperation'): gcloud.bigtable._generated.operations_pb2.DeleteOperationRequest.FromString,
    ('google.longrunning.Operations', 'GetOperation'): gcloud.bigtable._generated.operations_pb2.GetOperationRequest.FromString,
    ('google.longrunning.Operations', 'ListOperations'): gcloud.bigtable._generated.operations_pb2.ListOperationsRequest.FromString,
  }
```