### PR TITLE
Adding filter to Bigtable Row constructor.

### DIFF
--- a/gcloud/bigtable/_helpers.py
+++ b/gcloud/bigtable/_helpers.py
@@ -19,13 +19,19 @@ protobuf objects.
 """
 
 
+import platform
+
 from grpc.beta import implementations
 
 
 # See https://gist.github.com/dhermes/bbc5b7be1932bfffae77
 # for appropriate values on other systems.
-# NOTE: Even this path is Unix specific.
-SSL_CERT_FILE = '/etc/ssl/certs/ca-certificates.crt'
+_PLAT_SYS = platform.system()
+SSL_CERT_FILE = None
+if _PLAT_SYS == 'Linux':
+    SSL_CERT_FILE = '/etc/ssl/certs/ca-certificates.crt'
+elif _PLAT_SYS == 'Darwin':  # pragma: NO COVER
+    SSL_CERT_FILE = '/usr/local/etc/openssl/cert.pem'
 
 
 class MetadataTransformer(object):

--- a/gcloud/bigtable/column_family.py
+++ b/gcloud/bigtable/column_family.py
@@ -35,7 +35,7 @@ def _timedelta_to_duration_pb(timedelta_val):
     :type timedelta_val: :class:`datetime.timedelta`
     :param timedelta_val: A timedelta object.
 
-    :rtype: :class:`duration_pb2.Duration`
+    :rtype: :class:`.duration_pb2.Duration`
     :returns: A duration object equivalent to the time delta.
     """
     seconds_decimal = _total_seconds(timedelta_val)
@@ -144,7 +144,7 @@ class GCRuleUnion(GarbageCollectionRule):
     """Union of garbage collection rules.
 
     :type rules: list
-    :param rules: List of :class:`GarbageCollectionRule`,
+    :param rules: List of :class:`GarbageCollectionRule`.
     """
 
     def __init__(self, rules):

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -28,11 +28,20 @@ class Row(object):
 
     :type table: :class:`Table <gcloud.bigtable.table.Table>`
     :param table: The table that owns the row.
+
+    :type filter_: :class:`RowFilter`
+    :param filter_: (Optional) Filter to be used for conditional mutations.
+                    If a filter is set, then the :class:`Row` will accumulate
+                    mutations for either a :data:`True` or :data:`False` state.
+                    When :meth:`commit`-ed, the mutations for the :data:`True`
+                    state will be applied if the filter matches any cells in
+                    the row, otherwise the :data:`False` state will be.
     """
 
-    def __init__(self, row_key, table):
+    def __init__(self, row_key, table, filter_=None):
         self._row_key = _to_bytes(row_key)
         self._table = table
+        self._filter = filter_
 
 
 class RowFilter(object):

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -44,6 +44,7 @@ class Table(object):
     * :meth:`create` the table
     * :meth:`rename` the table
     * :meth:`delete` the table
+    * :meth:`list_column_families` in the table
 
     :type table_id: str
     :param table_id: The ID of the table.
@@ -90,16 +91,20 @@ class Table(object):
         """
         return ColumnFamily(column_family_id, self, gc_rule=gc_rule)
 
-    def row(self, row_key):
+    def row(self, row_key, filter_=None):
         """Factory to create a row associated with this table.
 
         :type row_key: bytes
         :param row_key: The key for the row being created.
 
+        :type filter_: :class:`.RowFilter`
+        :param filter_: (Optional) Filter to be used for conditional mutations.
+                        See :class:`.Row` for more details.
+
         :rtype: :class:`.Row`
         :returns: A row owned by this table.
         """
-        return Row(row_key, self)
+        return Row(row_key, self, filter_=filter_)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -28,10 +28,12 @@ class TestRow(unittest2.TestCase):
     def test_constructor(self):
         row_key = b'row_key'
         table = object()
+        filter_ = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._makeOne(row_key, table, filter_=filter_)
         self.assertEqual(row._row_key, row_key)
         self.assertTrue(row._table is table)
+        self.assertTrue(row._filter is filter_)
 
     def test_constructor_with_unicode(self):
         row_key = u'row_key'

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -62,11 +62,13 @@ class TestTable(unittest2.TestCase):
         table_id = 'table-id'
         table = self._makeOne(table_id, None)
         row_key = b'row_key'
-        row = table.row(row_key)
+        filter_ = object()
+        row = table.row(row_key, filter_=filter_)
 
         self.assertTrue(isinstance(row, Row))
         self.assertEqual(row._row_key, row_key)
         self.assertEqual(row._table, table)
+        self.assertEqual(row._filter, filter_)
 
     def test___eq__(self):
         table_id = 'table_id'


### PR DESCRIPTION
Also

-   Adding `filter` to `Table`'s row factory
-   Bringing in some changes from original `gcloud-python-bigtable`
    project

    - Adding `SSL_CERT_FILE` path for Mac OS X (installed via
      `homebrew`)
    - Fixing some docstring typos / missing docstring list of
      class functionality