### PR TITLE
Swapping PyCrypto for pyOpenSSL.

### DIFF
--- a/gcloud/_testing.py
+++ b/gcloud/_testing.py
@@ -20,6 +20,8 @@ class _Monkey(object):
 
     def __init__(self, module, **kw):
         self.module = module
+        if len(kw) == 0:  # pragma: NO COVER
+            raise ValueError('_Monkey was used with nothing to monkey-patch')
         self.to_restore = dict([(key, getattr(module, key)) for key in kw])
         for key, value in kw.items():
             setattr(module, key, value)

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -18,8 +18,7 @@ These are *not* part of the API.
 """
 
 import base64
-
-from Crypto.Hash import MD5
+from hashlib import md5
 
 
 class _PropertyMixin(object):
@@ -168,7 +167,7 @@ def _base64_md5hash(buffer_object):
     :param buffer_object: Buffer containing bytes used to compute an MD5
                           hash (as base64).
     """
-    hash_obj = MD5.new()
+    hash_obj = md5()
     _write_buffer_to_hash(buffer_object, hash_obj)
     digest_bytes = hash_obj.digest()
     return base64.b64encode(digest_bytes)

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -158,13 +158,13 @@ class Test__base64_md5hash(unittest2.TestCase):
         BUFFER = _Buffer([b'', BYTES_TO_SIGN])
         MD5 = _MD5(DIGEST_VAL)
 
-        with _Monkey(MUT, base64=BASE64, MD5=MD5):
+        with _Monkey(MUT, base64=BASE64, md5=MD5):
             SIGNED_CONTENT = self._callFUT(BUFFER)
 
         self.assertEqual(BUFFER._block_sizes, [8192, 8192])
         self.assertTrue(SIGNED_CONTENT is DIGEST_VAL)
         self.assertEqual(BASE64._called_b64encode, [DIGEST_VAL])
-        self.assertEqual(MD5._new_called, [None])
+        self.assertEqual(MD5._called, [None])
         self.assertEqual(MD5.hash_obj.num_digest_calls, 1)
         self.assertEqual(MD5.hash_obj._blocks, [BYTES_TO_SIGN])
 
@@ -200,10 +200,10 @@ class _MD5(object):
 
     def __init__(self, digest_val):
         self.hash_obj = _MD5Hash(digest_val)
-        self._new_called = []
+        self._called = []
 
-    def new(self, data=None):
-        self._new_called.append(data)
+    def __call__(self, data=None):
+        self._called.append(data)
         return self.hash_obj
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'oauth2client >= 1.4.6',
     'protobuf == 3.0.0a3',
-    'pycrypto',
+    'pyOpenSSL',
     'six',
 ]
 


### PR DESCRIPTION
This was done because `PyCrypto` does not install easily on Windows. `pyOpenSSL` is managed by PyCA (the Python crypto authority) and has a mature release process.

This change was influenced by discussions about #1009.