### PR TITLE
Adding helpers for interacting with properties in Entity protobuf.

### DIFF
--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -94,6 +94,8 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(batch._partial_key_entities, [entity])
 
     def test_put_entity_w_completed_key(self):
+        from gcloud.datastore.helpers import _property_tuples
+
         _DATASET = 'DATASET'
         _PROPERTIES = {
             'foo': 'bar',
@@ -112,17 +114,20 @@ class TestBatch(unittest2.TestCase):
 
         mutated_entity = _mutated_pb(self, batch.mutations, 'upsert')
         self.assertEqual(mutated_entity.key, key._key)
-        props = dict([(prop.name, prop.value)
-                      for prop in mutated_entity.property])
-        self.assertTrue(props['foo'].indexed)
-        self.assertFalse(props['baz'].indexed)
-        self.assertTrue(props['spam'].indexed)
-        self.assertFalse(props['spam'].list_value[0].indexed)
-        self.assertFalse(props['spam'].list_value[1].indexed)
-        self.assertFalse(props['spam'].list_value[2].indexed)
-        self.assertFalse('frotz' in props)
+
+        prop_dict = dict(_property_tuples(mutated_entity))
+        self.assertEqual(len(prop_dict), 3)
+        self.assertTrue(prop_dict['foo'].indexed)
+        self.assertFalse(prop_dict['baz'].indexed)
+        self.assertTrue(prop_dict['spam'].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[0].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[1].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[2].indexed)
+        self.assertFalse('frotz' in prop_dict)
 
     def test_put_entity_w_completed_key_prefixed_dataset_id(self):
+        from gcloud.datastore.helpers import _property_tuples
+
         _DATASET = 'DATASET'
         _PROPERTIES = {
             'foo': 'bar',
@@ -141,15 +146,16 @@ class TestBatch(unittest2.TestCase):
 
         mutated_entity = _mutated_pb(self, batch.mutations, 'upsert')
         self.assertEqual(mutated_entity.key, key._key)
-        props = dict([(prop.name, prop.value)
-                      for prop in mutated_entity.property])
-        self.assertTrue(props['foo'].indexed)
-        self.assertFalse(props['baz'].indexed)
-        self.assertTrue(props['spam'].indexed)
-        self.assertFalse(props['spam'].list_value[0].indexed)
-        self.assertFalse(props['spam'].list_value[1].indexed)
-        self.assertFalse(props['spam'].list_value[2].indexed)
-        self.assertFalse('frotz' in props)
+
+        prop_dict = dict(_property_tuples(mutated_entity))
+        self.assertEqual(len(prop_dict), 3)
+        self.assertTrue(prop_dict['foo'].indexed)
+        self.assertFalse(prop_dict['baz'].indexed)
+        self.assertTrue(prop_dict['spam'].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[0].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[1].indexed)
+        self.assertFalse(prop_dict['spam'].list_value[2].indexed)
+        self.assertFalse('frotz' in prop_dict)
 
     def test_delete_w_partial_key(self):
         _DATASET = 'DATASET'

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -670,6 +670,7 @@ class TestConnection(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore._generated import datastore_pb2
         from gcloud.datastore import connection as MUT
+        from gcloud.datastore.helpers import _new_value_pb
 
         DATASET_ID = 'DATASET'
         key_pb = self._make_key_pb(DATASET_ID)
@@ -677,9 +678,8 @@ class TestConnection(unittest2.TestCase):
         mutation = datastore_pb2.Mutation()
         insert = mutation.upsert.add()
         insert.key.CopyFrom(key_pb)
-        prop = insert.property.add()
-        prop.name = 'foo'
-        prop.value.string_value = u'Foo'
+        value_pb = _new_value_pb(insert, 'foo')
+        value_pb.string_value = u'Foo'
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
@@ -717,6 +717,7 @@ class TestConnection(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.datastore._generated import datastore_pb2
         from gcloud.datastore import connection as MUT
+        from gcloud.datastore.helpers import _new_value_pb
 
         DATASET_ID = 'DATASET'
         key_pb = self._make_key_pb(DATASET_ID)
@@ -724,9 +725,8 @@ class TestConnection(unittest2.TestCase):
         mutation = datastore_pb2.Mutation()
         insert = mutation.upsert.add()
         insert.key.CopyFrom(key_pb)
-        prop = insert.property.add()
-        prop.name = 'foo'
-        prop.value.string_value = u'Foo'
+        value_pb = _new_value_pb(insert, 'foo')
+        value_pb.string_value = u'Foo'
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -328,6 +328,7 @@ class TestIterator(unittest2.TestCase):
     def _addQueryResults(self, connection, cursor=_END, more=False):
         from gcloud.datastore._generated import entity_pb2
         from gcloud.datastore._generated import query_pb2
+        from gcloud.datastore.helpers import _new_value_pb
 
         MORE = query_pb2.QueryResultBatch.NOT_FINISHED
         NO_MORE = query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT
@@ -337,9 +338,8 @@ class TestIterator(unittest2.TestCase):
         path_element = entity_pb.key.path_element.add()
         path_element.kind = self._KIND
         path_element.id = _ID
-        prop = entity_pb.property.add()
-        prop.name = 'foo'
-        prop.value.string_value = u'Foo'
+        value_pb = _new_value_pb(entity_pb, 'foo')
+        value_pb.string_value = u'Foo'
         connection._results.append(
             ([entity_pb], cursor, MORE if more else NO_MORE))
 


### PR DESCRIPTION
This is because the repeated `property` message field in `Entity` becomes a `properties` map field in `v1beta3`. This makes adding new properties and iterating through all properties very different, so we add a helper to ease the transition from `v1beta2` to `v1beta3`.