### PR TITLE
Making pb2 auto-gen script also copy over .proto files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GENERATED_DIR=$(shell pwd)/generated_python
-FINAL_DIR=gcloud/bigtable/_generated
+FINAL_DIR=$(shell pwd)/gcloud/bigtable/_generated
 GRPC_PLUGIN=grpc_python_plugin
+PROTOC_CMD=protoc
+PROTOS_DIR=$(shell pwd)/cloud-bigtable-client/bigtable-protos/src/main/proto
 
 help:
 	@echo 'Makefile for gcloud-python Bigtable protos                      '
@@ -13,59 +15,54 @@ generate:
 	[ -d cloud-bigtable-client ] || git clone https://github.com/GoogleCloudPlatform/cloud-bigtable-client
 	cd cloud-bigtable-client && git pull origin master
 	mkdir -p $(GENERATED_DIR)
-	# Data API
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) google/bigtable/v1/*.proto
+	# Generate all *_pb2.py files.
+	$(PROTOC_CMD) \
+	    --proto_path=$(PROTOS_DIR) \
+	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
+	    --python_out=$(GENERATED_DIR) \
+	    --grpc_out=$(GENERATED_DIR) \
+	    $(PROTOS_DIR)/google/bigtable/v1/*.proto \
+	    $(PROTOS_DIR)/google/bigtable/admin/cluster/v1/*.proto \
+	    $(PROTOS_DIR)/google/bigtable/admin/table/v1/*.proto \
+	    $(PROTOS_DIR)/google/api/*.proto \
+	    $(PROTOS_DIR)/google/protobuf/any.proto \
+	    $(PROTOS_DIR)/google/protobuf/duration.proto \
+	    $(PROTOS_DIR)/google/protobuf/empty.proto \
+	    $(PROTOS_DIR)/google/protobuf/timestamp.proto \
+	    $(PROTOS_DIR)/google/longrunning/operations.proto \
+	    $(PROTOS_DIR)/google/rpc/status.proto
+	# Move the newly generated *_pb2.py files into our library.
 	mv $(GENERATED_DIR)/google/bigtable/v1/* $(FINAL_DIR)
-	# Cluster API
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/bigtable/admin/cluster/v1/*.proto
 	mv $(GENERATED_DIR)/google/bigtable/admin/cluster/v1/* $(FINAL_DIR)
-	# Table API
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/bigtable/admin/table/v1/*.proto
 	mv $(GENERATED_DIR)/google/bigtable/admin/table/v1/* $(FINAL_DIR)
-	# Auxiliary protos
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/api/*.proto
 	mv $(GENERATED_DIR)/google/api/* $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/protobuf/any.proto
 	mv $(GENERATED_DIR)/google/protobuf/any_pb2.py $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/protobuf/duration.proto
 	mv $(GENERATED_DIR)/google/protobuf/duration_pb2.py $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/protobuf/empty.proto
 	mv $(GENERATED_DIR)/google/protobuf/empty_pb2.py $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/protobuf/timestamp.proto
 	mv $(GENERATED_DIR)/google/protobuf/timestamp_pb2.py $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/longrunning/operations.proto
 	mv $(GENERATED_DIR)/google/longrunning/operations_pb2.py $(FINAL_DIR)
-	cd cloud-bigtable-client/bigtable-protos/src/main/proto && \
-	    protoc --python_out=$(GENERATED_DIR) --grpc_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    google/rpc/status.proto
 	mv $(GENERATED_DIR)/google/rpc/status_pb2.py $(FINAL_DIR)
+	# Remove all existing *.proto files before we replace
+	rm -f $(FINAL_DIR)/*.proto
+	# Copy over the *.proto files into our library.
+	cp $(PROTOS_DIR)/google/bigtable/v1/*.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/bigtable/admin/cluster/v1/*.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/bigtable/admin/table/v1/*.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/api/*.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/protobuf/any.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/protobuf/duration.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/protobuf/empty.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/protobuf/timestamp.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/longrunning/operations.proto $(FINAL_DIR)
+	cp $(PROTOS_DIR)/google/rpc/status.proto $(FINAL_DIR)
+	# Rename all *.proto files in our library with an
+	# underscore and remove executable bit.
+	cd $(FINAL_DIR) && \
+	    for filename in *.proto; do \
+	        chmod -x $$filename ; \
+	        mv $$filename _$$filename ; \
+	    done
+	# Rewrite the imports in the generated *_pb2.py files.
 	python scripts/rewrite_imports.py
 
 check_generate:


### PR DESCRIPTION
@tseaver As you'll notice, this is quite nasty. I'm open to suggestions for making this better. Some simple options:

- We are content that this is "good enough"
- I become competent using `bash`
- I rewrite this script in Python with judicious use of some system calls

FWIW, this is in advance of `v1beta3` for datastore, which will re-use some of these components (e.g. `timestamp`) so we need this pipeline to be a bit more polished.