### PR TITLE
Removing uses of non-public attributes in system tests.

### DIFF
--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -117,7 +117,6 @@ class TestBigQuery(unittest2.TestCase):
         self.to_delete.insert(0, table)
         self.assertTrue(table.exists())
         self.assertEqual(table.name, TABLE_NAME)
-        self.assertTrue(table._dataset is dataset)
 
     def test_list_tables(self):
         dataset = CLIENT.dataset(DATASET_NAME)
@@ -141,8 +140,8 @@ class TestBigQuery(unittest2.TestCase):
         all_tables, token = dataset.list_tables()
         self.assertTrue(token is None)
         created = [table for table in all_tables
-                   if table.name in tables_to_create and
-                   table._dataset.name == DATASET_NAME]
+                   if (table.name in tables_to_create and
+                       table.dataset_name == DATASET_NAME)]
         self.assertEqual(len(created), len(tables_to_create))
 
     def test_patch_table(self):

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -118,7 +118,6 @@ class TestStorageWriteFiles(TestStorageFiles):
 
     def test_large_file_write_from_stream(self):
         blob = self.bucket.blob('LargeFile')
-        self.assertEqual(blob._properties, {})
 
         file_data = self.FILES['big']
         with open(file_data['path'], 'rb') as file_obj:
@@ -132,7 +131,6 @@ class TestStorageWriteFiles(TestStorageFiles):
 
     def test_small_file_write_from_filename(self):
         blob = self.bucket.blob('SmallFile')
-        self.assertEqual(blob._properties, {})
 
         file_data = self.FILES['simple']
         blob.upload_from_filename(file_data['path'])


### PR DESCRIPTION
Three of the four uses were fully removed: these simply checked how factories created owned objects. The fourth just used a public property to access the same value. Fixes #1059.