### PR TITLE
Using protobuf CommitRequest in datastore Connection.commit.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -293,16 +293,16 @@ class Connection(connection.Connection):
                              _datastore_pb2.BeginTransactionResponse)
         return response.transaction
 
-    def commit(self, dataset_id, mutation_pb, transaction_id):
-        """Commit dataset mutations in context of current transation (if any).
+    def commit(self, dataset_id, commit_request, transaction_id):
+        """Commit mutations in context of current transation (if any).
 
         Maps the ``DatastoreService.Commit`` protobuf RPC.
 
         :type dataset_id: string
         :param dataset_id: The ID dataset to which the transaction applies.
 
-        :type mutation_pb: :class:`._generated.datastore_pb2.Mutation`
-        :param mutation_pb: The protobuf for the mutations being saved.
+        :type commit_request: :class:`._generated.datastore_pb2.CommitRequest`
+        :param commit_request: The protobuf with the mutations being committed.
 
         :type transaction_id: string or None
         :param transaction_id: The transaction ID returned from
@@ -315,6 +315,7 @@ class Connection(connection.Connection):
                    that was completed in the commit.
         """
         request = _datastore_pb2.CommitRequest()
+        request.CopyFrom(commit_request)
 
         if transaction_id:
             request.mode = _datastore_pb2.CommitRequest.TRANSACTIONAL
@@ -322,7 +323,6 @@ class Connection(connection.Connection):
         else:
             request.mode = _datastore_pb2.CommitRequest.NON_TRANSACTIONAL
 
-        request.mutation.CopyFrom(mutation_pb)
         response = self._rpc(dataset_id, 'commit', request,
                              _datastore_pb2.CommitResponse)
         return _parse_commit_response(response)

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -209,7 +209,7 @@ class TestBatch(unittest2.TestCase):
         batch.commit()
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch.mutations, None)])
+                         [(_DATASET, batch._commit_request, None)])
 
     def test_commit_w_partial_key_entities(self):
         _DATASET = 'DATASET'
@@ -225,7 +225,7 @@ class TestBatch(unittest2.TestCase):
         batch.commit()
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch.mutations, None)])
+                         [(_DATASET, batch._commit_request, None)])
         self.assertFalse(entity.key.is_partial)
         self.assertEqual(entity.key._id, _NEW_ID)
 
@@ -248,7 +248,7 @@ class TestBatch(unittest2.TestCase):
         mutated_entity = _mutated_pb(self, batch.mutations, 'upsert')
         self.assertEqual(mutated_entity.key, key._key)
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch.mutations, None)])
+                         [(_DATASET, batch._commit_request, None)])
 
     def test_as_context_mgr_nested(self):
         _DATASET = 'DATASET'
@@ -280,8 +280,8 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(mutated_entity2.key, key2._key)
 
         self.assertEqual(connection._committed,
-                         [(_DATASET, batch2.mutations, None),
-                          (_DATASET, batch1.mutations, None)])
+                         [(_DATASET, batch2._commit_request, None),
+                          (_DATASET, batch1._commit_request, None)])
 
     def test_as_context_mgr_w_error(self):
         _DATASET = 'DATASET'
@@ -329,8 +329,8 @@ class _Connection(object):
         self._committed = []
         self._index_updates = 0
 
-    def commit(self, dataset_id, mutation, transaction_id):
-        self._committed.append((dataset_id, mutation, transaction_id))
+    def commit(self, dataset_id, commit_request, transaction_id):
+        self._committed.append((dataset_id, commit_request, transaction_id))
         return self._index_updates, self._completed_keys
 
 

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -625,9 +625,10 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(result is None)
 
         self.assertEqual(len(client.connection._commit_cw), 1)
-        dataset_id, mutation, transaction_id = client.connection._commit_cw[0]
+        (dataset_id,
+         commit_req, transaction_id) = client.connection._commit_cw[0]
         self.assertEqual(dataset_id, self.DATASET_ID)
-        inserts = list(mutation.insert_auto_id)
+        inserts = list(commit_req.mutation.insert_auto_id)
         self.assertEqual(len(inserts), 1)
         self.assertEqual(inserts[0].key, key.to_protobuf())
 
@@ -697,9 +698,10 @@ class TestClient(unittest2.TestCase):
         result = client.delete_multi([key])
         self.assertEqual(result, None)
         self.assertEqual(len(client.connection._commit_cw), 1)
-        dataset_id, mutation, transaction_id = client.connection._commit_cw[0]
+        (dataset_id,
+         commit_req, transaction_id) = client.connection._commit_cw[0]
         self.assertEqual(dataset_id, self.DATASET_ID)
-        self.assertEqual(list(mutation.delete), [key.to_protobuf()])
+        self.assertEqual(list(commit_req.mutation.delete), [key.to_protobuf()])
         self.assertTrue(transaction_id is None)
 
     def test_delete_multi_w_existing_batch(self):
@@ -1012,8 +1014,8 @@ class _MockConnection(object):
         results, missing, deferred = triple
         return results, missing, deferred
 
-    def commit(self, dataset_id, mutation, transaction_id):
-        self._commit_cw.append((dataset_id, mutation, transaction_id))
+    def commit(self, dataset_id, commit_request, transaction_id):
+        self._commit_cw.append((dataset_id, commit_request, transaction_id))
         response, self._commit = self._commit[0], self._commit[1:]
         return self._index_updates, response
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -675,7 +675,8 @@ class TestConnection(unittest2.TestCase):
         DATASET_ID = 'DATASET'
         key_pb = self._make_key_pb(DATASET_ID)
         rsp_pb = datastore_pb2.CommitResponse()
-        mutation = datastore_pb2.Mutation()
+        req_pb = datastore_pb2.CommitRequest()
+        mutation = req_pb.mutation
         insert = mutation.upsert.add()
         insert.key.CopyFrom(key_pb)
         value_pb = _new_value_pb(insert, 'foo')
@@ -700,7 +701,7 @@ class TestConnection(unittest2.TestCase):
             return expected_result
 
         with _Monkey(MUT, _parse_commit_response=mock_parse):
-            result = conn.commit(DATASET_ID, mutation, None)
+            result = conn.commit(DATASET_ID, req_pb, None)
 
         self.assertTrue(result is expected_result)
         cw = http._called_with
@@ -722,7 +723,8 @@ class TestConnection(unittest2.TestCase):
         DATASET_ID = 'DATASET'
         key_pb = self._make_key_pb(DATASET_ID)
         rsp_pb = datastore_pb2.CommitResponse()
-        mutation = datastore_pb2.Mutation()
+        req_pb = datastore_pb2.CommitRequest()
+        mutation = req_pb.mutation
         insert = mutation.upsert.add()
         insert.key.CopyFrom(key_pb)
         value_pb = _new_value_pb(insert, 'foo')
@@ -747,7 +749,7 @@ class TestConnection(unittest2.TestCase):
             return expected_result
 
         with _Monkey(MUT, _parse_commit_response=mock_parse):
-            result = conn.commit(DATASET_ID, mutation, b'xact')
+            result = conn.commit(DATASET_ID, req_pb, b'xact')
 
         self.assertTrue(result is expected_result)
         cw = http._called_with

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -102,10 +102,11 @@ class TestTransaction(unittest2.TestCase):
         connection = _Connection(234)
         client = _Client(_DATASET, connection)
         xact = self._makeOne(client)
-        xact._mutation = mutation = object()
+        xact._commit_request = commit_request = object()
         xact.begin()
         xact.commit()
-        self.assertEqual(connection._committed, (_DATASET, mutation, 234))
+        self.assertEqual(connection._committed,
+                         (_DATASET, commit_request, 234))
         self.assertEqual(xact.id, None)
 
     def test_commit_w_partial_keys(self):
@@ -118,10 +119,11 @@ class TestTransaction(unittest2.TestCase):
         xact = self._makeOne(client)
         entity = _Entity()
         xact.put(entity)
-        xact._mutation = mutation = object()
+        xact._commit_request = commit_request = object()
         xact.begin()
         xact.commit()
-        self.assertEqual(connection._committed, (_DATASET, mutation, 234))
+        self.assertEqual(connection._committed,
+                         (_DATASET, commit_request, 234))
         self.assertEqual(xact.id, None)
         self.assertEqual(entity.key.path, [{'kind': _KIND, 'id': _ID}])
 
@@ -130,11 +132,12 @@ class TestTransaction(unittest2.TestCase):
         connection = _Connection(234)
         client = _Client(_DATASET, connection)
         xact = self._makeOne(client)
-        xact._mutation = mutation = object()
+        xact._commit_request = commit_request = object()
         with xact:
             self.assertEqual(xact.id, 234)
             self.assertEqual(connection._begun, _DATASET)
-        self.assertEqual(connection._committed, (_DATASET, mutation, 234))
+        self.assertEqual(connection._committed,
+                         (_DATASET, commit_request, 234))
         self.assertEqual(xact.id, None)
 
     def test_context_manager_w_raise(self):
@@ -186,8 +189,8 @@ class _Connection(object):
     def rollback(self, dataset_id, transaction_id):
         self._rolled_back = dataset_id, transaction_id
 
-    def commit(self, dataset_id, mutation, transaction_id):
-        self._committed = (dataset_id, mutation, transaction_id)
+    def commit(self, dataset_id, commit_request, transaction_id):
+        self._committed = (dataset_id, commit_request, transaction_id)
         return self._index_updates, self._completed_keys
 
 


### PR DESCRIPTION
This is towards #1288 in preparation for the upgrade to `v1beta3`. In particular, a single `Mutation` protobuf instance in `v1beta3` is not sufficient to contain all changes to be committed, so we use the container that is up one level in the hierarchy.