### PR TITLE
Fixing broken links in Pub/Sub docs.

### DIFF
--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -48,7 +48,7 @@ class Client(JSONClient):
         """List topics for the project associated with this client.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/list
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
@@ -85,10 +85,10 @@ class Client(JSONClient):
         """List subscriptions for the project associated with this client.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/list
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
 
         and (where ``topic_name`` is passed):
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/subscriptions/list
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,

--- a/gcloud/pubsub/message.py
+++ b/gcloud/pubsub/message.py
@@ -25,7 +25,7 @@ class Message(object):
     """Messages can be published to a topic and received by subscribers.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/google/pubsub/v1beta2/PubsubMessage
+    https://cloud.google.com/pubsub/reference/rest/v1/PubsubMessage
 
     :type data: bytes
     :param data: the payload of the message

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -23,7 +23,7 @@ class Subscription(object):
     """Subscriptions receive messages published to their topics.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions
+    https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions
 
     :type name: string
     :param name: the name of the subscription
@@ -103,7 +103,7 @@ class Subscription(object):
         """API call:  create the subscription via a PUT request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/create
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -124,7 +124,7 @@ class Subscription(object):
         """API call:  test existence of the subscription via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/get
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -142,7 +142,7 @@ class Subscription(object):
         """API call:  sync local subscription configuration via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/get
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -158,7 +158,7 @@ class Subscription(object):
         """API call:  update the push endpoint for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type push_endpoint: string
         :param push_endpoint: URL to which messages will be pushed by the
@@ -183,7 +183,7 @@ class Subscription(object):
         """API call:  retrieve messages for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/pull
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
 
         :type return_immediately: boolean
         :param return_immediately: if True, the back-end returns even if no
@@ -215,7 +215,7 @@ class Subscription(object):
         """API call:  acknowledge retrieved messages for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/acknowledge
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged
@@ -233,7 +233,7 @@ class Subscription(object):
         """API call:  update acknowledgement deadline for a retrieved message.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/acknowledge
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
 
         :type ack_id: string
         :param ack_id: ack ID of message being updated
@@ -255,7 +255,7 @@ class Subscription(object):
         """API call:  delete the subscription via a DELETE request.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/subscriptions/delete
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -29,7 +29,7 @@ class Topic(object):
     Subscribers then receive those messages.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics
+    https://cloud.google.com/pubsub/reference/rest/v1/projects.topics
 
     :type name: string
     :param name: the name of the topic
@@ -119,7 +119,7 @@ class Topic(object):
         """API call:  create the topic via a PUT request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/create
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -132,7 +132,7 @@ class Topic(object):
         """API call:  test for the existence of the topic via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/get
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -161,7 +161,7 @@ class Topic(object):
         """API call:  publish a message to a topic via a POST request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/publish
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
 
         :type message: bytes
         :param message: the message payload
@@ -203,7 +203,7 @@ class Topic(object):
         """API call:  delete the topic via a DELETE request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1beta2/projects/topics/delete
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the


### PR DESCRIPTION
These links were valid in v1beta2 but when the upgrade to
v1 occurred they started to give 404s. Fixes #1211.

Replaced mostly with

```
git grep -l v1beta2 -- gcloud/pubsub | xargs sed -i s/v1beta2/v1/g
git grep -l 'v1/projects/' -- gcloud/pubsub | \
    xargs sed -i 's/v1\/projects\//v1\/projects\./g'
```

but manually replaced

```
/pubsub/reference/rest/v1beta2/projects/topics/subscriptions/list
   -> /pubsub/reference/rest/v1/projects.topics.subscriptions/list

/pubsub/reference/rest/google/pubsub/v1beta2/PubsubMessage
   -> /pubsub/reference/rest/v1/PubsubMessage
```

after the fact.