### PR TITLE
Replace dataset id with project in datastore

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -30,9 +30,9 @@ The main concepts with this API are:
   API.
 
 - :class:`gcloud.datastore.client.Client`
-  which represents a dataset ID (string) and namespace (string) bundled with
+  which represents a project (string) and namespace (string) bundled with
   a connection and has convenience methods for constructing objects with that
-  dataset ID / namespace.
+  project / namespace.
 
 - :class:`gcloud.datastore.entity.Entity`
   which represents a single entity in the datastore

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -73,11 +73,11 @@ class Batch(object):
         return self._client.current_batch
 
     @property
-    def dataset_id(self):
-        """Getter for dataset ID in which the batch will run.
+    def project(self):
+        """Getter for project in which the batch will run.
 
         :rtype: :class:`str`
-        :returns: The dataset ID in which the batch will run.
+        :returns: The project in which the batch will run.
         """
         return self._client.project
 
@@ -172,7 +172,7 @@ class Batch(object):
         if entity.key is None:
             raise ValueError("Entity must have a key")
 
-        if not _dataset_ids_equal(self.dataset_id, entity.key.dataset_id):
+        if not _dataset_ids_equal(self.project, entity.key.dataset_id):
             raise ValueError("Key must be from same dataset as batch")
 
         if entity.key.is_partial:
@@ -195,7 +195,7 @@ class Batch(object):
         if key.is_partial:
             raise ValueError("Key must be complete")
 
-        if not _dataset_ids_equal(self.dataset_id, key.dataset_id):
+        if not _dataset_ids_equal(self.project, key.dataset_id):
             raise ValueError("Key must be from same dataset as batch")
 
         key_pb = helpers._prepare_key_for_request(key.to_protobuf())
@@ -215,7 +215,7 @@ class Batch(object):
         context manager.
         """
         _, updated_keys = self.connection.commit(
-            self.dataset_id, self._commit_request, self._id)
+            self.project, self._commit_request, self._id)
         # If the back-end returns without error, we are guaranteed that
         # :meth:`Connection.commit` will return keys that match (length and
         # order) directly ``_partial_key_entities``.

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -22,7 +22,7 @@ https://cloud.google.com/datastore/docs/concepts/entities#Datastore_Batch_operat
 """
 
 from gcloud.datastore import helpers
-from gcloud.datastore.key import _dataset_ids_equal
+from gcloud.datastore.key import _projects_equal
 from gcloud.datastore._generated import datastore_pb2 as _datastore_pb2
 
 
@@ -172,8 +172,8 @@ class Batch(object):
         if entity.key is None:
             raise ValueError("Entity must have a key")
 
-        if not _dataset_ids_equal(self.project, entity.key.dataset_id):
-            raise ValueError("Key must be from same dataset as batch")
+        if not _projects_equal(self.project, entity.key.project):
+            raise ValueError("Key must be from same project as batch")
 
         if entity.key.is_partial:
             entity_pb = self._add_partial_key_entity_pb()
@@ -195,8 +195,8 @@ class Batch(object):
         if key.is_partial:
             raise ValueError("Key must be complete")
 
-        if not _dataset_ids_equal(self.project, key.dataset_id):
-            raise ValueError("Key must be from same dataset as batch")
+        if not _projects_equal(self.project, key.project):
+            raise ValueError("Key must be from same project as batch")
 
         key_pb = helpers._prepare_key_for_request(key.to_protobuf())
         self._add_delete_key_pb().CopyFrom(key_pb)

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -167,7 +167,7 @@ class Batch(object):
         :param entity: the entity to be saved.
 
         :raises: ValueError if entity has no key assigned, or if the key's
-                 ``dataset_id`` does not match ours.
+                 ``project`` does not match ours.
         """
         if entity.key is None:
             raise ValueError("Entity must have a key")
@@ -190,7 +190,7 @@ class Batch(object):
         :param key: the key to be deleted.
 
         :raises: ValueError if key is not complete, or if the key's
-                 ``dataset_id`` does not match ours.
+                 ``project`` does not match ours.
         """
         if key.is_partial:
             raise ValueError("Key must be complete")

--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -79,7 +79,7 @@ class Batch(object):
         :rtype: :class:`str`
         :returns: The dataset ID in which the batch will run.
         """
-        return self._client.dataset_id
+        return self._client.project
 
     @property
     def namespace(self):

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -23,8 +23,8 @@ from gcloud.datastore import helpers
 from gcloud.datastore.connection import Connection
 from gcloud.datastore.batch import Batch
 from gcloud.datastore.entity import Entity
+from gcloud.datastore.key import _projects_equal
 from gcloud.datastore.key import Key
-from gcloud.datastore.key import _dataset_ids_equal
 from gcloud.datastore.query import Query
 from gcloud.datastore.transaction import Transaction
 from gcloud.environment_vars import DATASET
@@ -287,9 +287,9 @@ class Client(_BaseClient):
         if not keys:
             return []
 
-        ids = set(key.dataset_id for key in keys)
+        ids = set(key.project for key in keys)
         for current_id in ids:
-            if not _dataset_ids_equal(current_id, self.project):
+            if not _projects_equal(current_id, self.project):
                 raise ValueError('Keys do not match project')
 
         transaction = self.current_transaction
@@ -414,7 +414,7 @@ class Client(_BaseClient):
         incomplete_key_pbs = [incomplete_key_pb] * num_ids
 
         conn = self.connection
-        allocated_key_pbs = conn.allocate_ids(incomplete_key.dataset_id,
+        allocated_key_pbs = conn.allocate_ids(incomplete_key.project,
                                               incomplete_key_pbs)
         allocated_ids = [allocated_key_pb.path_element[-1].id
                          for allocated_key_pb in allocated_key_pbs]

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -158,8 +158,8 @@ def _extended_lookup(connection, dataset_id, key_pbs,
 class Client(_BaseClient):
     """Convenience wrapper for invoking APIs/factories w/ a dataset ID.
 
-    :type dataset_id: string
-    :param dataset_id: (optional) dataset ID to pass to proxied API methods.
+    :type project: string
+    :param project: (optional) The project to pass to proxied API methods.
 
     :type namespace: string
     :param namespace: (optional) namespace to pass to proxied API methods.
@@ -178,12 +178,12 @@ class Client(_BaseClient):
     """
     _connection_class = Connection
 
-    def __init__(self, dataset_id=None, namespace=None,
+    def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
-        dataset_id = _determine_default_dataset_id(dataset_id)
-        if dataset_id is None:
-            raise EnvironmentError('Dataset ID could not be inferred.')
-        self.dataset_id = dataset_id
+        project = _determine_default_dataset_id(project)
+        if project is None:
+            raise EnvironmentError('Project could not be inferred.')
+        self.project = project
         self.namespace = namespace
         self._batch_stack = _LocalStack()
         super(Client, self).__init__(credentials, http)
@@ -289,14 +289,14 @@ class Client(_BaseClient):
 
         ids = set(key.dataset_id for key in keys)
         for current_id in ids:
-            if not _dataset_ids_equal(current_id, self.dataset_id):
-                raise ValueError('Keys do not match dataset ID')
+            if not _dataset_ids_equal(current_id, self.project):
+                raise ValueError('Keys do not match project')
 
         transaction = self.current_transaction
 
         entity_pbs = _extended_lookup(
             connection=self.connection,
-            dataset_id=self.dataset_id,
+            dataset_id=self.project,
             key_pbs=[k.to_protobuf() for k in keys],
             missing=missing,
             deferred=deferred,
@@ -428,7 +428,7 @@ class Client(_BaseClient):
         """
         if 'dataset_id' in kwargs:
             raise TypeError('Cannot pass dataset_id')
-        kwargs['dataset_id'] = self.dataset_id
+        kwargs['dataset_id'] = self.project
         if 'namespace' not in kwargs:
             kwargs['namespace'] = self.namespace
         return Key(*path_args, **kwargs)
@@ -456,7 +456,7 @@ class Client(_BaseClient):
             raise TypeError('Cannot pass client')
         if 'dataset_id' in kwargs:
             raise TypeError('Cannot pass dataset_id')
-        kwargs['dataset_id'] = self.dataset_id
+        kwargs['dataset_id'] = self.project
         if 'namespace' not in kwargs:
             kwargs['namespace'] = self.namespace
         return Query(self, **kwargs)

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -426,9 +426,9 @@ class Client(_BaseClient):
 
         Passes our ``project``.
         """
-        if 'dataset_id' in kwargs:
-            raise TypeError('Cannot pass dataset_id')
-        kwargs['dataset_id'] = self.project
+        if 'project' in kwargs:
+            raise TypeError('Cannot pass project')
+        kwargs['project'] = self.project
         if 'namespace' not in kwargs:
             kwargs['namespace'] = self.namespace
         return Key(*path_args, **kwargs)
@@ -448,9 +448,9 @@ class Client(_BaseClient):
         """
         if 'client' in kwargs:
             raise TypeError('Cannot pass client')
-        if 'dataset_id' in kwargs:
-            raise TypeError('Cannot pass dataset_id')
-        kwargs['dataset_id'] = self.project
+        if 'project' in kwargs:
+            raise TypeError('Cannot pass project')
+        kwargs['project'] = self.project
         if 'namespace' not in kwargs:
             kwargs['namespace'] = self.namespace
         return Query(self, **kwargs)

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -130,7 +130,7 @@ def _extended_lookup(connection, project, key_pbs,
         loop_num += 1
 
         results_found, missing_found, deferred_found = connection.lookup(
-            dataset_id=project,
+            project=project,
             key_pbs=key_pbs,
             eventual=eventual,
             transaction_id=transaction_id,

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Convenience wrapper for invoking APIs/factories w/ a dataset ID."""
+"""Convenience wrapper for invoking APIs/factories w/ a project."""
 
 import os
 
@@ -35,18 +35,18 @@ _MAX_LOOPS = 128
 """Maximum number of iterations to wait for deferred keys."""
 
 
-def _get_production_dataset_id():
+def _get_production_project():
     """Gets the production application ID if it can be inferred."""
     return os.getenv(DATASET)
 
 
-def _get_gcd_dataset_id():
+def _get_gcd_project():
     """Gets the GCD application ID if it can be inferred."""
     return os.getenv(GCD_DATASET)
 
 
-def _determine_default_dataset_id(dataset_id=None):
-    """Determine default dataset ID explicitly or implicitly as fall-back.
+def _determine_default_project(project=None):
+    """Determine default project explicitly or implicitly as fall-back.
 
     In implicit case, supports four environments. In order of precedence, the
     implicit environments are:
@@ -56,28 +56,28 @@ def _determine_default_dataset_id(dataset_id=None):
     * Google App Engine application ID
     * Google Compute Engine project ID (from metadata server)
 
-    :type dataset_id: string
-    :param dataset_id: Optional. The dataset ID to use as default.
+    :type project: string
+    :param project: Optional. The project to use as default.
 
     :rtype: string or ``NoneType``
-    :returns: Default dataset ID if it can be determined.
+    :returns: Default project if it can be determined.
     """
-    if dataset_id is None:
-        dataset_id = _get_production_dataset_id()
+    if project is None:
+        project = _get_production_project()
 
-    if dataset_id is None:
-        dataset_id = _get_gcd_dataset_id()
+    if project is None:
+        project = _get_gcd_project()
 
-    if dataset_id is None:
-        dataset_id = _app_engine_id()
+    if project is None:
+        project = _app_engine_id()
 
-    if dataset_id is None:
-        dataset_id = _compute_engine_id()
+    if project is None:
+        project = _compute_engine_id()
 
-    return dataset_id
+    return project
 
 
-def _extended_lookup(connection, dataset_id, key_pbs,
+def _extended_lookup(connection, project, key_pbs,
                      missing=None, deferred=None,
                      eventual=False, transaction_id=None):
     """Repeat lookup until all keys found (unless stop requested).
@@ -87,8 +87,8 @@ def _extended_lookup(connection, dataset_id, key_pbs,
     :type connection: :class:`gcloud.datastore.connection.Connection`
     :param connection: The connection used to connect to datastore.
 
-    :type dataset_id: string
-    :param dataset_id: The ID of the dataset of which to make the request.
+    :type project: string
+    :param project: The project to make the request for.
 
     :type key_pbs: list of :class:`gcloud.datastore._generated.entity_pb2.Key`
     :param key_pbs: The keys to retrieve from the datastore.
@@ -130,7 +130,7 @@ def _extended_lookup(connection, dataset_id, key_pbs,
         loop_num += 1
 
         results_found, missing_found, deferred_found = connection.lookup(
-            dataset_id=dataset_id,
+            dataset_id=project,
             key_pbs=key_pbs,
             eventual=eventual,
             transaction_id=transaction_id,
@@ -156,7 +156,7 @@ def _extended_lookup(connection, dataset_id, key_pbs,
 
 
 class Client(_BaseClient):
-    """Convenience wrapper for invoking APIs/factories w/ a dataset ID.
+    """Convenience wrapper for invoking APIs/factories w/ a project.
 
     :type project: string
     :param project: (optional) The project to pass to proxied API methods.
@@ -180,7 +180,7 @@ class Client(_BaseClient):
 
     def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
-        project = _determine_default_dataset_id(project)
+        project = _determine_default_project(project)
         if project is None:
             raise EnvironmentError('Project could not be inferred.')
         self.project = project
@@ -281,8 +281,8 @@ class Client(_BaseClient):
 
         :rtype: list of :class:`gcloud.datastore.entity.Entity`
         :returns: The requested entities.
-        :raises: :class:`ValueError` if one or more of ``keys`` has a dataset
-                 ID which does not match our dataset ID.
+        :raises: :class:`ValueError` if one or more of ``keys`` has a project
+                 which does not match our project.
         """
         if not keys:
             return []
@@ -296,7 +296,7 @@ class Client(_BaseClient):
 
         entity_pbs = _extended_lookup(
             connection=self.connection,
-            dataset_id=self.project,
+            project=self.project,
             key_pbs=[k.to_protobuf() for k in keys],
             missing=missing,
             deferred=deferred,
@@ -424,7 +424,7 @@ class Client(_BaseClient):
     def key(self, *path_args, **kwargs):
         """Proxy to :class:`gcloud.datastore.key.Key`.
 
-        Passes our ``dataset_id``.
+        Passes our ``project``.
         """
         if 'dataset_id' in kwargs:
             raise TypeError('Cannot pass dataset_id')
@@ -434,23 +434,17 @@ class Client(_BaseClient):
         return Key(*path_args, **kwargs)
 
     def batch(self):
-        """Proxy to :class:`gcloud.datastore.batch.Batch`.
-
-        Passes our ``dataset_id``.
-        """
+        """Proxy to :class:`gcloud.datastore.batch.Batch`."""
         return Batch(self)
 
     def transaction(self):
-        """Proxy to :class:`gcloud.datastore.transaction.Transaction`.
-
-        Passes our ``dataset_id``.
-        """
+        """Proxy to :class:`gcloud.datastore.transaction.Transaction`."""
         return Transaction(self)
 
     def query(self, **kwargs):
         """Proxy to :class:`gcloud.datastore.query.Query`.
 
-        Passes our ``dataset_id``.
+        Passes our ``project``.
         """
         if 'client' in kwargs:
             raise TypeError('Cannot pass client')

--- a/gcloud/datastore/demo/__init__.py
+++ b/gcloud/datastore/demo/__init__.py
@@ -15,6 +15,6 @@
 import os
 from gcloud.environment_vars import TESTS_DATASET
 
-__all__ = ['DATASET_ID']
+__all__ = ['PROJECT']
 
-DATASET_ID = os.getenv(TESTS_DATASET)
+PROJECT = os.getenv(TESTS_DATASET)

--- a/gcloud/datastore/demo/demo.py
+++ b/gcloud/datastore/demo/demo.py
@@ -20,7 +20,7 @@
 from gcloud import datastore
 from gcloud.datastore import demo
 
-client = datastore.Client(dataset_id=demo.DATASET_ID)
+client = datastore.Client(project=demo.PROJECT)
 
 # Let's create a new entity of type "Thing" and name it 'Toy':
 key = client.key('Thing')

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -60,7 +60,7 @@ def find_true_dataset_id(dataset_id, connection):
     # Create the bogus Key protobuf to be looked up and remove
     # the dataset ID so the backend won't complain.
     bogus_key_pb = Key('__MissingLookupKind', 1,
-                       dataset_id=dataset_id).to_protobuf()
+                       project=dataset_id).to_protobuf()
     bogus_key_pb.partition_id.ClearField('dataset_id')
 
     found_pbs, missing_pbs, _ = connection.lookup(dataset_id, [bogus_key_pb])
@@ -273,7 +273,7 @@ def key_from_protobuf(pb):
     if pb.partition_id.HasField('namespace'):
         namespace = pb.partition_id.namespace
 
-    return Key(*path_args, namespace=namespace, dataset_id=dataset_id)
+    return Key(*path_args, namespace=namespace, project=dataset_id)
 
 
 def _pb_attr_value(val):

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -33,37 +33,37 @@ __all__ = ('entity_from_protobuf', 'key_from_protobuf')
 INT_VALUE_CHECKER = Int64ValueChecker()
 
 
-def find_true_dataset_id(dataset_id, connection):
-    """Find the true (unaliased) dataset ID.
+def find_true_project(project, connection):
+    """Find the true (unaliased) project.
 
     If the given ID already has a 's~' or 'e~' prefix, does nothing.
     Otherwise, looks up a bogus Key('__MissingLookupKind', 1) and reads the
-    true prefixed dataset ID from the response (either from found or from
+    true prefixed project from the response (either from found or from
     missing).
 
     For some context, see:
       github.com/GoogleCloudPlatform/gcloud-python/pull/528
       github.com/GoogleCloudPlatform/google-cloud-datastore/issues/59
 
-    :type dataset_id: string
-    :param dataset_id: The dataset ID to un-alias / prefix.
+    :type project: string
+    :param project: The project to un-alias / prefix.
 
     :type connection: :class:`gcloud.datastore.connection.Connection`
-    :param connection: A connection provided to connection to the dataset.
+    :param connection: A connection provided to connect to the project.
 
     :rtype: string
-    :returns: The true / prefixed / un-aliased dataset ID.
+    :returns: The true / prefixed / un-aliased project.
     """
-    if dataset_id.startswith('s~') or dataset_id.startswith('e~'):
-        return dataset_id
+    if project.startswith('s~') or project.startswith('e~'):
+        return project
 
     # Create the bogus Key protobuf to be looked up and remove
-    # the dataset ID so the backend won't complain.
+    # the project so the backend won't complain.
     bogus_key_pb = Key('__MissingLookupKind', 1,
-                       project=dataset_id).to_protobuf()
+                       project=project).to_protobuf()
     bogus_key_pb.partition_id.ClearField('dataset_id')
 
-    found_pbs, missing_pbs, _ = connection.lookup(dataset_id, [bogus_key_pb])
+    found_pbs, missing_pbs, _ = connection.lookup(project, [bogus_key_pb])
     # By not passing in `deferred`, lookup will continue until
     # all results are `found` or `missing`.
     all_pbs = missing_pbs + found_pbs
@@ -266,14 +266,14 @@ def key_from_protobuf(pb):
         if element.HasField('name'):
             path_args.append(element.name)
 
-    dataset_id = None
+    project = None
     if pb.partition_id.HasField('dataset_id'):
-        dataset_id = pb.partition_id.dataset_id
+        project = pb.partition_id.dataset_id
     namespace = None
     if pb.partition_id.HasField('namespace'):
         namespace = pb.partition_id.namespace
 
-    return Key(*path_args, namespace=namespace, project=dataset_id)
+    return Key(*path_args, namespace=namespace, project=project)
 
 
 def _pb_attr_value(val):
@@ -431,7 +431,7 @@ def _prepare_key_for_request(key_pb):
     if key_pb.partition_id.HasField('dataset_id'):
         # We remove the dataset_id from the protobuf. This is because
         # the backend fails a request if the key contains un-prefixed
-        # dataset ID. The backend fails because requests to
+        # project. The backend fails because requests to
         #     /datastore/.../datasets/foo/...
         # and
         #     /datastore/.../datasets/s~foo/...

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -404,7 +404,7 @@ class Iterator(object):
 
         query_results = self._client.connection.run_query(
             query_pb=pb,
-            dataset_id=self._query.project,
+            project=self._query.project,
             namespace=self._query.namespace,
             transaction_id=transaction and transaction.id,
             )

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -34,9 +34,9 @@ class Query(object):
     :type kind: string
     :param kind: The kind to query.
 
-    :type dataset_id: string
-    :param dataset_id: The ID of the dataset to query.  If not passed,
-                       uses the client's value.
+    :type project: string
+    :param project: The project associated with the query.  If not passed,
+                    uses the client's value.
 
     :type namespace: string or None
     :param namespace: The namespace to which to restrict results.  If not
@@ -59,7 +59,7 @@ class Query(object):
     :type group_by: sequence of string
     :param group_by: field names used to group query results.
 
-    :raises: ValueError if ``dataset_id`` is not passed and no implicit
+    :raises: ValueError if ``project`` is not passed and no implicit
              default is set.
     """
 
@@ -75,7 +75,7 @@ class Query(object):
     def __init__(self,
                  client,
                  kind=None,
-                 dataset_id=None,
+                 project=None,
                  namespace=None,
                  ancestor=None,
                  filters=(),
@@ -85,7 +85,7 @@ class Query(object):
 
         self._client = client
         self._kind = kind
-        self._dataset_id = dataset_id or client.dataset_id
+        self._project = project or client.project
         self._namespace = namespace or client.namespace
         self._ancestor = ancestor
         self._filters = []
@@ -97,12 +97,12 @@ class Query(object):
         self._group_by = _ensure_tuple_or_list('group_by', group_by)
 
     @property
-    def dataset_id(self):
-        """Get the dataset ID for this Query.
+    def project(self):
+        """Get the project for this Query.
 
         :rtype: str
         """
-        return self._dataset_id or self._client.dataset_id
+        return self._project or self._client.project
 
     @property
     def namespace(self):
@@ -404,7 +404,7 @@ class Iterator(object):
 
         query_results = self._client.connection.run_query(
             query_pb=pb,
-            dataset_id=self._query.dataset_id,
+            dataset_id=self._query.project,
             namespace=self._query.namespace,
             transaction_id=transaction and transaction.id,
             )

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -377,8 +377,8 @@ class _Key(object):
 
 class _Client(object):
 
-    def __init__(self, dataset_id, connection, namespace=None):
-        self.dataset_id = dataset_id
+    def __init__(self, project, connection, namespace=None):
+        self.project = project
         self.connection = connection
         self.namespace = namespace
         self._batches = []

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -348,8 +348,8 @@ class _Key(object):
     _id = 1234
     _stored = None
 
-    def __init__(self, dataset_id):
-        self.dataset_id = dataset_id
+    def __init__(self, project):
+        self.project = project
 
     @property
     def is_partial(self):
@@ -359,7 +359,7 @@ class _Key(object):
         from gcloud.datastore._generated import entity_pb2
         key = self._key = entity_pb2.Key()
         # Don't assign it, because it will just get ripped out
-        # key.partition_id.dataset_id = self.dataset_id
+        # key.partition_id.dataset_id = self.project
 
         element = key.path_element.add()
         element.kind = self._kind
@@ -370,7 +370,7 @@ class _Key(object):
 
     def completed_key(self, new_id):
         assert self.is_partial
-        new_key = self.__class__(self.dataset_id)
+        new_key = self.__class__(self.project)
         new_key._id = new_id
         return new_key
 

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -329,8 +329,8 @@ class _Connection(object):
         self._committed = []
         self._index_updates = 0
 
-    def commit(self, dataset_id, commit_request, transaction_id):
-        self._committed.append((dataset_id, commit_request, transaction_id))
+    def commit(self, project, commit_request, transaction_id):
+        self._committed.append((project, commit_request, transaction_id))
         return self._index_updates, self._completed_keys
 
 

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -33,7 +33,7 @@ class TestBatch(unittest2.TestCase):
         client = _Client(_DATASET, connection, _NAMESPACE)
         batch = self._makeOne(client)
 
-        self.assertEqual(batch.dataset_id, _DATASET)
+        self.assertEqual(batch.project, _DATASET)
         self.assertEqual(batch.connection, connection)
         self.assertEqual(batch.namespace, _NAMESPACE)
         self.assertTrue(batch._id is None)

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -27,13 +27,13 @@ class TestBatch(unittest2.TestCase):
 
     def test_ctor(self):
         from gcloud.datastore._generated import datastore_pb2
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _NAMESPACE = 'NAMESPACE'
         connection = _Connection()
-        client = _Client(_DATASET, connection, _NAMESPACE)
+        client = _Client(_PROJECT, connection, _NAMESPACE)
         batch = self._makeOne(client)
 
-        self.assertEqual(batch.project, _DATASET)
+        self.assertEqual(batch.project, _PROJECT)
         self.assertEqual(batch.connection, connection)
         self.assertEqual(batch.namespace, _NAMESPACE)
         self.assertTrue(batch._id is None)
@@ -41,9 +41,9 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(batch._partial_key_entities, [])
 
     def test_current(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch1 = self._makeOne(client)
         batch2 = self._makeOne(client)
         self.assertTrue(batch1.current() is None)
@@ -60,17 +60,17 @@ class TestBatch(unittest2.TestCase):
         self.assertTrue(batch2.current() is None)
 
     def test_put_entity_wo_key(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
 
         self.assertRaises(ValueError, batch.put, _Entity())
 
-    def test_put_entity_w_key_wrong_dataset_id(self):
-        _DATASET = 'DATASET'
+    def test_put_entity_w_key_wrong_project(self):
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         entity = _Entity()
         entity.key = _Key('OTHER')
@@ -78,13 +78,13 @@ class TestBatch(unittest2.TestCase):
         self.assertRaises(ValueError, batch.put, entity)
 
     def test_put_entity_w_partial_key(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
-        key = entity.key = _Key(_DATASET)
+        key = entity.key = _Key(_PROJECT)
         key._id = None
 
         batch.put(entity)
@@ -96,7 +96,7 @@ class TestBatch(unittest2.TestCase):
     def test_put_entity_w_completed_key(self):
         from gcloud.datastore.helpers import _property_tuples
 
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {
             'foo': 'bar',
             'baz': 'qux',
@@ -104,11 +104,11 @@ class TestBatch(unittest2.TestCase):
             'frotz': [],  # will be ignored
             }
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
         entity.exclude_from_indexes = ('baz', 'spam')
-        key = entity.key = _Key(_DATASET)
+        key = entity.key = _Key(_PROJECT)
 
         batch.put(entity)
 
@@ -125,10 +125,10 @@ class TestBatch(unittest2.TestCase):
         self.assertFalse(prop_dict['spam'].list_value[2].indexed)
         self.assertFalse('frotz' in prop_dict)
 
-    def test_put_entity_w_completed_key_prefixed_dataset_id(self):
+    def test_put_entity_w_completed_key_prefixed_project(self):
         from gcloud.datastore.helpers import _property_tuples
 
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {
             'foo': 'bar',
             'baz': 'qux',
@@ -136,11 +136,11 @@ class TestBatch(unittest2.TestCase):
             'frotz': [],  # will be ignored
             }
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         entity = _Entity(_PROPERTIES)
         entity.exclude_from_indexes = ('baz', 'spam')
-        key = entity.key = _Key('s~' + _DATASET)
+        key = entity.key = _Key('s~' + _PROJECT)
 
         batch.put(entity)
 
@@ -158,42 +158,42 @@ class TestBatch(unittest2.TestCase):
         self.assertFalse('frotz' in prop_dict)
 
     def test_delete_w_partial_key(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
-        key = _Key(_DATASET)
+        key = _Key(_PROJECT)
         key._id = None
 
         self.assertRaises(ValueError, batch.delete, key)
 
-    def test_delete_w_key_wrong_dataset_id(self):
-        _DATASET = 'DATASET'
+    def test_delete_w_key_wrong_project(self):
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         key = _Key('OTHER')
 
         self.assertRaises(ValueError, batch.delete, key)
 
     def test_delete_w_completed_key(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
-        key = _Key(_DATASET)
+        key = _Key(_PROJECT)
 
         batch.delete(key)
 
         mutated_key = _mutated_pb(self, batch.mutations, 'delete')
         self.assertEqual(mutated_key, key._key)
 
-    def test_delete_w_completed_key_w_prefixed_dataset_id(self):
-        _DATASET = 'DATASET'
+    def test_delete_w_completed_key_w_prefixed_project(self):
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
-        key = _Key('s~' + _DATASET)
+        key = _Key('s~' + _PROJECT)
 
         batch.delete(key)
 
@@ -201,42 +201,42 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(mutated_key, key._key)
 
     def test_commit(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
 
         batch.commit()
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch._commit_request, None)])
+                         [(_PROJECT, batch._commit_request, None)])
 
     def test_commit_w_partial_key_entities(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _NEW_ID = 1234
         connection = _Connection(_NEW_ID)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         batch = self._makeOne(client)
         entity = _Entity({})
-        key = entity.key = _Key(_DATASET)
+        key = entity.key = _Key(_PROJECT)
         key._id = None
         batch._partial_key_entities.append(entity)
 
         batch.commit()
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch._commit_request, None)])
+                         [(_PROJECT, batch._commit_request, None)])
         self.assertFalse(entity.key.is_partial)
         self.assertEqual(entity.key._id, _NEW_ID)
 
     def test_as_context_mgr_wo_error(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
-        key = entity.key = _Key(_DATASET)
+        key = entity.key = _Key(_PROJECT)
 
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         self.assertEqual(list(client._batches), [])
 
         with self._makeOne(client) as batch:
@@ -248,18 +248,18 @@ class TestBatch(unittest2.TestCase):
         mutated_entity = _mutated_pb(self, batch.mutations, 'upsert')
         self.assertEqual(mutated_entity.key, key._key)
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch._commit_request, None)])
+                         [(_PROJECT, batch._commit_request, None)])
 
     def test_as_context_mgr_nested(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity1 = _Entity(_PROPERTIES)
-        key1 = entity1.key = _Key(_DATASET)
+        key1 = entity1.key = _Key(_PROJECT)
         entity2 = _Entity(_PROPERTIES)
-        key2 = entity2.key = _Key(_DATASET)
+        key2 = entity2.key = _Key(_PROJECT)
 
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         self.assertEqual(list(client._batches), [])
 
         with self._makeOne(client) as batch1:
@@ -280,17 +280,17 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(mutated_entity2.key, key2._key)
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch2._commit_request, None),
-                          (_DATASET, batch1._commit_request, None)])
+                         [(_PROJECT, batch2._commit_request, None),
+                          (_PROJECT, batch1._commit_request, None)])
 
     def test_as_context_mgr_w_error(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         entity = _Entity(_PROPERTIES)
-        key = entity.key = _Key(_DATASET)
+        key = entity.key = _Key(_PROJECT)
 
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         self.assertEqual(list(client._batches), [])
 
         try:

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -769,7 +769,7 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
 
         self.assertRaises(TypeError,
-                          client.key, KIND, ID, dataset_id=self.PROJECT)
+                          client.key, KIND, ID, project=self.PROJECT)
 
     def test_key_wo_project(self):
         from gcloud.datastore import client as MUT
@@ -787,7 +787,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(key, _Dummy))
         self.assertEqual(key.args, (KIND, ID))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': None,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -808,7 +808,7 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(key, _Dummy))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': NAMESPACE,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -830,7 +830,7 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(key, _Dummy))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': NAMESPACE2,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -894,7 +894,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': None,
         }
         self.assertEqual(query.kwargs, expected_kwargs)
@@ -928,7 +928,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'kind': KIND,
             'namespace': NAMESPACE,
             'ancestor': ANCESTOR,
@@ -955,7 +955,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': NAMESPACE,
             'kind': KIND,
         }
@@ -978,7 +978,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.PROJECT,
+            'project': self.PROJECT,
             'namespace': NAMESPACE2,
             'kind': KIND,
         }

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -182,9 +182,9 @@ class TestClient(unittest2.TestCase):
         from gcloud.datastore.client import Client
         return Client
 
-    def _makeOne(self, dataset_id=DATASET_ID, namespace=None,
+    def _makeOne(self, project=DATASET_ID, namespace=None,
                  credentials=None, http=None):
-        return self._getTargetClass()(dataset_id=dataset_id,
+        return self._getTargetClass()(project=project,
                                       namespace=namespace,
                                       credentials=credentials,
                                       http=http)
@@ -212,7 +212,7 @@ class TestClient(unittest2.TestCase):
             with _Monkey(_base_client,
                          get_credentials=lambda: creds):
                 client = klass()
-        self.assertEqual(client.dataset_id, OTHER)
+        self.assertEqual(client.project, OTHER)
         self.assertEqual(client.namespace, None)
         self.assertTrue(isinstance(client.connection, _MockConnection))
         self.assertTrue(client.connection.credentials is creds)
@@ -225,11 +225,11 @@ class TestClient(unittest2.TestCase):
         NAMESPACE = 'namespace'
         creds = object()
         http = object()
-        client = self._makeOne(dataset_id=OTHER,
+        client = self._makeOne(project=OTHER,
                                namespace=NAMESPACE,
                                credentials=creds,
                                http=http)
-        self.assertEqual(client.dataset_id, OTHER)
+        self.assertEqual(client.project, OTHER)
         self.assertEqual(client.namespace, NAMESPACE)
         self.assertTrue(isinstance(client.connection, _MockConnection))
         self.assertTrue(client.connection.credentials is creds)

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -1008,8 +1008,8 @@ class _MockConnection(object):
     def _add_lookup_result(self, results=(), missing=(), deferred=()):
         self._lookup.append((list(results), list(missing), list(deferred)))
 
-    def lookup(self, dataset_id, key_pbs, eventual=False, transaction_id=None):
-        self._lookup_cw.append((dataset_id, key_pbs, eventual, transaction_id))
+    def lookup(self, project, key_pbs, eventual=False, transaction_id=None):
+        self._lookup_cw.append((project, key_pbs, eventual, transaction_id))
         triple, self._lookup = self._lookup[0], self._lookup[1:]
         results, missing, deferred = triple
         return results, missing, deferred

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -15,12 +15,12 @@
 import unittest2
 
 
-def _make_entity_pb(dataset_id, kind, integer_id, name=None, str_val=None):
+def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
     from gcloud.datastore._generated import entity_pb2
     from gcloud.datastore.helpers import _new_value_pb
 
     entity_pb = entity_pb2.Entity()
-    entity_pb.key.partition_id.dataset_id = dataset_id
+    entity_pb.key.partition_id.dataset_id = project
     path_element = entity_pb.key.path_element.add()
     path_element.kind = kind
     path_element.id = integer_id
@@ -31,11 +31,11 @@ def _make_entity_pb(dataset_id, kind, integer_id, name=None, str_val=None):
     return entity_pb
 
 
-class Test__get_production_dataset_id(unittest2.TestCase):
+class Test__get_production_project(unittest2.TestCase):
 
     def _callFUT(self):
-        from gcloud.datastore.client import _get_production_dataset_id
-        return _get_production_dataset_id()
+        from gcloud.datastore.client import _get_production_project
+        return _get_production_project()
 
     def test_no_value(self):
         import os
@@ -43,26 +43,26 @@ class Test__get_production_dataset_id(unittest2.TestCase):
 
         environ = {}
         with _Monkey(os, getenv=environ.get):
-            dataset_id = self._callFUT()
-            self.assertEqual(dataset_id, None)
+            project = self._callFUT()
+            self.assertEqual(project, None)
 
     def test_value_set(self):
         import os
         from gcloud._testing import _Monkey
         from gcloud.datastore.client import DATASET
 
-        MOCK_DATASET_ID = object()
-        environ = {DATASET: MOCK_DATASET_ID}
+        MOCK_PROJECT = object()
+        environ = {DATASET: MOCK_PROJECT}
         with _Monkey(os, getenv=environ.get):
-            dataset_id = self._callFUT()
-            self.assertEqual(dataset_id, MOCK_DATASET_ID)
+            project = self._callFUT()
+            self.assertEqual(project, MOCK_PROJECT)
 
 
-class Test__get_gcd_dataset_id(unittest2.TestCase):
+class Test__get_gcd_project(unittest2.TestCase):
 
     def _callFUT(self):
-        from gcloud.datastore.client import _get_gcd_dataset_id
-        return _get_gcd_dataset_id()
+        from gcloud.datastore.client import _get_gcd_project
+        return _get_gcd_project()
 
     def test_no_value(self):
         import os
@@ -70,29 +70,29 @@ class Test__get_gcd_dataset_id(unittest2.TestCase):
 
         environ = {}
         with _Monkey(os, getenv=environ.get):
-            dataset_id = self._callFUT()
-            self.assertEqual(dataset_id, None)
+            project = self._callFUT()
+            self.assertEqual(project, None)
 
     def test_value_set(self):
         import os
         from gcloud._testing import _Monkey
         from gcloud.datastore.client import GCD_DATASET
 
-        MOCK_DATASET_ID = object()
-        environ = {GCD_DATASET: MOCK_DATASET_ID}
+        MOCK_PROJECT = object()
+        environ = {GCD_DATASET: MOCK_PROJECT}
         with _Monkey(os, getenv=environ.get):
-            dataset_id = self._callFUT()
-            self.assertEqual(dataset_id, MOCK_DATASET_ID)
+            project = self._callFUT()
+            self.assertEqual(project, MOCK_PROJECT)
 
 
-class Test__determine_default_dataset_id(unittest2.TestCase):
+class Test__determine_default_project(unittest2.TestCase):
 
-    def _callFUT(self, dataset_id=None):
-        from gcloud.datastore.client import _determine_default_dataset_id
-        return _determine_default_dataset_id(dataset_id=dataset_id)
+    def _callFUT(self, project=None):
+        from gcloud.datastore.client import _determine_default_project
+        return _determine_default_project(project=project)
 
     def _determine_default_helper(self, prod=None, gcd=None, gae=None,
-                                  gce=None, dataset_id=None):
+                                  gce=None, project=None):
         from gcloud._testing import _Monkey
         from gcloud.datastore import client
 
@@ -115,59 +115,59 @@ class Test__determine_default_dataset_id(unittest2.TestCase):
             return gce
 
         patched_methods = {
-            '_get_production_dataset_id': prod_mock,
-            '_get_gcd_dataset_id': gcd_mock,
+            '_get_production_project': prod_mock,
+            '_get_gcd_project': gcd_mock,
             '_app_engine_id': gae_mock,
             '_compute_engine_id': gce_mock,
         }
 
         with _Monkey(client, **patched_methods):
-            returned_dataset_id = self._callFUT(dataset_id)
+            returned_project = self._callFUT(project)
 
-        return returned_dataset_id, _callers
+        return returned_project, _callers
 
     def test_no_value(self):
-        dataset_id, callers = self._determine_default_helper()
-        self.assertEqual(dataset_id, None)
+        project, callers = self._determine_default_helper()
+        self.assertEqual(project, None)
         self.assertEqual(callers,
                          ['prod_mock', 'gcd_mock', 'gae_mock', 'gce_mock'])
 
     def test_explicit(self):
-        DATASET_ID = object()
-        dataset_id, callers = self._determine_default_helper(
-            dataset_id=DATASET_ID)
-        self.assertEqual(dataset_id, DATASET_ID)
+        PROJECT = object()
+        project, callers = self._determine_default_helper(
+            project=PROJECT)
+        self.assertEqual(project, PROJECT)
         self.assertEqual(callers, [])
 
     def test_prod(self):
-        DATASET_ID = object()
-        dataset_id, callers = self._determine_default_helper(prod=DATASET_ID)
-        self.assertEqual(dataset_id, DATASET_ID)
+        PROJECT = object()
+        project, callers = self._determine_default_helper(prod=PROJECT)
+        self.assertEqual(project, PROJECT)
         self.assertEqual(callers, ['prod_mock'])
 
     def test_gcd(self):
-        DATASET_ID = object()
-        dataset_id, callers = self._determine_default_helper(gcd=DATASET_ID)
-        self.assertEqual(dataset_id, DATASET_ID)
+        PROJECT = object()
+        project, callers = self._determine_default_helper(gcd=PROJECT)
+        self.assertEqual(project, PROJECT)
         self.assertEqual(callers, ['prod_mock', 'gcd_mock'])
 
     def test_gae(self):
-        DATASET_ID = object()
-        dataset_id, callers = self._determine_default_helper(gae=DATASET_ID)
-        self.assertEqual(dataset_id, DATASET_ID)
+        PROJECT = object()
+        project, callers = self._determine_default_helper(gae=PROJECT)
+        self.assertEqual(project, PROJECT)
         self.assertEqual(callers, ['prod_mock', 'gcd_mock', 'gae_mock'])
 
     def test_gce(self):
-        DATASET_ID = object()
-        dataset_id, callers = self._determine_default_helper(gce=DATASET_ID)
-        self.assertEqual(dataset_id, DATASET_ID)
+        PROJECT = object()
+        project, callers = self._determine_default_helper(gce=PROJECT)
+        self.assertEqual(project, PROJECT)
         self.assertEqual(callers,
                          ['prod_mock', 'gcd_mock', 'gae_mock', 'gce_mock'])
 
 
 class TestClient(unittest2.TestCase):
 
-    DATASET_ID = 'DATASET'
+    PROJECT = 'PROJECT'
 
     def setUp(self):
         KLASS = self._getTargetClass()
@@ -182,14 +182,14 @@ class TestClient(unittest2.TestCase):
         from gcloud.datastore.client import Client
         return Client
 
-    def _makeOne(self, project=DATASET_ID, namespace=None,
+    def _makeOne(self, project=PROJECT, namespace=None,
                  credentials=None, http=None):
         return self._getTargetClass()(project=project,
                                       namespace=namespace,
                                       credentials=credentials,
                                       http=http)
 
-    def test_ctor_w_dataset_id_no_environ(self):
+    def test_ctor_w_project_no_environ(self):
         from gcloud._testing import _Monkey
         from gcloud.datastore import client as _MUT
 
@@ -208,7 +208,7 @@ class TestClient(unittest2.TestCase):
 
         klass = self._getTargetClass()
         with _Monkey(_MUT,
-                     _determine_default_dataset_id=lambda x: x or OTHER):
+                     _determine_default_project=lambda x: x or OTHER):
             with _Monkey(_base_client,
                          get_credentials=lambda: creds):
                 client = klass()
@@ -309,7 +309,7 @@ class TestClient(unittest2.TestCase):
         creds = object()
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result()
-        key = Key('Kind', 1234, dataset_id=self.DATASET_ID)
+        key = Key('Kind', 1234, dataset_id=self.PROJECT)
         results = client.get_multi([key])
         self.assertEqual(results, [])
 
@@ -322,7 +322,7 @@ class TestClient(unittest2.TestCase):
 
         # Make a missing entity pb to be returned from mock backend.
         missed = entity_pb2.Entity()
-        missed.key.partition_id.dataset_id = self.DATASET_ID
+        missed.key.partition_id.dataset_id = self.PROJECT
         path_element = missed.key.path_element.add()
         path_element.kind = KIND
         path_element.id = ID
@@ -332,7 +332,7 @@ class TestClient(unittest2.TestCase):
         # Set missing entity on mock connection.
         client.connection._add_lookup_result(missing=[missed])
 
-        key = Key(KIND, ID, dataset_id=self.DATASET_ID)
+        key = Key(KIND, ID, dataset_id=self.PROJECT)
         missing = []
         entities = client.get_multi([key], missing=missing)
         self.assertEqual(entities, [])
@@ -344,7 +344,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = Key('Kind', 1234, dataset_id=self.DATASET_ID)
+        key = Key('Kind', 1234, dataset_id=self.PROJECT)
 
         missing = ['this', 'list', 'is', 'not', 'empty']
         self.assertRaises(ValueError, client.get_multi,
@@ -355,7 +355,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = Key('Kind', 1234, dataset_id=self.DATASET_ID)
+        key = Key('Kind', 1234, dataset_id=self.PROJECT)
 
         deferred = ['this', 'list', 'is', 'not', 'empty']
         self.assertRaises(ValueError, client.get_multi,
@@ -364,7 +364,7 @@ class TestClient(unittest2.TestCase):
     def test_get_multi_miss_w_deferred(self):
         from gcloud.datastore.key import Key
 
-        key = Key('Kind', 1234, dataset_id=self.DATASET_ID)
+        key = Key('Kind', 1234, dataset_id=self.PROJECT)
 
         # Set deferred entity on mock connection.
         creds = object()
@@ -382,9 +382,9 @@ class TestClient(unittest2.TestCase):
         from gcloud.datastore.entity import Entity
         from gcloud.datastore.key import Key
 
-        key1 = Key('Kind', dataset_id=self.DATASET_ID)
+        key1 = Key('Kind', dataset_id=self.PROJECT)
         key1_pb = key1.to_protobuf()
-        key2 = Key('Kind', 2345, dataset_id=self.DATASET_ID)
+        key2 = Key('Kind', 2345, dataset_id=self.PROJECT)
         key2_pb = key2.to_protobuf()
 
         entity1_pb = entity_pb2.Entity()
@@ -416,7 +416,7 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(len(cw), 2)
 
         ds_id, k_pbs, eventual, tid = cw[0]
-        self.assertEqual(ds_id, self.DATASET_ID)
+        self.assertEqual(ds_id, self.PROJECT)
         self.assertEqual(len(k_pbs), 2)
         self.assertEqual(key1_pb, k_pbs[0])
         self.assertEqual(key2_pb, k_pbs[1])
@@ -424,7 +424,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(tid is None)
 
         ds_id, k_pbs, eventual, tid = cw[1]
-        self.assertEqual(ds_id, self.DATASET_ID)
+        self.assertEqual(ds_id, self.PROJECT)
         self.assertEqual(len(k_pbs), 1)
         self.assertEqual(key2_pb, k_pbs[0])
         self.assertFalse(eventual)
@@ -438,25 +438,25 @@ class TestClient(unittest2.TestCase):
         PATH = [{'kind': KIND, 'id': ID}]
 
         # Make a found entity pb to be returned from mock backend.
-        entity_pb = _make_entity_pb(self.DATASET_ID, KIND, ID, 'foo', 'Foo')
+        entity_pb = _make_entity_pb(self.PROJECT, KIND, ID, 'foo', 'Foo')
 
         # Make a connection to return the entity pb.
         creds = object()
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
-        key = Key(KIND, ID, dataset_id=self.DATASET_ID)
+        key = Key(KIND, ID, dataset_id=self.PROJECT)
         result, = client.get_multi([key])
         new_key = result.key
 
         # Check the returned value is as expected.
         self.assertFalse(new_key is key)
-        self.assertEqual(new_key.dataset_id, self.DATASET_ID)
+        self.assertEqual(new_key.dataset_id, self.PROJECT)
         self.assertEqual(new_key.path, PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
-    def test_get_multi_hit_multiple_keys_same_dataset(self):
+    def test_get_multi_hit_multiple_keys_same_project(self):
         from gcloud.datastore.key import Key
 
         KIND = 'Kind'
@@ -464,16 +464,16 @@ class TestClient(unittest2.TestCase):
         ID2 = 2345
 
         # Make a found entity pb to be returned from mock backend.
-        entity_pb1 = _make_entity_pb(self.DATASET_ID, KIND, ID1)
-        entity_pb2 = _make_entity_pb(self.DATASET_ID, KIND, ID2)
+        entity_pb1 = _make_entity_pb(self.PROJECT, KIND, ID1)
+        entity_pb2 = _make_entity_pb(self.PROJECT, KIND, ID2)
 
         # Make a connection to return the entity pbs.
         creds = object()
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb1, entity_pb2])
 
-        key1 = Key(KIND, ID1, dataset_id=self.DATASET_ID)
-        key2 = Key(KIND, ID2, dataset_id=self.DATASET_ID)
+        key1 = Key(KIND, ID1, dataset_id=self.PROJECT)
+        key2 = Key(KIND, ID2, dataset_id=self.PROJECT)
         retrieved1, retrieved2 = client.get_multi([key1, key2])
 
         # Check values match.
@@ -482,17 +482,17 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(retrieved2.key.path, key2.path)
         self.assertEqual(dict(retrieved2), {})
 
-    def test_get_multi_hit_multiple_keys_different_dataset(self):
+    def test_get_multi_hit_multiple_keys_different_project(self):
         from gcloud.datastore.key import Key
 
-        DATASET_ID1 = 'DATASET'
-        DATASET_ID2 = 'DATASET-ALT'
+        PROJECT1 = 'PROJECT'
+        PROJECT2 = 'PROJECT-ALT'
 
         # Make sure our IDs are actually different.
-        self.assertNotEqual(DATASET_ID1, DATASET_ID2)
+        self.assertNotEqual(PROJECT1, PROJECT2)
 
-        key1 = Key('KIND', 1234, dataset_id=DATASET_ID1)
-        key2 = Key('KIND', 1234, dataset_id=DATASET_ID2)
+        key1 = Key('KIND', 1234, dataset_id=PROJECT1)
+        key2 = Key('KIND', 1234, dataset_id=PROJECT2)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -503,18 +503,18 @@ class TestClient(unittest2.TestCase):
     def test_get_multi_diff_prefixes(self):
         from gcloud.datastore.key import Key
 
-        DATASET_ID1 = 'DATASET'
-        DATASET_ID2 = 'e~DATASET'
-        DATASET_ID3 = 's~DATASET'
+        PROJECT1 = 'PROJECT'
+        PROJECT2 = 'e~PROJECT'
+        PROJECT3 = 's~PROJECT'
         KIND = 'Kind'
         ID1 = 1234
         ID2 = 2345
         ID3 = 3456
 
         # Make found entity pbs to be returned from mock backend.
-        entity_pb1 = _make_entity_pb(DATASET_ID1, KIND, ID1)
-        entity_pb2 = _make_entity_pb(DATASET_ID2, KIND, ID2)
-        entity_pb3 = _make_entity_pb(DATASET_ID3, KIND, ID3)
+        entity_pb1 = _make_entity_pb(PROJECT1, KIND, ID1)
+        entity_pb2 = _make_entity_pb(PROJECT2, KIND, ID2)
+        entity_pb3 = _make_entity_pb(PROJECT3, KIND, ID3)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -522,9 +522,9 @@ class TestClient(unittest2.TestCase):
                                               entity_pb2,
                                               entity_pb3])
 
-        key1 = Key(KIND, ID1, dataset_id=DATASET_ID1)
-        key2 = Key(KIND, ID2, dataset_id=DATASET_ID2)
-        key3 = Key(KIND, ID3, dataset_id=DATASET_ID3)
+        key1 = Key(KIND, ID1, dataset_id=PROJECT1)
+        key2 = Key(KIND, ID2, dataset_id=PROJECT2)
+        key3 = Key(KIND, ID3, dataset_id=PROJECT3)
 
         retrieved_all = client.get_multi([key1, key2, key3])
         retrieved1, retrieved2, retrieved3 = retrieved_all
@@ -534,14 +534,14 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(retrieved2.key.path, key2.path)
         self.assertEqual(retrieved3.key.path, key3.path)
 
-    def test_get_multi_diff_datasets_w_prefix(self):
+    def test_get_multi_diff_projects_w_prefix(self):
         from gcloud.datastore.key import Key
 
-        DATASET_ID1 = 'e~DATASET'
-        DATASET_ID2 = 's~DATASET-ALT'
+        PROJECT1 = 'e~PROJECT'
+        PROJECT2 = 's~PROJECT-ALT'
 
-        key1 = Key('KIND', 1234, dataset_id=DATASET_ID1)
-        key2 = Key('KIND', 1234, dataset_id=DATASET_ID2)
+        key1 = Key('KIND', 1234, dataset_id=PROJECT1)
+        key2 = Key('KIND', 1234, dataset_id=PROJECT2)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -558,14 +558,14 @@ class TestClient(unittest2.TestCase):
         ID = 1234
 
         # Make a found entity pb to be returned from mock backend.
-        entity_pb = _make_entity_pb(self.DATASET_ID, KIND, ID, 'foo', 'Foo')
+        entity_pb = _make_entity_pb(self.PROJECT, KIND, ID, 'foo', 'Foo')
 
         # Make a connection to return the entity pb.
         creds = object()
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
-        key = Key(KIND, ID, dataset_id=self.DATASET_ID)
+        key = Key(KIND, ID, dataset_id=self.PROJECT)
         deferred = []
         missing = []
         with _Monkey(_MUT, _MAX_LOOPS=-1):
@@ -614,7 +614,7 @@ class TestClient(unittest2.TestCase):
         from gcloud.datastore.test_batch import _KeyPB
 
         entity = _Entity(foo=u'bar')
-        key = entity.key = _Key(self.DATASET_ID)
+        key = entity.key = _Key(self.PROJECT)
         key._id = None
 
         creds = object()
@@ -625,9 +625,9 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(result is None)
 
         self.assertEqual(len(client.connection._commit_cw), 1)
-        (dataset_id,
+        (project,
          commit_req, transaction_id) = client.connection._commit_cw[0]
-        self.assertEqual(dataset_id, self.DATASET_ID)
+        self.assertEqual(project, self.PROJECT)
         inserts = list(commit_req.mutation.insert_auto_id)
         self.assertEqual(len(inserts), 1)
         self.assertEqual(inserts[0].key, key.to_protobuf())
@@ -648,7 +648,7 @@ class TestClient(unittest2.TestCase):
         creds = object()
         client = self._makeOne(credentials=creds)
         entity = _Entity(foo=u'bar')
-        key = entity.key = _Key(self.DATASET_ID)
+        key = entity.key = _Key(self.PROJECT)
 
         with _NoCommitBatch(client) as CURR_BATCH:
             result = client.put_multi([entity])
@@ -689,7 +689,7 @@ class TestClient(unittest2.TestCase):
     def test_delete_multi_no_batch(self):
         from gcloud.datastore.test_batch import _Key
 
-        key = _Key(self.DATASET_ID)
+        key = _Key(self.PROJECT)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -698,9 +698,9 @@ class TestClient(unittest2.TestCase):
         result = client.delete_multi([key])
         self.assertEqual(result, None)
         self.assertEqual(len(client.connection._commit_cw), 1)
-        (dataset_id,
+        (project,
          commit_req, transaction_id) = client.connection._commit_cw[0]
-        self.assertEqual(dataset_id, self.DATASET_ID)
+        self.assertEqual(project, self.PROJECT)
         self.assertEqual(list(commit_req.mutation.delete), [key.to_protobuf()])
         self.assertTrue(transaction_id is None)
 
@@ -710,7 +710,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = _Key(self.DATASET_ID)
+        key = _Key(self.PROJECT)
 
         with _NoCommitBatch(client) as CURR_BATCH:
             result = client.delete_multi([key])
@@ -726,7 +726,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = _Key(self.DATASET_ID)
+        key = _Key(self.PROJECT)
 
         with _NoCommitTransaction(client) as CURR_XACT:
             result = client.delete_multi([key])
@@ -741,7 +741,7 @@ class TestClient(unittest2.TestCase):
 
         NUM_IDS = 2
 
-        INCOMPLETE_KEY = _Key(self.DATASET_ID)
+        INCOMPLETE_KEY = _Key(self.PROJECT)
         INCOMPLETE_KEY._id = None
 
         creds = object()
@@ -758,10 +758,10 @@ class TestClient(unittest2.TestCase):
         creds = object()
         client = self._makeOne(credentials=creds)
 
-        COMPLETE_KEY = _Key(self.DATASET_ID)
+        COMPLETE_KEY = _Key(self.PROJECT)
         self.assertRaises(ValueError, client.allocate_ids, COMPLETE_KEY, 2)
 
-    def test_key_w_dataset_id(self):
+    def test_key_w_project(self):
         KIND = 'KIND'
         ID = 1234
 
@@ -769,9 +769,9 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
 
         self.assertRaises(TypeError,
-                          client.key, KIND, ID, dataset_id=self.DATASET_ID)
+                          client.key, KIND, ID, dataset_id=self.PROJECT)
 
-    def test_key_wo_dataset_id(self):
+    def test_key_wo_project(self):
         from gcloud.datastore import client as MUT
         from gcloud._testing import _Monkey
 
@@ -787,7 +787,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(key, _Dummy))
         self.assertEqual(key.args, (KIND, ID))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': None,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -808,7 +808,7 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(key, _Dummy))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': NAMESPACE,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -830,7 +830,7 @@ class TestClient(unittest2.TestCase):
 
         self.assertTrue(isinstance(key, _Dummy))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': NAMESPACE2,
         }
         self.assertEqual(key.kwargs, expected_kwargs)
@@ -872,14 +872,14 @@ class TestClient(unittest2.TestCase):
 
         self.assertRaises(TypeError, client.query, kind=KIND, client=other)
 
-    def test_query_w_dataset_id(self):
+    def test_query_w_project(self):
         KIND = 'KIND'
 
         creds = object()
         client = self._makeOne(credentials=creds)
 
         self.assertRaises(TypeError,
-                          client.query, kind=KIND, dataset_id=self.DATASET_ID)
+                          client.query, kind=KIND, dataset_id=self.PROJECT)
 
     def test_query_w_defaults(self):
         from gcloud.datastore import client as MUT
@@ -894,7 +894,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': None,
         }
         self.assertEqual(query.kwargs, expected_kwargs)
@@ -928,7 +928,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'kind': KIND,
             'namespace': NAMESPACE,
             'ancestor': ANCESTOR,
@@ -955,7 +955,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': NAMESPACE,
             'kind': KIND,
         }
@@ -978,7 +978,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(query, _Dummy))
         self.assertEqual(query.args, (client,))
         expected_kwargs = {
-            'dataset_id': self.DATASET_ID,
+            'dataset_id': self.PROJECT,
             'namespace': NAMESPACE2,
             'kind': KIND,
         }
@@ -1014,14 +1014,14 @@ class _MockConnection(object):
         results, missing, deferred = triple
         return results, missing, deferred
 
-    def commit(self, dataset_id, commit_request, transaction_id):
-        self._commit_cw.append((dataset_id, commit_request, transaction_id))
+    def commit(self, project, commit_request, transaction_id):
+        self._commit_cw.append((project, commit_request, transaction_id))
         response, self._commit = self._commit[0], self._commit[1:]
         return self._index_updates, response
 
-    def allocate_ids(self, dataset_id, key_pbs):
+    def allocate_ids(self, project, key_pbs):
         from gcloud.datastore.test_connection import _KeyProto
-        self._alloc_cw.append((dataset_id, key_pbs))
+        self._alloc_cw.append((project, key_pbs))
         num_pbs = len(key_pbs)
         return [_KeyProto(i) for i in list(range(num_pbs))]
 

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -879,7 +879,7 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
 
         self.assertRaises(TypeError,
-                          client.query, kind=KIND, dataset_id=self.PROJECT)
+                          client.query, kind=KIND, project=self.PROJECT)
 
     def test_query_w_defaults(self):
         from gcloud.datastore import client as MUT

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -309,7 +309,7 @@ class TestClient(unittest2.TestCase):
         creds = object()
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result()
-        key = Key('Kind', 1234, dataset_id=self.PROJECT)
+        key = Key('Kind', 1234, project=self.PROJECT)
         results = client.get_multi([key])
         self.assertEqual(results, [])
 
@@ -332,7 +332,7 @@ class TestClient(unittest2.TestCase):
         # Set missing entity on mock connection.
         client.connection._add_lookup_result(missing=[missed])
 
-        key = Key(KIND, ID, dataset_id=self.PROJECT)
+        key = Key(KIND, ID, project=self.PROJECT)
         missing = []
         entities = client.get_multi([key], missing=missing)
         self.assertEqual(entities, [])
@@ -344,7 +344,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = Key('Kind', 1234, dataset_id=self.PROJECT)
+        key = Key('Kind', 1234, project=self.PROJECT)
 
         missing = ['this', 'list', 'is', 'not', 'empty']
         self.assertRaises(ValueError, client.get_multi,
@@ -355,7 +355,7 @@ class TestClient(unittest2.TestCase):
 
         creds = object()
         client = self._makeOne(credentials=creds)
-        key = Key('Kind', 1234, dataset_id=self.PROJECT)
+        key = Key('Kind', 1234, project=self.PROJECT)
 
         deferred = ['this', 'list', 'is', 'not', 'empty']
         self.assertRaises(ValueError, client.get_multi,
@@ -364,7 +364,7 @@ class TestClient(unittest2.TestCase):
     def test_get_multi_miss_w_deferred(self):
         from gcloud.datastore.key import Key
 
-        key = Key('Kind', 1234, dataset_id=self.PROJECT)
+        key = Key('Kind', 1234, project=self.PROJECT)
 
         # Set deferred entity on mock connection.
         creds = object()
@@ -382,9 +382,9 @@ class TestClient(unittest2.TestCase):
         from gcloud.datastore.entity import Entity
         from gcloud.datastore.key import Key
 
-        key1 = Key('Kind', dataset_id=self.PROJECT)
+        key1 = Key('Kind', project=self.PROJECT)
         key1_pb = key1.to_protobuf()
-        key2 = Key('Kind', 2345, dataset_id=self.PROJECT)
+        key2 = Key('Kind', 2345, project=self.PROJECT)
         key2_pb = key2.to_protobuf()
 
         entity1_pb = entity_pb2.Entity()
@@ -406,11 +406,11 @@ class TestClient(unittest2.TestCase):
         # Check the actual contents on the response.
         self.assertTrue(isinstance(found[0], Entity))
         self.assertEqual(found[0].key.path, key1.path)
-        self.assertEqual(found[0].key.dataset_id, key1.dataset_id)
+        self.assertEqual(found[0].key.project, key1.project)
 
         self.assertTrue(isinstance(found[1], Entity))
         self.assertEqual(found[1].key.path, key2.path)
-        self.assertEqual(found[1].key.dataset_id, key2.dataset_id)
+        self.assertEqual(found[1].key.project, key2.project)
 
         cw = client.connection._lookup_cw
         self.assertEqual(len(cw), 2)
@@ -445,13 +445,13 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
-        key = Key(KIND, ID, dataset_id=self.PROJECT)
+        key = Key(KIND, ID, project=self.PROJECT)
         result, = client.get_multi([key])
         new_key = result.key
 
         # Check the returned value is as expected.
         self.assertFalse(new_key is key)
-        self.assertEqual(new_key.dataset_id, self.PROJECT)
+        self.assertEqual(new_key.project, self.PROJECT)
         self.assertEqual(new_key.path, PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
@@ -472,8 +472,8 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb1, entity_pb2])
 
-        key1 = Key(KIND, ID1, dataset_id=self.PROJECT)
-        key2 = Key(KIND, ID2, dataset_id=self.PROJECT)
+        key1 = Key(KIND, ID1, project=self.PROJECT)
+        key2 = Key(KIND, ID2, project=self.PROJECT)
         retrieved1, retrieved2 = client.get_multi([key1, key2])
 
         # Check values match.
@@ -491,8 +491,8 @@ class TestClient(unittest2.TestCase):
         # Make sure our IDs are actually different.
         self.assertNotEqual(PROJECT1, PROJECT2)
 
-        key1 = Key('KIND', 1234, dataset_id=PROJECT1)
-        key2 = Key('KIND', 1234, dataset_id=PROJECT2)
+        key1 = Key('KIND', 1234, project=PROJECT1)
+        key2 = Key('KIND', 1234, project=PROJECT2)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -522,9 +522,9 @@ class TestClient(unittest2.TestCase):
                                               entity_pb2,
                                               entity_pb3])
 
-        key1 = Key(KIND, ID1, dataset_id=PROJECT1)
-        key2 = Key(KIND, ID2, dataset_id=PROJECT2)
-        key3 = Key(KIND, ID3, dataset_id=PROJECT3)
+        key1 = Key(KIND, ID1, project=PROJECT1)
+        key2 = Key(KIND, ID2, project=PROJECT2)
+        key3 = Key(KIND, ID3, project=PROJECT3)
 
         retrieved_all = client.get_multi([key1, key2, key3])
         retrieved1, retrieved2, retrieved3 = retrieved_all
@@ -540,8 +540,8 @@ class TestClient(unittest2.TestCase):
         PROJECT1 = 'e~PROJECT'
         PROJECT2 = 's~PROJECT-ALT'
 
-        key1 = Key('KIND', 1234, dataset_id=PROJECT1)
-        key2 = Key('KIND', 1234, dataset_id=PROJECT2)
+        key1 = Key('KIND', 1234, project=PROJECT1)
+        key2 = Key('KIND', 1234, project=PROJECT2)
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -565,7 +565,7 @@ class TestClient(unittest2.TestCase):
         client = self._makeOne(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
-        key = Key(KIND, ID, dataset_id=self.PROJECT)
+        key = Key(KIND, ID, project=self.PROJECT)
         deferred = []
         missing = []
         with _Monkey(_MUT, _MAX_LOOPS=-1):

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest2.TestCase):
         path_args = ('Kind',)
         if id is not None:
             path_args += (id,)
-        return Key(*path_args, dataset_id=dataset_id).to_protobuf()
+        return Key(*path_args, project=dataset_id).to_protobuf()
 
     def _make_query_pb(self, kind):
         from gcloud.datastore._generated import query_pb2

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -80,7 +80,7 @@ class TestEntity(unittest2.TestCase):
         entity1[name] = value
         entity1._meanings[name] = (meaning, value)
 
-        key2 = Key(_KIND, _ID, project_PROJECT)
+        key2 = Key(_KIND, _ID, project=_PROJECT)
         entity2 = self._makeOne(key=key2, exclude_from_indexes=(name,))
         entity2[name] = value
         entity2._meanings[name] = (meaning, value)
@@ -156,7 +156,7 @@ class TestEntity(unittest2.TestCase):
 
         name = 'foo'
         value = 42
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_PROJECT)
 
         entity1 = self._makeOne(key=key, exclude_from_indexes=(name,))
         entity1[name] = value
@@ -172,7 +172,7 @@ class TestEntity(unittest2.TestCase):
         name = 'foo'
         value = 42
         meaning = 9
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_PROJECT)
 
         entity1 = self._makeOne(key=key, exclude_from_indexes=(name,))
         entity1[name] = value

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -52,7 +52,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_non_entity(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_DATASET_ID)
         entity = self._makeOne(key=key)
         self.assertFalse(entity == object())
         self.assertTrue(entity != object())
@@ -61,9 +61,9 @@ class TestEntity(unittest2.TestCase):
         from gcloud.datastore.key import Key
         _ID1 = 1234
         _ID2 = 2345
-        key1 = Key(_KIND, _ID1, dataset_id=_DATASET_ID)
+        key1 = Key(_KIND, _ID1, project=_DATASET_ID)
         entity1 = self._makeOne(key=key1)
-        key2 = Key(_KIND, _ID2, dataset_id=_DATASET_ID)
+        key2 = Key(_KIND, _ID2, project=_DATASET_ID)
         entity2 = self._makeOne(key=key2)
         self.assertFalse(entity1 == entity2)
         self.assertTrue(entity1 != entity2)
@@ -75,12 +75,12 @@ class TestEntity(unittest2.TestCase):
         value = 42
         meaning = 9
 
-        key1 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_DATASET_ID)
         entity1 = self._makeOne(key=key1, exclude_from_indexes=(name,))
         entity1[name] = value
         entity1._meanings[name] = (meaning, value)
 
-        key2 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key2 = Key(_KIND, _ID, project=_DATASET_ID)
         entity2 = self._makeOne(key=key2, exclude_from_indexes=(name,))
         entity2[name] = value
         entity2._meanings[name] = (meaning, value)
@@ -90,10 +90,10 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_different_props(self):
         from gcloud.datastore.key import Key
-        key1 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_DATASET_ID)
         entity1 = self._makeOne(key=key1)
         entity1['foo'] = 'Foo'
-        key2 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key2 = Key(_KIND, _ID, project=_DATASET_ID)
         entity2 = self._makeOne(key=key2)
         entity1['bar'] = 'Bar'
         self.assertFalse(entity1 == entity2)
@@ -101,8 +101,8 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_equiv_keys_as_value(self):
         from gcloud.datastore.key import Key
-        key1 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
-        key2 = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_DATASET_ID)
+        key2 = Key(_KIND, _ID, project=_DATASET_ID)
         entity1 = self._makeOne(key=key1)
         entity1['some_key'] = key1
         entity2 = self._makeOne(key=key1)
@@ -114,8 +114,8 @@ class TestEntity(unittest2.TestCase):
         from gcloud.datastore.key import Key
         _ID1 = 1234
         _ID2 = 2345
-        key1 = Key(_KIND, _ID1, dataset_id=_DATASET_ID)
-        key2 = Key(_KIND, _ID2, dataset_id=_DATASET_ID)
+        key1 = Key(_KIND, _ID1, project=_DATASET_ID)
+        key2 = Key(_KIND, _ID2, project=_DATASET_ID)
         entity1 = self._makeOne(key=key1)
         entity1['some_key'] = key1
         entity2 = self._makeOne(key=key1)
@@ -125,7 +125,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_equiv_entities_as_value(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_DATASET_ID)
         entity1 = self._makeOne(key=key)
         sub1 = self._makeOne()
         sub1.update({'foo': 'Foo'})
@@ -139,7 +139,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_diff_entities_as_value(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, dataset_id=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_DATASET_ID)
         entity1 = self._makeOne(key=key)
         sub1 = self._makeOne()
         sub1.update({'foo': 'Foo'})
@@ -203,8 +203,8 @@ class _Key(object):
     _id = None
     _stored = None
 
-    def __init__(self, dataset_id=_DATASET_ID):
-        self.dataset_id = dataset_id
+    def __init__(self, project=_DATASET_ID):
+        self.project = project
 
     @property
     def path(self):

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -14,7 +14,7 @@
 
 import unittest2
 
-_DATASET_ID = 'DATASET'
+_PROJECT = 'PROJECT'
 _KIND = 'KIND'
 _ID = 1234
 
@@ -52,7 +52,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_non_entity(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, project=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_PROJECT)
         entity = self._makeOne(key=key)
         self.assertFalse(entity == object())
         self.assertTrue(entity != object())
@@ -61,9 +61,9 @@ class TestEntity(unittest2.TestCase):
         from gcloud.datastore.key import Key
         _ID1 = 1234
         _ID2 = 2345
-        key1 = Key(_KIND, _ID1, project=_DATASET_ID)
+        key1 = Key(_KIND, _ID1, project=_PROJECT)
         entity1 = self._makeOne(key=key1)
-        key2 = Key(_KIND, _ID2, project=_DATASET_ID)
+        key2 = Key(_KIND, _ID2, project=_PROJECT)
         entity2 = self._makeOne(key=key2)
         self.assertFalse(entity1 == entity2)
         self.assertTrue(entity1 != entity2)
@@ -75,12 +75,12 @@ class TestEntity(unittest2.TestCase):
         value = 42
         meaning = 9
 
-        key1 = Key(_KIND, _ID, project=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_PROJECT)
         entity1 = self._makeOne(key=key1, exclude_from_indexes=(name,))
         entity1[name] = value
         entity1._meanings[name] = (meaning, value)
 
-        key2 = Key(_KIND, _ID, project=_DATASET_ID)
+        key2 = Key(_KIND, _ID, project_PROJECT)
         entity2 = self._makeOne(key=key2, exclude_from_indexes=(name,))
         entity2[name] = value
         entity2._meanings[name] = (meaning, value)
@@ -90,10 +90,10 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_different_props(self):
         from gcloud.datastore.key import Key
-        key1 = Key(_KIND, _ID, project=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_PROJECT)
         entity1 = self._makeOne(key=key1)
         entity1['foo'] = 'Foo'
-        key2 = Key(_KIND, _ID, project=_DATASET_ID)
+        key2 = Key(_KIND, _ID, project=_PROJECT)
         entity2 = self._makeOne(key=key2)
         entity1['bar'] = 'Bar'
         self.assertFalse(entity1 == entity2)
@@ -101,8 +101,8 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_equiv_keys_as_value(self):
         from gcloud.datastore.key import Key
-        key1 = Key(_KIND, _ID, project=_DATASET_ID)
-        key2 = Key(_KIND, _ID, project=_DATASET_ID)
+        key1 = Key(_KIND, _ID, project=_PROJECT)
+        key2 = Key(_KIND, _ID, project=_PROJECT)
         entity1 = self._makeOne(key=key1)
         entity1['some_key'] = key1
         entity2 = self._makeOne(key=key1)
@@ -114,8 +114,8 @@ class TestEntity(unittest2.TestCase):
         from gcloud.datastore.key import Key
         _ID1 = 1234
         _ID2 = 2345
-        key1 = Key(_KIND, _ID1, project=_DATASET_ID)
-        key2 = Key(_KIND, _ID2, project=_DATASET_ID)
+        key1 = Key(_KIND, _ID1, project=_PROJECT)
+        key2 = Key(_KIND, _ID2, project=_PROJECT)
         entity1 = self._makeOne(key=key1)
         entity1['some_key'] = key1
         entity2 = self._makeOne(key=key1)
@@ -125,7 +125,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_equiv_entities_as_value(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, project=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_PROJECT)
         entity1 = self._makeOne(key=key)
         sub1 = self._makeOne()
         sub1.update({'foo': 'Foo'})
@@ -139,7 +139,7 @@ class TestEntity(unittest2.TestCase):
 
     def test___eq_____ne___w_same_keys_props_w_diff_entities_as_value(self):
         from gcloud.datastore.key import Key
-        key = Key(_KIND, _ID, project=_DATASET_ID)
+        key = Key(_KIND, _ID, project=_PROJECT)
         entity1 = self._makeOne(key=key)
         sub1 = self._makeOne()
         sub1.update({'foo': 'Foo'})
@@ -203,7 +203,7 @@ class _Key(object):
     _id = None
     _stored = None
 
-    def __init__(self, project=_DATASET_ID):
+    def __init__(self, project=_PROJECT):
         self.project = project
 
     @property

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -104,7 +104,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
         # Also check the key.
         key = entity.key
-        self.assertEqual(key.dataset_id, _DATASET_ID)
+        self.assertEqual(key.project, _DATASET_ID)
         self.assertEqual(key.namespace, None)
         self.assertEqual(key.kind, _KIND)
         self.assertEqual(key.id, _ID)
@@ -181,7 +181,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         outside_val_pb.entity_value.CopyFrom(entity_inside)
 
         entity = self._callFUT(entity_pb)
-        self.assertEqual(entity.key.dataset_id, DATASET_ID)
+        self.assertEqual(entity.key.project, DATASET_ID)
         self.assertEqual(entity.key.flat_path, (KIND,))
         self.assertEqual(len(entity), 1)
 
@@ -230,7 +230,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
 
         kind, name = 'PATH', 'NAME'
         dataset_id = 'DATASET'
-        key = Key(kind, name, dataset_id=dataset_id)
+        key = Key(kind, name, project=dataset_id)
         entity = Entity(key=key)
         entity_pb = self._callFUT(entity)
 
@@ -371,7 +371,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         _DATASET = 'DATASET'
         pb = self._makePB(path=[{'kind': 'KIND'}], dataset_id=_DATASET)
         key = self._callFUT(pb)
-        self.assertEqual(key.dataset_id, _DATASET)
+        self.assertEqual(key.project, _DATASET)
         self.assertEqual(key.namespace, None)
 
     def test_w_namespace_in_pb(self):
@@ -380,7 +380,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         pb = self._makePB(path=[{'kind': 'KIND'}], namespace=_NAMESPACE,
                           dataset_id=_DATASET)
         key = self._callFUT(pb)
-        self.assertEqual(key.dataset_id, _DATASET)
+        self.assertEqual(key.project, _DATASET)
         self.assertEqual(key.namespace, _NAMESPACE)
 
     def test_w_nested_path_in_pb(self):
@@ -431,7 +431,7 @@ class Test__pb_attr_value(unittest2.TestCase):
     def test_key(self):
         from gcloud.datastore.key import Key
 
-        key = Key('PATH', 1234, dataset_id='DATASET')
+        key = Key('PATH', 1234, project='DATASET')
         name, value = self._callFUT(key)
         self.assertEqual(name, 'key_value')
         self.assertEqual(value, key.to_protobuf())
@@ -530,7 +530,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
         from gcloud.datastore.key import Key
 
         pb = entity_pb2.Value()
-        expected = Key('KIND', 1234, dataset_id='DATASET').to_protobuf()
+        expected = Key('KIND', 1234, project='DATASET').to_protobuf()
         pb.key_value.CopyFrom(expected)
         found = self._callFUT(pb)
         self.assertEqual(found.to_protobuf(), expected)
@@ -617,7 +617,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         from gcloud.datastore.key import Key
 
         pb = self._makePB()
-        key = Key('KIND', 1234, dataset_id='DATASET')
+        key = Key('KIND', 1234, project='DATASET')
         self._callFUT(pb, key)
         value = pb.key_value
         self.assertEqual(value, key.to_protobuf())
@@ -707,7 +707,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         name = 'foo'
         value = u'Foo'
         pb = self._makePB()
-        key = Key('KIND', 123, dataset_id='DATASET')
+        key = Key('KIND', 123, project='DATASET')
         entity = Entity(key=key)
         entity[name] = value
         self._callFUT(pb, entity)

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -66,11 +66,11 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         from gcloud.datastore._generated import entity_pb2
         from gcloud.datastore.helpers import _new_value_pb
 
-        _DATASET_ID = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = _DATASET_ID
+        entity_pb.key.partition_id.dataset_id = _PROJECT
         entity_pb.key.path_element.add(kind=_KIND, id=_ID)
 
         value_pb = _new_value_pb(entity_pb, 'foo')
@@ -104,7 +104,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
         # Also check the key.
         key = entity.key
-        self.assertEqual(key.project, _DATASET_ID)
+        self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, None)
         self.assertEqual(key.kind, _KIND)
         self.assertEqual(key.id, _ID)
@@ -113,11 +113,11 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         from gcloud.datastore._generated import entity_pb2
         from gcloud.datastore.helpers import _new_value_pb
 
-        _DATASET_ID = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = _DATASET_ID
+        entity_pb.key.partition_id.dataset_id = _PROJECT
         entity_pb.key.path_element.add(kind=_KIND, id=_ID)
 
         list_val_pb = _new_value_pb(entity_pb, 'baz')
@@ -162,7 +162,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         from gcloud.datastore._generated import entity_pb2
         from gcloud.datastore.helpers import _new_value_pb
 
-        DATASET_ID = 's~FOO'
+        PROJECT = 's~FOO'
         KIND = 'KIND'
         INSIDE_NAME = 'IFOO'
         OUTSIDE_NAME = 'OBAR'
@@ -173,7 +173,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         inside_val_pb.integer_value = INSIDE_VALUE
 
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = DATASET_ID
+        entity_pb.key.partition_id.dataset_id = PROJECT
         element = entity_pb.key.path_element.add()
         element.kind = KIND
 
@@ -181,7 +181,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         outside_val_pb.entity_value.CopyFrom(entity_inside)
 
         entity = self._callFUT(entity_pb)
-        self.assertEqual(entity.key.project, DATASET_ID)
+        self.assertEqual(entity.key.project, PROJECT)
         self.assertEqual(entity.key.flat_path, (KIND,))
         self.assertEqual(len(entity), 1)
 
@@ -229,13 +229,13 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         from gcloud.datastore.key import Key
 
         kind, name = 'PATH', 'NAME'
-        dataset_id = 'DATASET'
-        key = Key(kind, name, project=dataset_id)
+        project = 'PROJECT'
+        key = Key(kind, name, project=project)
         entity = Entity(key=key)
         entity_pb = self._callFUT(entity)
 
         expected_pb = entity_pb2.Entity()
-        expected_pb.key.partition_id.dataset_id = dataset_id
+        expected_pb.key.partition_id.dataset_id = project
         path_elt = expected_pb.key.path_element.add()
         path_elt.kind = kind
         path_elt.name = name
@@ -279,7 +279,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
 
         original_pb = entity_pb2.Entity()
         # Add a key.
-        original_pb.key.partition_id.dataset_id = dataset_id = 'DATASET'
+        original_pb.key.partition_id.dataset_id = project = 'PROJECT'
         elem1 = original_pb.key.path_element.add()
         elem1.kind = 'Family'
         elem1.id = 1234
@@ -321,8 +321,8 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         # Convert the user-space Entity back to a protobuf.
         new_pb = self._callFUT(entity)
 
-        # NOTE: entity_to_protobuf() strips the dataset_id so we "cheat".
-        new_pb.key.partition_id.dataset_id = dataset_id
+        # NOTE: entity_to_protobuf() strips the project so we "cheat".
+        new_pb.key.partition_id.dataset_id = project
         self._compareEntityProto(original_pb, new_pb)
 
     def test_meaning_with_change(self):
@@ -351,11 +351,11 @@ class Test_key_from_protobuf(unittest2.TestCase):
 
         return key_from_protobuf(val)
 
-    def _makePB(self, dataset_id=None, namespace=None, path=()):
+    def _makePB(self, project=None, namespace=None, path=()):
         from gcloud.datastore._generated import entity_pb2
         pb = entity_pb2.Key()
-        if dataset_id is not None:
-            pb.partition_id.dataset_id = dataset_id
+        if project is not None:
+            pb.partition_id.dataset_id = project
         if namespace is not None:
             pb.partition_id.namespace = namespace
         for elem in path:
@@ -368,19 +368,19 @@ class Test_key_from_protobuf(unittest2.TestCase):
         return pb
 
     def test_wo_namespace_in_pb(self):
-        _DATASET = 'DATASET'
-        pb = self._makePB(path=[{'kind': 'KIND'}], dataset_id=_DATASET)
+        _PROJECT = 'PROJECT'
+        pb = self._makePB(path=[{'kind': 'KIND'}], project=_PROJECT)
         key = self._callFUT(pb)
-        self.assertEqual(key.project, _DATASET)
+        self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, None)
 
     def test_w_namespace_in_pb(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _NAMESPACE = 'NAMESPACE'
         pb = self._makePB(path=[{'kind': 'KIND'}], namespace=_NAMESPACE,
-                          dataset_id=_DATASET)
+                          project=_PROJECT)
         key = self._callFUT(pb)
-        self.assertEqual(key.project, _DATASET)
+        self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, _NAMESPACE)
 
     def test_w_nested_path_in_pb(self):
@@ -389,7 +389,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
             {'kind': 'CHILD', 'id': 1234},
             {'kind': 'GRANDCHILD', 'id': 5678},
         ]
-        pb = self._makePB(path=_PATH, dataset_id='DATASET')
+        pb = self._makePB(path=_PATH, project='PROJECT')
         key = self._callFUT(pb)
         self.assertEqual(key.path, _PATH)
 
@@ -431,7 +431,7 @@ class Test__pb_attr_value(unittest2.TestCase):
     def test_key(self):
         from gcloud.datastore.key import Key
 
-        key = Key('PATH', 1234, project='DATASET')
+        key = Key('PATH', 1234, project='PROJECT')
         name, value = self._callFUT(key)
         self.assertEqual(name, 'key_value')
         self.assertEqual(value, key.to_protobuf())
@@ -530,7 +530,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
         from gcloud.datastore.key import Key
 
         pb = entity_pb2.Value()
-        expected = Key('KIND', 1234, project='DATASET').to_protobuf()
+        expected = Key('KIND', 1234, project='PROJECT').to_protobuf()
         pb.key_value.CopyFrom(expected)
         found = self._callFUT(pb)
         self.assertEqual(found.to_protobuf(), expected)
@@ -563,7 +563,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
         pb = entity_pb2.Value()
         entity_pb = pb.entity_value
         entity_pb.key.path_element.add(kind='KIND')
-        entity_pb.key.partition_id.dataset_id = 'DATASET'
+        entity_pb.key.partition_id.dataset_id = 'PROJECT'
 
         value_pb = _new_value_pb(entity_pb, 'foo')
         value_pb.string_value = 'Foo'
@@ -617,7 +617,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         from gcloud.datastore.key import Key
 
         pb = self._makePB()
-        key = Key('KIND', 1234, project='DATASET')
+        key = Key('KIND', 1234, project='PROJECT')
         self._callFUT(pb, key)
         value = pb.key_value
         self.assertEqual(value, key.to_protobuf())
@@ -707,7 +707,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         name = 'foo'
         value = u'Foo'
         pb = self._makePB()
-        key = Key('KIND', 123, project='DATASET')
+        key = Key('KIND', 123, project='PROJECT')
         entity = Entity(key=key)
         entity[name] = value
         self._callFUT(pb, entity)
@@ -737,7 +737,7 @@ class Test__prepare_key_for_request(unittest2.TestCase):
 
         return _prepare_key_for_request(key_pb)
 
-    def test_prepare_dataset_id_valid(self):
+    def test_prepare_project_valid(self):
         from gcloud.datastore._generated import entity_pb2
         key = entity_pb2.Key()
         key.partition_id.dataset_id = 'foo'
@@ -748,31 +748,31 @@ class Test__prepare_key_for_request(unittest2.TestCase):
         new_key.ClearField('partition_id')
         self.assertEqual(new_key, key_without)
 
-    def test_prepare_dataset_id_unset(self):
+    def test_prepare_project_unset(self):
         from gcloud.datastore._generated import entity_pb2
         key = entity_pb2.Key()
         new_key = self._callFUT(key)
         self.assertTrue(new_key is key)
 
 
-class Test_find_true_dataset_id(unittest2.TestCase):
+class Test_find_true_project(unittest2.TestCase):
 
-    def _callFUT(self, dataset_id, connection):
-        from gcloud.datastore.helpers import find_true_dataset_id
-        return find_true_dataset_id(dataset_id, connection)
+    def _callFUT(self, project, connection):
+        from gcloud.datastore.helpers import find_true_project
+        return find_true_project(project, connection)
 
     def test_prefixed(self):
-        PREFIXED = 's~DATASET'
+        PREFIXED = 's~PROJECT'
         result = self._callFUT(PREFIXED, object())
         self.assertEqual(PREFIXED, result)
 
     def test_unprefixed_bogus_key_miss(self):
-        UNPREFIXED = 'DATASET'
+        UNPREFIXED = 'PROJECT'
         PREFIX = 's~'
         CONNECTION = _Connection(PREFIX, from_missing=False)
         result = self._callFUT(UNPREFIXED, CONNECTION)
 
-        self.assertEqual(CONNECTION._called_dataset_id, UNPREFIXED)
+        self.assertEqual(CONNECTION._called_project, UNPREFIXED)
 
         self.assertEqual(len(CONNECTION._lookup_result), 1)
 
@@ -788,12 +788,12 @@ class Test_find_true_dataset_id(unittest2.TestCase):
         self.assertEqual(result, PREFIXED)
 
     def test_unprefixed_bogus_key_hit(self):
-        UNPREFIXED = 'DATASET'
+        UNPREFIXED = 'PROJECT'
         PREFIX = 'e~'
         CONNECTION = _Connection(PREFIX, from_missing=True)
         result = self._callFUT(UNPREFIXED, CONNECTION)
 
-        self.assertEqual(CONNECTION._called_dataset_id, UNPREFIXED)
+        self.assertEqual(CONNECTION._called_project, UNPREFIXED)
         self.assertEqual(CONNECTION._lookup_result, [])
 
         # Make sure just one.
@@ -890,24 +890,24 @@ class Test__get_meaning(unittest2.TestCase):
 
 class _Connection(object):
 
-    _called_dataset_id = _called_key_pbs = _lookup_result = None
+    _called_project = _called_key_pbs = _lookup_result = None
 
     def __init__(self, prefix, from_missing=False):
         self.prefix = prefix
         self.from_missing = from_missing
 
-    def lookup(self, dataset_id, key_pbs):
+    def lookup(self, project, key_pbs):
         from gcloud.datastore._generated import entity_pb2
 
         # Store the arguments called with.
-        self._called_dataset_id = dataset_id
+        self._called_project = project
         self._called_key_pbs = key_pbs
 
         key_pb, = key_pbs
 
         response = entity_pb2.Entity()
         response.key.CopyFrom(key_pb)
-        response.key.partition_id.dataset_id = self.prefix + dataset_id
+        response.key.partition_id.dataset_id = self.prefix + project
 
         missing = []
         deferred = []

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -17,7 +17,7 @@ import unittest2
 
 class TestKey(unittest2.TestCase):
 
-    _DEFAULT_DATASET = 'DATASET'
+    _DEFAULT_PROJECT = 'PROJECT'
 
     def _getTargetClass(self):
         from gcloud.datastore.key import Key
@@ -29,18 +29,18 @@ class TestKey(unittest2.TestCase):
     def test_ctor_empty(self):
         self.assertRaises(ValueError, self._makeOne)
 
-    def test_ctor_no_dataset_id(self):
+    def test_ctor_no_project(self):
         klass = self._getTargetClass()
         self.assertRaises(ValueError, klass, 'KIND')
 
-    def test_ctor_w_explicit_dataset_id_empty_path(self):
-        _DATASET = 'DATASET'
-        self.assertRaises(ValueError, self._makeOne, project=_DATASET)
+    def test_ctor_w_explicit_project_empty_path(self):
+        _PROJECT = 'PROJECT'
+        self.assertRaises(ValueError, self._makeOne, project=_PROJECT)
 
     def test_ctor_parent(self):
         _PARENT_KIND = 'KIND1'
         _PARENT_ID = 1234
-        _PARENT_DATASET = 'DATASET-ALT'
+        _PARENT_PROJECT = 'PROJECT-ALT'
         _PARENT_NAMESPACE = 'NAMESPACE'
         _CHILD_KIND = 'KIND2'
         _CHILD_ID = 2345
@@ -49,7 +49,7 @@ class TestKey(unittest2.TestCase):
             {'kind': _CHILD_KIND, 'id': _CHILD_ID},
         ]
         parent_key = self._makeOne(_PARENT_KIND, _PARENT_ID,
-                                   project=_PARENT_DATASET,
+                                   project=_PARENT_PROJECT,
                                    namespace=_PARENT_NAMESPACE)
         key = self._makeOne(_CHILD_KIND, _CHILD_ID, parent=parent_key)
         self.assertEqual(key.project, parent_key.project)
@@ -59,23 +59,23 @@ class TestKey(unittest2.TestCase):
         self.assertTrue(key.parent is parent_key)
 
     def test_ctor_partial_parent(self):
-        parent_key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        parent_key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, parent=parent_key)
 
     def test_ctor_parent_bad_type(self):
         with self.assertRaises(AttributeError):
             self._makeOne('KIND2', 1234, parent=('KIND1', 1234),
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
 
     def test_ctor_parent_bad_namespace(self):
         parent_key = self._makeOne('KIND', 1234, namespace='FOO',
-                                   project=self._DEFAULT_DATASET)
+                                   project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, namespace='BAR', parent=parent_key,
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
 
-    def test_ctor_parent_bad_dataset_id(self):
+    def test_ctor_parent_bad_project(self):
         parent_key = self._makeOne('KIND', 1234, project='FOO')
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, parent=parent_key,
@@ -83,51 +83,51 @@ class TestKey(unittest2.TestCase):
 
     def test_ctor_parent_empty_path(self):
         parent_key = self._makeOne('KIND', 1234,
-                                   project=self._DEFAULT_DATASET)
+                                   project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
             self._makeOne(parent=parent_key)
 
     def test_ctor_explicit(self):
-        _DATASET = 'DATASET-ALT'
+        _PROJECT = 'PROJECT-ALT'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
-                            project=_DATASET)
-        self.assertEqual(key.project, _DATASET)
+                            project=_PROJECT)
+        self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, _NAMESPACE)
         self.assertEqual(key.kind, _KIND)
         self.assertEqual(key.path, _PATH)
 
     def test_ctor_bad_kind(self):
         self.assertRaises(ValueError, self._makeOne, object(),
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
 
     def test_ctor_bad_id_or_name(self):
         self.assertRaises(ValueError, self._makeOne, 'KIND', object(),
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, self._makeOne, 'KIND', None,
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, self._makeOne, 'KIND', 10, 'KIND2', None,
-                          project=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_PROJECT)
 
     def test__clone(self):
-        _DATASET = 'DATASET-ALT'
+        _PROJECT = 'PROJECT-ALT'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
-                            project=_DATASET)
+                            project=_PROJECT)
         clone = key._clone()
-        self.assertEqual(clone.project, _DATASET)
+        self.assertEqual(clone.project, _PROJECT)
         self.assertEqual(clone.namespace, _NAMESPACE)
         self.assertEqual(clone.kind, _KIND)
         self.assertEqual(clone.path, _PATH)
 
     def test__clone_with_parent(self):
-        _DATASET = 'DATASET-ALT'
+        _PROJECT = 'PROJECT-ALT'
         _NAMESPACE = 'NAMESPACE'
         _KIND1 = 'PARENT'
         _KIND2 = 'KIND'
@@ -136,180 +136,180 @@ class TestKey(unittest2.TestCase):
         _PATH = [{'kind': _KIND1, 'id': _ID1}, {'kind': _KIND2, 'id': _ID2}]
 
         parent = self._makeOne(_KIND1, _ID1, namespace=_NAMESPACE,
-                               project=_DATASET)
+                               project=_PROJECT)
         key = self._makeOne(_KIND2, _ID2, parent=parent)
         self.assertTrue(key.parent is parent)
         clone = key._clone()
         self.assertTrue(clone.parent is key.parent)
-        self.assertEqual(clone.project, _DATASET)
+        self.assertEqual(clone.project, _PROJECT)
         self.assertEqual(clone.namespace, _NAMESPACE)
         self.assertEqual(clone.path, _PATH)
 
     def test___eq_____ne___w_non_key(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'one'
-        key = self._makeOne(_KIND, _NAME, project=_DATASET)
+        key = self._makeOne(_KIND, _NAME, project=_PROJECT)
         self.assertFalse(key == object())
         self.assertTrue(key != object())
 
     def test___eq_____ne___two_incomplete_keys_same_kind(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
-        key1 = self._makeOne(_KIND, project=_DATASET)
-        key2 = self._makeOne(_KIND, project=_DATASET)
+        key1 = self._makeOne(_KIND, project=_PROJECT)
+        key2 = self._makeOne(_KIND, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___incomplete_key_w_complete_key_same_kind(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, project=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, project=_DATASET)
+        key1 = self._makeOne(_KIND, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _ID, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___complete_key_w_incomplete_key_same_kind(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
-        key2 = self._makeOne(_KIND, project=_DATASET)
+        key1 = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key2 = self._makeOne(_KIND, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___same_kind_different_ids(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID1 = 1234
         _ID2 = 2345
-        key1 = self._makeOne(_KIND, _ID1, project=_DATASET)
-        key2 = self._makeOne(_KIND, _ID2, project=_DATASET)
+        key1 = self._makeOne(_KIND, _ID1, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _ID2, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___same_kind_and_id(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, project=_DATASET)
+        key1 = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _ID, project=_PROJECT)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
-    def test___eq_____ne___same_kind_and_id_different_dataset(self):
-        _DATASET1 = 'DATASET1'
-        _DATASET2 = 'DATASET2'
+    def test___eq_____ne___same_kind_and_id_different_project(self):
+        _PROJECT1 = 'PROJECT1'
+        _PROJECT2 = 'PROJECT2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_DATASET1)
-        key2 = self._makeOne(_KIND, _ID, project=_DATASET2)
+        key1 = self._makeOne(_KIND, _ID, project=_PROJECT1)
+        key2 = self._makeOne(_KIND, _ID, project=_PROJECT2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___same_kind_and_id_different_namespace(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _NAMESPACE1 = 'NAMESPACE1'
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_DATASET,
+        key1 = self._makeOne(_KIND, _ID, project=_PROJECT,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _ID, project=_DATASET,
+        key2 = self._makeOne(_KIND, _ID, project=_PROJECT,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
-    def test___eq_____ne___same_kind_and_id_different_dataset_pfx(self):
-        _DATASET = 'DATASET'
-        _DATASET_W_PFX = 's~DATASET'
+    def test___eq_____ne___same_kind_and_id_different_project_pfx(self):
+        _PROJECT = 'PROJECT'
+        _PROJECT_W_PFX = 's~PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, project=_DATASET_W_PFX)
+        key1 = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _ID, project=_PROJECT_W_PFX)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
     def test___eq_____ne___same_kind_different_names(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME1 = 'one'
         _NAME2 = 'two'
-        key1 = self._makeOne(_KIND, _NAME1, project=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME2, project=_DATASET)
+        key1 = self._makeOne(_KIND, _NAME1, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _NAME2, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___same_kind_and_name(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME, project=_DATASET)
+        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
-    def test___eq_____ne___same_kind_and_name_different_dataset(self):
-        _DATASET1 = 'DATASET1'
-        _DATASET2 = 'DATASET2'
+    def test___eq_____ne___same_kind_and_name_different_project(self):
+        _PROJECT1 = 'PROJECT1'
+        _PROJECT2 = 'PROJECT2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_DATASET1)
-        key2 = self._makeOne(_KIND, _NAME, project=_DATASET2)
+        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT1)
+        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
     def test___eq_____ne___same_kind_and_name_different_namespace(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _NAMESPACE1 = 'NAMESPACE1'
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_DATASET,
+        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _NAME, project=_DATASET,
+        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
-    def test___eq_____ne___same_kind_and_name_different_dataset_pfx(self):
-        _DATASET = 'DATASET'
-        _DATASET_W_PFX = 's~DATASET'
+    def test___eq_____ne___same_kind_and_name_different_project_pfx(self):
+        _PROJECT = 'PROJECT'
+        _PROJECT_W_PFX = 's~PROJECT'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME, project=_DATASET_W_PFX)
+        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT)
+        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT_W_PFX)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
     def test___hash___incomplete(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, project=_DATASET)
+        key = self._makeOne(_KIND, project=_PROJECT)
         self.assertNotEqual(hash(key),
-                            hash(_KIND) + hash(_DATASET) + hash(None))
+                            hash(_KIND) + hash(_PROJECT) + hash(None))
 
     def test___hash___completed_w_id(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key = self._makeOne(_KIND, _ID, project=_DATASET)
+        key = self._makeOne(_KIND, _ID, project=_PROJECT)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_ID) +
-                            hash(_DATASET) + hash(None))
+                            hash(_PROJECT) + hash(None))
 
     def test___hash___completed_w_name(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'NAME'
-        key = self._makeOne(_KIND, _NAME, project=_DATASET)
+        key = self._makeOne(_KIND, _NAME, project=_PROJECT)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_NAME) +
-                            hash(_DATASET) + hash(None))
+                            hash(_PROJECT) + hash(None))
 
     def test_completed_key_on_partial_w_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         _ID = 1234
         new_key = key.completed_key(_ID)
         self.assertFalse(key is new_key)
@@ -317,7 +317,7 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(new_key.name, None)
 
     def test_completed_key_on_partial_w_name(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         _NAME = 'NAME'
         new_key = key.completed_key(_NAME)
         self.assertFalse(key is new_key)
@@ -325,22 +325,22 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(new_key.name, _NAME)
 
     def test_completed_key_on_partial_w_invalid(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, key.completed_key, object())
 
     def test_completed_key_on_complete(self):
-        key = self._makeOne('KIND', 1234, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', 1234, project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, key.completed_key, 5678)
 
     def test_to_protobuf_defaults(self):
         from gcloud.datastore._generated import entity_pb2
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, project=self._DEFAULT_DATASET)
+        key = self._makeOne(_KIND, project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         self.assertTrue(isinstance(pb, entity_pb2.Key))
 
         # Check partition ID.
-        self.assertEqual(pb.partition_id.dataset_id, self._DEFAULT_DATASET)
+        self.assertEqual(pb.partition_id.dataset_id, self._DEFAULT_PROJECT)
         self.assertEqual(pb.partition_id.namespace, '')
         self.assertFalse(pb.partition_id.HasField('namespace'))
 
@@ -352,16 +352,16 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(elem.id, 0)
         self.assertFalse(elem.HasField('id'))
 
-    def test_to_protobuf_w_explicit_dataset_id(self):
-        _DATASET = 'DATASET-ALT'
-        key = self._makeOne('KIND', project=_DATASET)
+    def test_to_protobuf_w_explicit_project(self):
+        _PROJECT = 'PROJECT-ALT'
+        key = self._makeOne('KIND', project=_PROJECT)
         pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, _DATASET)
+        self.assertEqual(pb.partition_id.dataset_id, _PROJECT)
 
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'
         key = self._makeOne('KIND', namespace=_NAMESPACE,
-                            project=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.namespace, _NAMESPACE)
 
@@ -371,7 +371,7 @@ class TestKey(unittest2.TestCase):
         _ID = 1234
         _NAME = 'NAME'
         key = self._makeOne(_PARENT, _NAME, _CHILD, _ID,
-                            project=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         elems = list(pb.path_element)
         self.assertEqual(len(elems), 2)
@@ -381,7 +381,7 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(elems[1].id, _ID)
 
     def test_to_protobuf_w_no_kind(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         # Force the 'kind' to be unset. Maybe `to_protobuf` should fail
         # on this? The backend certainly will.
         key._path[-1].pop('kind')
@@ -389,44 +389,44 @@ class TestKey(unittest2.TestCase):
         self.assertFalse(pb.path_element[0].HasField('kind'))
 
     def test_is_partial_no_name_or_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         self.assertTrue(key.is_partial)
 
     def test_is_partial_w_id(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _ID, project=self._DEFAULT_PROJECT)
         self.assertFalse(key.is_partial)
 
     def test_is_partial_w_name(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_PROJECT)
         self.assertFalse(key.is_partial)
 
     def test_id_or_name_no_name_or_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_no_name_or_id_child(self):
         key = self._makeOne('KIND1', 1234, 'KIND2',
-                            project=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_w_id_only(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _ID, project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, _ID)
 
     def test_id_or_name_w_name_only(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, _NAME)
 
     def test_parent_default(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
         self.assertEqual(key.parent, None)
 
     def test_parent_explicit_top_level(self):
-        key = self._makeOne('KIND', 1234, project=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', 1234, project=self._DEFAULT_PROJECT)
         self.assertEqual(key.parent, None)
 
     def test_parent_explicit_nested(self):
@@ -434,7 +434,7 @@ class TestKey(unittest2.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            project=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_PROJECT)
         self.assertEqual(key.parent.path, _PARENT_PATH)
 
     def test_parent_multiple_calls(self):
@@ -442,7 +442,7 @@ class TestKey(unittest2.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            project=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_PROJECT)
         parent = key.parent
         self.assertEqual(parent.path, _PARENT_PATH)
         new_parent = key.parent
@@ -451,9 +451,9 @@ class TestKey(unittest2.TestCase):
 
 class Test__projects_equal(unittest2.TestCase):
 
-    def _callFUT(self, dataset_id1, dataset_id2):
+    def _callFUT(self, project1, project2):
         from gcloud.datastore.key import _projects_equal
-        return _projects_equal(dataset_id1, dataset_id2)
+        return _projects_equal(project1, project2)
 
     def test_identical_prefixed(self):
         self.assertTrue(self._callFUT('s~foo', 's~foo'))

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -35,7 +35,7 @@ class TestKey(unittest2.TestCase):
 
     def test_ctor_w_explicit_dataset_id_empty_path(self):
         _DATASET = 'DATASET'
-        self.assertRaises(ValueError, self._makeOne, dataset_id=_DATASET)
+        self.assertRaises(ValueError, self._makeOne, project=_DATASET)
 
     def test_ctor_parent(self):
         _PARENT_KIND = 'KIND1'
@@ -49,41 +49,41 @@ class TestKey(unittest2.TestCase):
             {'kind': _CHILD_KIND, 'id': _CHILD_ID},
         ]
         parent_key = self._makeOne(_PARENT_KIND, _PARENT_ID,
-                                   dataset_id=_PARENT_DATASET,
+                                   project=_PARENT_DATASET,
                                    namespace=_PARENT_NAMESPACE)
         key = self._makeOne(_CHILD_KIND, _CHILD_ID, parent=parent_key)
-        self.assertEqual(key.dataset_id, parent_key.dataset_id)
+        self.assertEqual(key.project, parent_key.project)
         self.assertEqual(key.namespace, parent_key.namespace)
         self.assertEqual(key.kind, _CHILD_KIND)
         self.assertEqual(key.path, _PATH)
         self.assertTrue(key.parent is parent_key)
 
     def test_ctor_partial_parent(self):
-        parent_key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        parent_key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, parent=parent_key)
 
     def test_ctor_parent_bad_type(self):
         with self.assertRaises(AttributeError):
             self._makeOne('KIND2', 1234, parent=('KIND1', 1234),
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
 
     def test_ctor_parent_bad_namespace(self):
         parent_key = self._makeOne('KIND', 1234, namespace='FOO',
-                                   dataset_id=self._DEFAULT_DATASET)
+                                   project=self._DEFAULT_DATASET)
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, namespace='BAR', parent=parent_key,
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
 
     def test_ctor_parent_bad_dataset_id(self):
-        parent_key = self._makeOne('KIND', 1234, dataset_id='FOO')
+        parent_key = self._makeOne('KIND', 1234, project='FOO')
         with self.assertRaises(ValueError):
             self._makeOne('KIND2', 1234, parent=parent_key,
-                          dataset_id='BAR')
+                          project='BAR')
 
     def test_ctor_parent_empty_path(self):
         parent_key = self._makeOne('KIND', 1234,
-                                   dataset_id=self._DEFAULT_DATASET)
+                                   project=self._DEFAULT_DATASET)
         with self.assertRaises(ValueError):
             self._makeOne(parent=parent_key)
 
@@ -94,23 +94,23 @@ class TestKey(unittest2.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
-                            dataset_id=_DATASET)
-        self.assertEqual(key.dataset_id, _DATASET)
+                            project=_DATASET)
+        self.assertEqual(key.project, _DATASET)
         self.assertEqual(key.namespace, _NAMESPACE)
         self.assertEqual(key.kind, _KIND)
         self.assertEqual(key.path, _PATH)
 
     def test_ctor_bad_kind(self):
         self.assertRaises(ValueError, self._makeOne, object(),
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
 
     def test_ctor_bad_id_or_name(self):
         self.assertRaises(ValueError, self._makeOne, 'KIND', object(),
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
         self.assertRaises(ValueError, self._makeOne, 'KIND', None,
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
         self.assertRaises(ValueError, self._makeOne, 'KIND', 10, 'KIND2', None,
-                          dataset_id=self._DEFAULT_DATASET)
+                          project=self._DEFAULT_DATASET)
 
     def test__clone(self):
         _DATASET = 'DATASET-ALT'
@@ -119,9 +119,9 @@ class TestKey(unittest2.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
-                            dataset_id=_DATASET)
+                            project=_DATASET)
         clone = key._clone()
-        self.assertEqual(clone.dataset_id, _DATASET)
+        self.assertEqual(clone.project, _DATASET)
         self.assertEqual(clone.namespace, _NAMESPACE)
         self.assertEqual(clone.kind, _KIND)
         self.assertEqual(clone.path, _PATH)
@@ -136,12 +136,12 @@ class TestKey(unittest2.TestCase):
         _PATH = [{'kind': _KIND1, 'id': _ID1}, {'kind': _KIND2, 'id': _ID2}]
 
         parent = self._makeOne(_KIND1, _ID1, namespace=_NAMESPACE,
-                               dataset_id=_DATASET)
+                               project=_DATASET)
         key = self._makeOne(_KIND2, _ID2, parent=parent)
         self.assertTrue(key.parent is parent)
         clone = key._clone()
         self.assertTrue(clone.parent is key.parent)
-        self.assertEqual(clone.dataset_id, _DATASET)
+        self.assertEqual(clone.project, _DATASET)
         self.assertEqual(clone.namespace, _NAMESPACE)
         self.assertEqual(clone.path, _PATH)
 
@@ -149,15 +149,15 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _NAME = 'one'
-        key = self._makeOne(_KIND, _NAME, dataset_id=_DATASET)
+        key = self._makeOne(_KIND, _NAME, project=_DATASET)
         self.assertFalse(key == object())
         self.assertTrue(key != object())
 
     def test___eq_____ne___two_incomplete_keys_same_kind(self):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
-        key1 = self._makeOne(_KIND, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, project=_DATASET)
+        key2 = self._makeOne(_KIND, project=_DATASET)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -165,8 +165,8 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, project=_DATASET)
+        key2 = self._makeOne(_KIND, _ID, project=_DATASET)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -174,8 +174,8 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
+        key2 = self._makeOne(_KIND, project=_DATASET)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -184,8 +184,8 @@ class TestKey(unittest2.TestCase):
         _KIND = 'KIND'
         _ID1 = 1234
         _ID2 = 2345
-        key1 = self._makeOne(_KIND, _ID1, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _ID2, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, _ID1, project=_DATASET)
+        key2 = self._makeOne(_KIND, _ID2, project=_DATASET)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -193,8 +193,8 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
+        key2 = self._makeOne(_KIND, _ID, project=_DATASET)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
@@ -203,8 +203,8 @@ class TestKey(unittest2.TestCase):
         _DATASET2 = 'DATASET2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, dataset_id=_DATASET1)
-        key2 = self._makeOne(_KIND, _ID, dataset_id=_DATASET2)
+        key1 = self._makeOne(_KIND, _ID, project=_DATASET1)
+        key2 = self._makeOne(_KIND, _ID, project=_DATASET2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -214,9 +214,9 @@ class TestKey(unittest2.TestCase):
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, dataset_id=_DATASET,
+        key1 = self._makeOne(_KIND, _ID, project=_DATASET,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _ID, dataset_id=_DATASET,
+        key2 = self._makeOne(_KIND, _ID, project=_DATASET,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
@@ -226,8 +226,8 @@ class TestKey(unittest2.TestCase):
         _DATASET_W_PFX = 's~DATASET'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _ID, dataset_id=_DATASET_W_PFX)
+        key1 = self._makeOne(_KIND, _ID, project=_DATASET)
+        key2 = self._makeOne(_KIND, _ID, project=_DATASET_W_PFX)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
@@ -236,8 +236,8 @@ class TestKey(unittest2.TestCase):
         _KIND = 'KIND'
         _NAME1 = 'one'
         _NAME2 = 'two'
-        key1 = self._makeOne(_KIND, _NAME1, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME2, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, _NAME1, project=_DATASET)
+        key2 = self._makeOne(_KIND, _NAME2, project=_DATASET)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -245,8 +245,8 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET)
+        key1 = self._makeOne(_KIND, _NAME, project=_DATASET)
+        key2 = self._makeOne(_KIND, _NAME, project=_DATASET)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
@@ -255,8 +255,8 @@ class TestKey(unittest2.TestCase):
         _DATASET2 = 'DATASET2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET1)
-        key2 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET2)
+        key1 = self._makeOne(_KIND, _NAME, project=_DATASET1)
+        key2 = self._makeOne(_KIND, _NAME, project=_DATASET2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -266,9 +266,9 @@ class TestKey(unittest2.TestCase):
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET,
+        key1 = self._makeOne(_KIND, _NAME, project=_DATASET,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET,
+        key2 = self._makeOne(_KIND, _NAME, project=_DATASET,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
@@ -278,15 +278,15 @@ class TestKey(unittest2.TestCase):
         _DATASET_W_PFX = 's~DATASET'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET)
-        key2 = self._makeOne(_KIND, _NAME, dataset_id=_DATASET_W_PFX)
+        key1 = self._makeOne(_KIND, _NAME, project=_DATASET)
+        key2 = self._makeOne(_KIND, _NAME, project=_DATASET_W_PFX)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
     def test___hash___incomplete(self):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, dataset_id=_DATASET)
+        key = self._makeOne(_KIND, project=_DATASET)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_DATASET) + hash(None))
 
@@ -294,7 +294,7 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _ID = 1234
-        key = self._makeOne(_KIND, _ID, dataset_id=_DATASET)
+        key = self._makeOne(_KIND, _ID, project=_DATASET)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_ID) +
                             hash(_DATASET) + hash(None))
@@ -303,13 +303,13 @@ class TestKey(unittest2.TestCase):
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _NAME = 'NAME'
-        key = self._makeOne(_KIND, _NAME, dataset_id=_DATASET)
+        key = self._makeOne(_KIND, _NAME, project=_DATASET)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_NAME) +
                             hash(_DATASET) + hash(None))
 
     def test_completed_key_on_partial_w_id(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         _ID = 1234
         new_key = key.completed_key(_ID)
         self.assertFalse(key is new_key)
@@ -317,7 +317,7 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(new_key.name, None)
 
     def test_completed_key_on_partial_w_name(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         _NAME = 'NAME'
         new_key = key.completed_key(_NAME)
         self.assertFalse(key is new_key)
@@ -325,17 +325,17 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(new_key.name, _NAME)
 
     def test_completed_key_on_partial_w_invalid(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         self.assertRaises(ValueError, key.completed_key, object())
 
     def test_completed_key_on_complete(self):
-        key = self._makeOne('KIND', 1234, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', 1234, project=self._DEFAULT_DATASET)
         self.assertRaises(ValueError, key.completed_key, 5678)
 
     def test_to_protobuf_defaults(self):
         from gcloud.datastore._generated import entity_pb2
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne(_KIND, project=self._DEFAULT_DATASET)
         pb = key.to_protobuf()
         self.assertTrue(isinstance(pb, entity_pb2.Key))
 
@@ -354,14 +354,14 @@ class TestKey(unittest2.TestCase):
 
     def test_to_protobuf_w_explicit_dataset_id(self):
         _DATASET = 'DATASET-ALT'
-        key = self._makeOne('KIND', dataset_id=_DATASET)
+        key = self._makeOne('KIND', project=_DATASET)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.dataset_id, _DATASET)
 
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'
         key = self._makeOne('KIND', namespace=_NAMESPACE,
-                            dataset_id=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_DATASET)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.namespace, _NAMESPACE)
 
@@ -371,7 +371,7 @@ class TestKey(unittest2.TestCase):
         _ID = 1234
         _NAME = 'NAME'
         key = self._makeOne(_PARENT, _NAME, _CHILD, _ID,
-                            dataset_id=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_DATASET)
         pb = key.to_protobuf()
         elems = list(pb.path_element)
         self.assertEqual(len(elems), 2)
@@ -381,7 +381,7 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(elems[1].id, _ID)
 
     def test_to_protobuf_w_no_kind(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         # Force the 'kind' to be unset. Maybe `to_protobuf` should fail
         # on this? The backend certainly will.
         key._path[-1].pop('kind')
@@ -389,44 +389,44 @@ class TestKey(unittest2.TestCase):
         self.assertFalse(pb.path_element[0].HasField('kind'))
 
     def test_is_partial_no_name_or_id(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         self.assertTrue(key.is_partial)
 
     def test_is_partial_w_id(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _ID, project=self._DEFAULT_DATASET)
         self.assertFalse(key.is_partial)
 
     def test_is_partial_w_name(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_DATASET)
         self.assertFalse(key.is_partial)
 
     def test_id_or_name_no_name_or_id(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_no_name_or_id_child(self):
         key = self._makeOne('KIND1', 1234, 'KIND2',
-                            dataset_id=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_DATASET)
         self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_w_id_only(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _ID, project=self._DEFAULT_DATASET)
         self.assertEqual(key.id_or_name, _ID)
 
     def test_id_or_name_w_name_only(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_DATASET)
         self.assertEqual(key.id_or_name, _NAME)
 
     def test_parent_default(self):
-        key = self._makeOne('KIND', dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', project=self._DEFAULT_DATASET)
         self.assertEqual(key.parent, None)
 
     def test_parent_explicit_top_level(self):
-        key = self._makeOne('KIND', 1234, dataset_id=self._DEFAULT_DATASET)
+        key = self._makeOne('KIND', 1234, project=self._DEFAULT_DATASET)
         self.assertEqual(key.parent, None)
 
     def test_parent_explicit_nested(self):
@@ -434,7 +434,7 @@ class TestKey(unittest2.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            dataset_id=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_DATASET)
         self.assertEqual(key.parent.path, _PARENT_PATH)
 
     def test_parent_multiple_calls(self):
@@ -442,18 +442,18 @@ class TestKey(unittest2.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            dataset_id=self._DEFAULT_DATASET)
+                            project=self._DEFAULT_DATASET)
         parent = key.parent
         self.assertEqual(parent.path, _PARENT_PATH)
         new_parent = key.parent
         self.assertTrue(parent is new_parent)
 
 
-class Test__dataset_ids_equal(unittest2.TestCase):
+class Test__projects_equal(unittest2.TestCase):
 
     def _callFUT(self, dataset_id1, dataset_id2):
-        from gcloud.datastore.key import _dataset_ids_equal
-        return _dataset_ids_equal(dataset_id1, dataset_id2)
+        from gcloud.datastore.key import _projects_equal
+        return _projects_equal(dataset_id1, dataset_id2)
 
     def test_identical_prefixed(self):
         self.assertTrue(self._callFUT('s~foo', 's~foo'))

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -383,7 +383,7 @@ class TestIterator(unittest2.TestCase):
         qpb = _pb_from_query(query)
         qpb.offset = 0
         EXPECTED = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -410,7 +410,7 @@ class TestIterator(unittest2.TestCase):
         qpb.limit = 13
         qpb.offset = 29
         EXPECTED = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -444,7 +444,7 @@ class TestIterator(unittest2.TestCase):
         qpb.start_cursor = urlsafe_b64decode(self._START)
         qpb.end_cursor = urlsafe_b64decode(self._END)
         EXPECTED = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -478,7 +478,7 @@ class TestIterator(unittest2.TestCase):
         qpb = _pb_from_query(query)
         qpb.offset = 0
         EXPECTED = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -508,13 +508,13 @@ class TestIterator(unittest2.TestCase):
         qpb2.offset = 0
         qpb2.start_cursor = self._END
         EXPECTED1 = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb1,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
         }
         EXPECTED2 = {
-            'dataset_id': self._PROJECT,
+            'project': self._PROJECT,
             'query_pb': qpb2,
             'namespace': self._NAMESPACE,
             'transaction_id': None,

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -50,7 +50,7 @@ class TestQuery(unittest2.TestCase):
         _KIND = 'KIND'
         _NAMESPACE = 'OTHER_NAMESPACE'
         client = self._makeClient()
-        ancestor = Key('ANCESTOR', 123, dataset_id=_DATASET)
+        ancestor = Key('ANCESTOR', 123, project=_DATASET)
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
@@ -145,7 +145,7 @@ class TestQuery(unittest2.TestCase):
     def test_ancestor_setter_w_key(self):
         from gcloud.datastore.key import Key
         _NAME = u'NAME'
-        key = Key('KIND', 123, dataset_id=self._DATASET)
+        key = Key('KIND', 123, project=self._DATASET)
         query = self._makeOne(self._makeClient())
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
@@ -153,7 +153,7 @@ class TestQuery(unittest2.TestCase):
 
     def test_ancestor_deleter_w_key(self):
         from gcloud.datastore.key import Key
-        key = Key('KIND', 123, dataset_id=self._DATASET)
+        key = Key('KIND', 123, project=self._DATASET)
         query = self._makeOne(client=self._makeClient(), ancestor=key)
         del query.ancestor
         self.assertTrue(query.ancestor is None)
@@ -200,13 +200,13 @@ class TestQuery(unittest2.TestCase):
     def test_add_filter___key__valid_key(self):
         from gcloud.datastore.key import Key
         query = self._makeOne(self._makeClient())
-        key = Key('Foo', dataset_id=self._DATASET)
+        key = Key('Foo', project=self._DATASET)
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
     def test_filter___key__not_equal_operator(self):
         from gcloud.datastore.key import Key
-        key = Key('Foo', dataset_id=self._DATASET)
+        key = Key('Foo', project=self._DATASET)
         query = self._makeOne(self._makeClient())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])
@@ -561,7 +561,7 @@ class Test__pb_from_query(unittest2.TestCase):
         from gcloud.datastore.helpers import _prepare_key_for_request
         from gcloud.datastore._generated import query_pb2
 
-        ancestor = Key('Ancestor', 123, dataset_id='DATASET')
+        ancestor = Key('Ancestor', 123, project='DATASET')
         pb = self._callFUT(_Query(ancestor=ancestor))
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
@@ -591,7 +591,7 @@ class Test__pb_from_query(unittest2.TestCase):
         from gcloud.datastore.helpers import _prepare_key_for_request
         from gcloud.datastore._generated import query_pb2
 
-        key = Key('Kind', 123, dataset_id='DATASET')
+        key = Key('Kind', 123, project='DATASET')
         query = _Query(filters=[('__key__', '=', key)])
         query.OPERATORS = {
             '=': query_pb2.PropertyFilter.EQUAL,

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -17,7 +17,7 @@ import unittest2
 
 class TestQuery(unittest2.TestCase):
 
-    _DATASET = 'DATASET'
+    _PROJECT = 'PROJECT'
 
     def _getTargetClass(self):
         from gcloud.datastore.query import Query
@@ -29,13 +29,13 @@ class TestQuery(unittest2.TestCase):
     def _makeClient(self, connection=None):
         if connection is None:
             connection = _Connection()
-        return _Client(self._DATASET, connection)
+        return _Client(self._PROJECT, connection)
 
     def test_ctor_defaults(self):
         client = self._makeClient()
         query = self._makeOne(client)
         self.assertTrue(query._client is client)
-        self.assertEqual(query.dataset_id, client.dataset_id)
+        self.assertEqual(query.project, client.project)
         self.assertEqual(query.kind, None)
         self.assertEqual(query.namespace, client.namespace)
         self.assertEqual(query.ancestor, None)
@@ -46,11 +46,11 @@ class TestQuery(unittest2.TestCase):
 
     def test_ctor_explicit(self):
         from gcloud.datastore.key import Key
-        _DATASET = 'OTHER_DATASET'
+        _PROJECT = 'OTHER_PROJECT'
         _KIND = 'KIND'
         _NAMESPACE = 'OTHER_NAMESPACE'
         client = self._makeClient()
-        ancestor = Key('ANCESTOR', 123, project=_DATASET)
+        ancestor = Key('ANCESTOR', 123, project=_PROJECT)
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
@@ -58,7 +58,7 @@ class TestQuery(unittest2.TestCase):
         query = self._makeOne(
             client,
             kind=_KIND,
-            dataset_id=_DATASET,
+            project=_PROJECT,
             namespace=_NAMESPACE,
             ancestor=ancestor,
             filters=FILTERS,
@@ -67,7 +67,7 @@ class TestQuery(unittest2.TestCase):
             group_by=GROUP_BY,
             )
         self.assertTrue(query._client is client)
-        self.assertEqual(query.dataset_id, _DATASET)
+        self.assertEqual(query.project, _PROJECT)
         self.assertEqual(query.kind, _KIND)
         self.assertEqual(query.namespace, _NAMESPACE)
         self.assertEqual(query.ancestor.path, ancestor.path)
@@ -130,7 +130,7 @@ class TestQuery(unittest2.TestCase):
         query = self._makeOne(self._makeClient(), kind=_KIND_BEFORE)
         self.assertEqual(query.kind, _KIND_BEFORE)
         query.kind = _KIND_AFTER
-        self.assertEqual(query.dataset_id, self._DATASET)
+        self.assertEqual(query.project, self._PROJECT)
         self.assertEqual(query.kind, _KIND_AFTER)
 
     def test_ancestor_setter_w_non_key(self):
@@ -145,7 +145,7 @@ class TestQuery(unittest2.TestCase):
     def test_ancestor_setter_w_key(self):
         from gcloud.datastore.key import Key
         _NAME = u'NAME'
-        key = Key('KIND', 123, project=self._DATASET)
+        key = Key('KIND', 123, project=self._PROJECT)
         query = self._makeOne(self._makeClient())
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
@@ -153,7 +153,7 @@ class TestQuery(unittest2.TestCase):
 
     def test_ancestor_deleter_w_key(self):
         from gcloud.datastore.key import Key
-        key = Key('KIND', 123, project=self._DATASET)
+        key = Key('KIND', 123, project=self._PROJECT)
         query = self._makeOne(client=self._makeClient(), ancestor=key)
         del query.ancestor
         self.assertTrue(query.ancestor is None)
@@ -200,13 +200,13 @@ class TestQuery(unittest2.TestCase):
     def test_add_filter___key__valid_key(self):
         from gcloud.datastore.key import Key
         query = self._makeOne(self._makeClient())
-        key = Key('Foo', project=self._DATASET)
+        key = Key('Foo', project=self._PROJECT)
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
 
     def test_filter___key__not_equal_operator(self):
         from gcloud.datastore.key import Key
-        key = Key('Foo', project=self._DATASET)
+        key = Key('Foo', project=self._PROJECT)
         query = self._makeOne(self._makeClient())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])
@@ -311,7 +311,7 @@ class TestQuery(unittest2.TestCase):
 
 
 class TestIterator(unittest2.TestCase):
-    _DATASET = 'DATASET'
+    _PROJECT = 'PROJECT'
     _NAMESPACE = 'NAMESPACE'
     _KIND = 'KIND'
     _ID = 123
@@ -334,7 +334,7 @@ class TestIterator(unittest2.TestCase):
         NO_MORE = query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT
         _ID = 123
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = self._DATASET
+        entity_pb.key.partition_id.dataset_id = self._PROJECT
         path_element = entity_pb.key.path_element.add()
         path_element.kind = self._KIND
         path_element.id = _ID
@@ -346,7 +346,7 @@ class TestIterator(unittest2.TestCase):
     def _makeClient(self, connection=None):
         if connection is None:
             connection = _Connection()
-        return _Client(self._DATASET, connection)
+        return _Client(self._PROJECT, connection)
 
     def test_ctor_defaults(self):
         connection = _Connection()
@@ -368,7 +368,7 @@ class TestIterator(unittest2.TestCase):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection, cursor=b'')
         iterator = self._makeOne(query, client)
         entities, more_results, cursor = iterator.next_page()
@@ -383,7 +383,7 @@ class TestIterator(unittest2.TestCase):
         qpb = _pb_from_query(query)
         qpb.offset = 0
         EXPECTED = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -394,7 +394,7 @@ class TestIterator(unittest2.TestCase):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection, cursor=b'')
         iterator = self._makeOne(query, client, 13, 29)
         entities, more_results, cursor = iterator.next_page()
@@ -410,7 +410,7 @@ class TestIterator(unittest2.TestCase):
         qpb.limit = 13
         qpb.offset = 29
         EXPECTED = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -423,7 +423,7 @@ class TestIterator(unittest2.TestCase):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
         iterator = self._makeOne(query, client)
         iterator._start_cursor = self._START
@@ -444,7 +444,7 @@ class TestIterator(unittest2.TestCase):
         qpb.start_cursor = urlsafe_b64decode(self._START)
         qpb.end_cursor = urlsafe_b64decode(self._END)
         EXPECTED = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -454,7 +454,7 @@ class TestIterator(unittest2.TestCase):
     def test_next_page_w_cursors_w_bogus_more(self):
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
         epb, cursor, _ = connection._results.pop()
         connection._results.append((epb, cursor, 4))  # invalid enum
@@ -465,7 +465,7 @@ class TestIterator(unittest2.TestCase):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection)
         iterator = self._makeOne(query, client)
         entities = list(iterator)
@@ -478,7 +478,7 @@ class TestIterator(unittest2.TestCase):
         qpb = _pb_from_query(query)
         qpb.offset = 0
         EXPECTED = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -489,7 +489,7 @@ class TestIterator(unittest2.TestCase):
         from gcloud.datastore.query import _pb_from_query
         connection = _Connection()
         client = self._makeClient(connection)
-        query = _Query(client, self._KIND, self._DATASET, self._NAMESPACE)
+        query = _Query(client, self._KIND, self._PROJECT, self._NAMESPACE)
         self._addQueryResults(connection, cursor=self._END, more=True)
         self._addQueryResults(connection)
         iterator = self._makeOne(query, client)
@@ -508,13 +508,13 @@ class TestIterator(unittest2.TestCase):
         qpb2.offset = 0
         qpb2.start_cursor = self._END
         EXPECTED1 = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb1,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
         }
         EXPECTED2 = {
-            'dataset_id': self._DATASET,
+            'dataset_id': self._PROJECT,
             'query_pb': qpb2,
             'namespace': self._NAMESPACE,
             'transaction_id': None,
@@ -561,7 +561,7 @@ class Test__pb_from_query(unittest2.TestCase):
         from gcloud.datastore.helpers import _prepare_key_for_request
         from gcloud.datastore._generated import query_pb2
 
-        ancestor = Key('Ancestor', 123, project='DATASET')
+        ancestor = Key('Ancestor', 123, project='PROJECT')
         pb = self._callFUT(_Query(ancestor=ancestor))
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
@@ -591,7 +591,7 @@ class Test__pb_from_query(unittest2.TestCase):
         from gcloud.datastore.helpers import _prepare_key_for_request
         from gcloud.datastore._generated import query_pb2
 
-        key = Key('Kind', 123, project='DATASET')
+        key = Key('Kind', 123, project='PROJECT')
         query = _Query(filters=[('__key__', '=', key)])
         query.OPERATORS = {
             '=': query_pb2.PropertyFilter.EQUAL,
@@ -627,7 +627,7 @@ class _Query(object):
     def __init__(self,
                  client=object(),
                  kind=None,
-                 dataset_id=None,
+                 project=None,
                  namespace=None,
                  ancestor=None,
                  filters=(),
@@ -636,7 +636,7 @@ class _Query(object):
                  group_by=()):
         self._client = client
         self.kind = kind
-        self.dataset_id = dataset_id
+        self.project = project
         self.namespace = namespace
         self.ancestor = ancestor
         self.filters = filters
@@ -663,8 +663,8 @@ class _Connection(object):
 
 class _Client(object):
 
-    def __init__(self, dataset_id, connection, namespace=None):
-        self.dataset_id = dataset_id
+    def __init__(self, project, connection, namespace=None):
+        self.project = project
         self.connection = connection
         self.namespace = namespace
 

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -199,7 +199,7 @@ class _Entity(dict):
     def __init__(self):
         super(_Entity, self).__init__()
         from gcloud.datastore.key import Key
-        self.key = Key('KIND', dataset_id='DATASET')
+        self.key = Key('KIND', project='DATASET')
 
 
 class _Client(object):

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -27,11 +27,11 @@ class TestTransaction(unittest2.TestCase):
     def test_ctor_defaults(self):
         from gcloud.datastore._generated import datastore_pb2
 
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
-        self.assertEqual(xact.project, _DATASET)
+        self.assertEqual(xact.project, _PROJECT)
         self.assertEqual(xact.connection, connection)
         self.assertEqual(xact.id, None)
         self.assertEqual(xact._status, self._getTargetClass()._INITIAL)
@@ -40,9 +40,9 @@ class TestTransaction(unittest2.TestCase):
 
     def test_current(self):
         from gcloud.datastore.test_client import _NoCommitBatch
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection()
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact1 = self._makeOne(client)
         xact2 = self._makeOne(client)
         self.assertTrue(xact1.current() is None)
@@ -65,22 +65,22 @@ class TestTransaction(unittest2.TestCase):
         self.assertTrue(xact2.current() is None)
 
     def test_begin(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
-        self.assertEqual(connection._begun, _DATASET)
+        self.assertEqual(connection._begun, _PROJECT)
 
     def test_begin_tombstoned(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
-        self.assertEqual(connection._begun, _DATASET)
+        self.assertEqual(connection._begun, _PROJECT)
 
         xact.rollback()
         self.assertEqual(xact.id, None)
@@ -88,34 +88,34 @@ class TestTransaction(unittest2.TestCase):
         self.assertRaises(ValueError, xact.begin)
 
     def test_rollback(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact.begin()
         xact.rollback()
         self.assertEqual(xact.id, None)
-        self.assertEqual(connection._rolled_back, (_DATASET, 234))
+        self.assertEqual(connection._rolled_back, (_PROJECT, 234))
 
     def test_commit_no_partial_keys(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact._commit_request = commit_request = object()
         xact.begin()
         xact.commit()
         self.assertEqual(connection._committed,
-                         (_DATASET, commit_request, 234))
+                         (_PROJECT, commit_request, 234))
         self.assertEqual(xact.id, None)
 
     def test_commit_w_partial_keys(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 123
         connection = _Connection(234)
-        connection._completed_keys = [_make_key(_KIND, _ID, _DATASET)]
-        client = _Client(_DATASET, connection)
+        connection._completed_keys = [_make_key(_KIND, _ID, _PROJECT)]
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         entity = _Entity()
         xact.put(entity)
@@ -123,21 +123,21 @@ class TestTransaction(unittest2.TestCase):
         xact.begin()
         xact.commit()
         self.assertEqual(connection._committed,
-                         (_DATASET, commit_request, 234))
+                         (_PROJECT, commit_request, 234))
         self.assertEqual(xact.id, None)
         self.assertEqual(entity.key.path, [{'kind': _KIND, 'id': _ID}])
 
     def test_context_manager_no_raise(self):
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact._commit_request = commit_request = object()
         with xact:
             self.assertEqual(xact.id, 234)
-            self.assertEqual(connection._begun, _DATASET)
+            self.assertEqual(connection._begun, _PROJECT)
         self.assertEqual(connection._committed,
-                         (_DATASET, commit_request, 234))
+                         (_PROJECT, commit_request, 234))
         self.assertEqual(xact.id, None)
 
     def test_context_manager_w_raise(self):
@@ -145,31 +145,31 @@ class TestTransaction(unittest2.TestCase):
         class Foo(Exception):
             pass
 
-        _DATASET = 'DATASET'
+        _PROJECT = 'PROJECT'
         connection = _Connection(234)
-        client = _Client(_DATASET, connection)
+        client = _Client(_PROJECT, connection)
         xact = self._makeOne(client)
         xact._mutation = object()
         try:
             with xact:
                 self.assertEqual(xact.id, 234)
-                self.assertEqual(connection._begun, _DATASET)
+                self.assertEqual(connection._begun, _PROJECT)
                 raise Foo()
         except Foo:
             self.assertEqual(xact.id, None)
-            self.assertEqual(connection._rolled_back, (_DATASET, 234))
+            self.assertEqual(connection._rolled_back, (_PROJECT, 234))
         self.assertEqual(connection._committed, None)
         self.assertEqual(xact.id, None)
 
 
-def _make_key(kind, id, dataset_id):
+def _make_key(kind, id_, project):
     from gcloud.datastore._generated import entity_pb2
 
     key = entity_pb2.Key()
-    key.partition_id.dataset_id = dataset_id
+    key.partition_id.dataset_id = project
     elem = key.path_element.add()
     elem.kind = kind
-    elem.id = id
+    elem.id = id_
     return key
 
 
@@ -182,15 +182,15 @@ class _Connection(object):
         self._completed_keys = []
         self._index_updates = 0
 
-    def begin_transaction(self, dataset_id):
-        self._begun = dataset_id
+    def begin_transaction(self, project):
+        self._begun = project
         return self._xact_id
 
-    def rollback(self, dataset_id, transaction_id):
-        self._rolled_back = dataset_id, transaction_id
+    def rollback(self, project, transaction_id):
+        self._rolled_back = project, transaction_id
 
-    def commit(self, dataset_id, commit_request, transaction_id):
-        self._committed = (dataset_id, commit_request, transaction_id)
+    def commit(self, project, commit_request, transaction_id):
+        self._committed = (project, commit_request, transaction_id)
         return self._index_updates, self._completed_keys
 
 
@@ -199,7 +199,7 @@ class _Entity(dict):
     def __init__(self):
         super(_Entity, self).__init__()
         from gcloud.datastore.key import Key
-        self.key = Key('KIND', project='DATASET')
+        self.key = Key('KIND', project='PROJECT')
 
 
 class _Client(object):

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -31,7 +31,7 @@ class TestTransaction(unittest2.TestCase):
         connection = _Connection()
         client = _Client(_DATASET, connection)
         xact = self._makeOne(client)
-        self.assertEqual(xact.dataset_id, _DATASET)
+        self.assertEqual(xact.project, _DATASET)
         self.assertEqual(xact.connection, connection)
         self.assertEqual(xact.id, None)
         self.assertEqual(xact._status, self._getTargetClass()._INITIAL)

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -204,8 +204,8 @@ class _Entity(dict):
 
 class _Client(object):
 
-    def __init__(self, dataset_id, connection, namespace=None):
-        self.dataset_id = dataset_id
+    def __init__(self, project, connection, namespace=None):
+        self.project = project
         self.connection = connection
         self.namespace = namespace
         self._batches = []

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -142,7 +142,7 @@ class Transaction(Batch):
         if self._status != self._INITIAL:
             raise ValueError('Transaction already started previously.')
         self._status = self._IN_PROGRESS
-        self._id = self.connection.begin_transaction(self.dataset_id)
+        self._id = self.connection.begin_transaction(self.project)
 
     def rollback(self):
         """Rolls back the current transaction.
@@ -153,7 +153,7 @@ class Transaction(Batch):
         - Sets the current transaction's ID to None.
         """
         try:
-            self.connection.rollback(self.dataset_id, self._id)
+            self.connection.rollback(self.project, self._id)
         finally:
             self._status = self._ABORTED
             # Clear our own ID in case this gets accidentally reused.

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -361,7 +361,7 @@ class TestDatastoreTransaction(TestDatastore):
     def test_failure_with_contention(self):
         contention_key = 'baz'
         # Fool the Client constructor to avoid creating a new connection.
-        local_client = datastore.Client(dataset_id=Config.CLIENT.project,
+        local_client = datastore.Client(project=Config.CLIENT.project,
                                         http=object())
         local_client.connection = Config.CLIENT.connection
 

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -361,7 +361,7 @@ class TestDatastoreTransaction(TestDatastore):
     def test_failure_with_contention(self):
         contention_key = 'baz'
         # Fool the Client constructor to avoid creating a new connection.
-        local_client = datastore.Client(dataset_id=Config.CLIENT.dataset_id,
+        local_client = datastore.Client(dataset_id=Config.CLIENT.project,
                                         http=object())
         local_client.connection = Config.CLIENT.connection
 


### PR DESCRIPTION
This is done in advance of `v1beta3` where `PartitionId.dataset_id` becomes `PartitionId.project_id`.

@tseaver This is part of the plan in #1288. It's a bit of a mouthful, maybe you have some suggestions on how to make it easier to review? (I'm happy to make the necessary changes)

Also note that I haven't changed the use of `GCLOUD_TESTS_DATASET_ID` and similar for finding the default project. IMO that should come in a separate PR. I feel that that separate PR will be complicated enough without throwing in **ALL** these renames. (I also realized that we only check the env. var. for the project with every other service, though we could check the App Engine ID or the Compute Engine ID as well.)