### PR TITLE
Removing use of isolation level in datastore.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -288,8 +288,6 @@ class Connection(connection.Connection):
         :returns: The serialized transaction that was begun.
         """
         request = _datastore_pb2.BeginTransactionRequest()
-        request.isolation_level = (
-            _datastore_pb2.BeginTransactionRequest.SERIALIZABLE)
         response = self._rpc(project, 'beginTransaction', request,
                              _datastore_pb2.BeginTransactionResponse)
         return response.transaction

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -664,7 +664,6 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.BeginTransactionRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.isolation_level, rq_class.SERIALIZABLE)
 
     def test_commit_wo_transaction(self):
         from gcloud._testing import _Monkey


### PR DESCRIPTION
In `v1beta3` all transactions are serializable.

**NOTE**: This should not be merged until v1beta3 is launched but it should be straightforward to review.