### PR TITLE
Handling datastore renames on CompositeFilter and PropertyFilter.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -471,7 +471,7 @@ def _pb_from_query(query):
         pb.kind.add().name = query.kind
 
     composite_filter = pb.filter.composite_filter
-    composite_filter.operator = _query_pb2.CompositeFilter.AND
+    composite_filter.op = _query_pb2.CompositeFilter.AND
 
     if query.ancestor:
         ancestor_pb = helpers._prepare_key_for_request(
@@ -480,7 +480,7 @@ def _pb_from_query(query):
         # Filter on __key__ HAS_ANCESTOR == ancestor.
         ancestor_filter = composite_filter.filter.add().property_filter
         ancestor_filter.property.name = '__key__'
-        ancestor_filter.operator = _query_pb2.PropertyFilter.HAS_ANCESTOR
+        ancestor_filter.op = _query_pb2.PropertyFilter.HAS_ANCESTOR
         ancestor_filter.value.key_value.CopyFrom(ancestor_pb)
 
     for property_name, operator, value in query.filters:
@@ -489,7 +489,7 @@ def _pb_from_query(query):
         # Add the specific filter
         property_filter = composite_filter.filter.add().property_filter
         property_filter.property.name = property_name
-        property_filter.operator = pb_op_enum
+        property_filter.op = pb_op_enum
 
         # Set the value to filter on based on the type.
         if property_name == '__key__':

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -478,7 +478,7 @@ def _pb_from_query(query):
             query.ancestor.to_protobuf())
 
         # Filter on __key__ HAS_ANCESTOR == ancestor.
-        ancestor_filter = composite_filter.filter.add().property_filter
+        ancestor_filter = composite_filter.filters.add().property_filter
         ancestor_filter.property.name = '__key__'
         ancestor_filter.op = _query_pb2.PropertyFilter.HAS_ANCESTOR
         ancestor_filter.value.key_value.CopyFrom(ancestor_pb)
@@ -487,7 +487,7 @@ def _pb_from_query(query):
         pb_op_enum = query.OPERATORS.get(operator)
 
         # Add the specific filter
-        property_filter = composite_filter.filter.add().property_filter
+        property_filter = composite_filter.filters.add().property_filter
         property_filter.property.name = property_name
         property_filter.op = pb_op_enum
 
@@ -499,7 +499,7 @@ def _pb_from_query(query):
         else:
             helpers._set_protobuf_value(property_filter.value, value)
 
-    if not composite_filter.filter:
+    if not composite_filter.filters:
         pb.ClearField('filter')
 
     for prop in query.order:

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -551,8 +551,9 @@ class TestConnection(unittest2.TestCase):
         request.ParseFromString(cw['body'])
         self.assertEqual(request.partition_id.namespace, '')
         self.assertEqual(request.query, q_pb)
-        self.assertEqual(request.read_options.read_consistency,
-                         datastore_pb2.ReadOptions.DEFAULT)
+        self.assertEqual(
+            request.read_options.read_consistency,
+            datastore_pb2.ReadOptions.READ_CONSISTENCY_UNSPECIFIED)
         self.assertEqual(request.read_options.transaction, TRANSACTION)
 
     def test_run_query_w_eventual_and_transaction(self):

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -540,7 +540,7 @@ class Test__pb_from_query(unittest2.TestCase):
         self.assertEqual(list(pb.group_by), [])
         self.assertEqual(pb.filter.property_filter.property.name, '')
         cfilter = pb.filter.composite_filter
-        self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
+        self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(list(cfilter.filter), [])
         self.assertEqual(pb.start_cursor, b'')
         self.assertEqual(pb.end_cursor, b'')
@@ -564,7 +564,7 @@ class Test__pb_from_query(unittest2.TestCase):
         ancestor = Key('Ancestor', 123, project='PROJECT')
         pb = self._callFUT(_Query(ancestor=ancestor))
         cfilter = pb.filter.composite_filter
-        self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
+        self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filter), 1)
         pfilter = cfilter.filter[0].property_filter
         self.assertEqual(pfilter.property.name, '__key__')
@@ -580,7 +580,7 @@ class Test__pb_from_query(unittest2.TestCase):
         }
         pb = self._callFUT(query)
         cfilter = pb.filter.composite_filter
-        self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
+        self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filter), 1)
         pfilter = cfilter.filter[0].property_filter
         self.assertEqual(pfilter.property.name, 'name')
@@ -598,7 +598,7 @@ class Test__pb_from_query(unittest2.TestCase):
         }
         pb = self._callFUT(query)
         cfilter = pb.filter.composite_filter
-        self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
+        self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filter), 1)
         pfilter = cfilter.filter[0].property_filter
         self.assertEqual(pfilter.property.name, '__key__')

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -541,7 +541,7 @@ class Test__pb_from_query(unittest2.TestCase):
         self.assertEqual(pb.filter.property_filter.property.name, '')
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
-        self.assertEqual(list(cfilter.filter), [])
+        self.assertEqual(list(cfilter.filters), [])
         self.assertEqual(pb.start_cursor, b'')
         self.assertEqual(pb.end_cursor, b'')
         self.assertEqual(pb.limit, 0)
@@ -565,8 +565,8 @@ class Test__pb_from_query(unittest2.TestCase):
         pb = self._callFUT(_Query(ancestor=ancestor))
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
-        self.assertEqual(len(cfilter.filter), 1)
-        pfilter = cfilter.filter[0].property_filter
+        self.assertEqual(len(cfilter.filters), 1)
+        pfilter = cfilter.filters[0].property_filter
         self.assertEqual(pfilter.property.name, '__key__')
         ancestor_pb = _prepare_key_for_request(ancestor.to_protobuf())
         self.assertEqual(pfilter.value.key_value, ancestor_pb)
@@ -581,8 +581,8 @@ class Test__pb_from_query(unittest2.TestCase):
         pb = self._callFUT(query)
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
-        self.assertEqual(len(cfilter.filter), 1)
-        pfilter = cfilter.filter[0].property_filter
+        self.assertEqual(len(cfilter.filters), 1)
+        pfilter = cfilter.filters[0].property_filter
         self.assertEqual(pfilter.property.name, 'name')
         self.assertEqual(pfilter.value.string_value, u'John')
 
@@ -599,8 +599,8 @@ class Test__pb_from_query(unittest2.TestCase):
         pb = self._callFUT(query)
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
-        self.assertEqual(len(cfilter.filter), 1)
-        pfilter = cfilter.filter[0].property_filter
+        self.assertEqual(len(cfilter.filters), 1)
+        pfilter = cfilter.filters[0].property_filter
         self.assertEqual(pfilter.property.name, '__key__')
         key_pb = _prepare_key_for_request(key.to_protobuf())
         self.assertEqual(pfilter.value.key_value, key_pb)

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -540,7 +540,8 @@ class Test__pb_from_query(unittest2.TestCase):
         self.assertEqual(list(pb.group_by), [])
         self.assertEqual(pb.filter.property_filter.property.name, '')
         cfilter = pb.filter.composite_filter
-        self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
+        self.assertEqual(cfilter.op,
+                         query_pb2.CompositeFilter.OPERATOR_UNSPECIFIED)
         self.assertEqual(list(cfilter.filters), [])
         self.assertEqual(pb.start_cursor, b'')
         self.assertEqual(pb.end_cursor, b'')


### PR DESCRIPTION
Can't be merged until `v1beta3` is released.