### PR TITLE
Handling datastore renames on Query and QueryResultBatch.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -269,7 +269,7 @@ class Connection(connection.Connection):
         response = self._rpc(project, 'runQuery', request,
                              _datastore_pb2.RunQueryResponse)
         return (
-            [e.entity for e in response.batch.entity_result],
+            [e.entity for e in response.batch.entity_results],
             response.batch.end_cursor,  # Assume response always has cursor.
             response.batch.more_results,
             response.batch.skipped_results,

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -56,8 +56,8 @@ class Query(object):
     :param order:  field names used to order query results. Prepend '-'
                    to a field name to sort it in descending order.
 
-    :type group_by: sequence of string
-    :param group_by: field names used to group query results.
+    :type distinct_on: sequence of string
+    :param distinct_on: field names used to group query results.
 
     :raises: ValueError if ``project`` is not passed and no implicit
              default is set.
@@ -81,7 +81,7 @@ class Query(object):
                  filters=(),
                  projection=(),
                  order=(),
-                 group_by=()):
+                 distinct_on=()):
 
         self._client = client
         self._kind = kind
@@ -94,7 +94,7 @@ class Query(object):
             self.add_filter(property_name, operator, value)
         self._projection = _ensure_tuple_or_list('projection', projection)
         self._order = _ensure_tuple_or_list('order', order)
-        self._group_by = _ensure_tuple_or_list('group_by', group_by)
+        self._distinct_on = _ensure_tuple_or_list('distinct_on', distinct_on)
 
     @property
     def project(self):
@@ -273,15 +273,15 @@ class Query(object):
         self._order[:] = value
 
     @property
-    def group_by(self):
+    def distinct_on(self):
         """Names of fields used to group query results.
 
         :rtype: sequence of string
         """
-        return self._group_by[:]
+        return self._distinct_on[:]
 
-    @group_by.setter
-    def group_by(self, value):
+    @distinct_on.setter
+    def distinct_on(self, value):
         """Set fields used to group query results.
 
         :type value: string or sequence of strings
@@ -290,7 +290,7 @@ class Query(object):
         """
         if isinstance(value, str):
             value = [value]
-        self._group_by[:] = value
+        self._distinct_on[:] = value
 
     def fetch(self, limit=None, offset=0, start_cursor=None, end_cursor=None,
               client=None):
@@ -512,7 +512,7 @@ def _pb_from_query(query):
             property_order.property.name = prop
             property_order.direction = property_order.ASCENDING
 
-    for group_by_name in query.group_by:
-        pb.group_by.add().name = group_by_name
+    for distinct_on_name in query.distinct_on:
+        pb.distinct_on.add().name = distinct_on_name
 
     return pb

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -396,7 +396,7 @@ class Iterator(object):
             pb.end_cursor = base64.urlsafe_b64decode(end_cursor)
 
         if self._limit is not None:
-            pb.limit = self._limit
+            pb.limit.value = self._limit
 
         pb.offset = self._offset
 

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -909,7 +909,7 @@ class TestClient(unittest2.TestCase):
         FILTERS = [('PROPERTY', '==', 'VALUE')]
         PROJECTION = ['__key__']
         ORDER = ['PROPERTY']
-        GROUP_BY = ['GROUPBY']
+        DISTINCT_ON = ['DISTINCT_ON']
 
         creds = object()
         client = self._makeOne(credentials=creds)
@@ -922,7 +922,7 @@ class TestClient(unittest2.TestCase):
                 filters=FILTERS,
                 projection=PROJECTION,
                 order=ORDER,
-                group_by=GROUP_BY,
+                distinct_on=DISTINCT_ON,
                 )
 
         self.assertTrue(isinstance(query, _Dummy))
@@ -935,7 +935,7 @@ class TestClient(unittest2.TestCase):
             'filters': FILTERS,
             'projection': PROJECTION,
             'order': ORDER,
-            'group_by': GROUP_BY,
+            'distinct_on': DISTINCT_ON,
         }
         self.assertEqual(query.kwargs, kwargs)
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -618,7 +618,7 @@ class TestConnection(unittest2.TestCase):
         entity = entity_pb2.Entity()
         q_pb = self._make_query_pb(KIND)
         rsp_pb = datastore_pb2.RunQueryResponse()
-        rsp_pb.batch.entity_result.add(entity=entity)
+        rsp_pb.batch.entity_results.add(entity=entity)
         rsp_pb.batch.entity_result_type = 1  # FULL
         rsp_pb.batch.more_results = 3  # NO_MORE_RESULTS
         conn = self._makeOne()

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -42,7 +42,7 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.filters, [])
         self.assertEqual(query.projection, [])
         self.assertEqual(query.order, [])
-        self.assertEqual(query.group_by, [])
+        self.assertEqual(query.distinct_on, [])
 
     def test_ctor_explicit(self):
         from gcloud.datastore.key import Key
@@ -54,7 +54,7 @@ class TestQuery(unittest2.TestCase):
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
-        GROUP_BY = ['foo']
+        DISTINCT_ON = ['foo']
         query = self._makeOne(
             client,
             kind=_KIND,
@@ -64,7 +64,7 @@ class TestQuery(unittest2.TestCase):
             filters=FILTERS,
             projection=PROJECTION,
             order=ORDER,
-            group_by=GROUP_BY,
+            distinct_on=DISTINCT_ON,
             )
         self.assertTrue(query._client is client)
         self.assertEqual(query.project, _PROJECT)
@@ -74,7 +74,7 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(query.filters, FILTERS)
         self.assertEqual(query.projection, PROJECTION)
         self.assertEqual(query.order, ORDER)
-        self.assertEqual(query.group_by, GROUP_BY)
+        self.assertEqual(query.distinct_on, DISTINCT_ON)
 
     def test_ctor_bad_projection(self):
         BAD_PROJECTION = object()
@@ -86,10 +86,10 @@ class TestQuery(unittest2.TestCase):
         self.assertRaises(TypeError, self._makeOne, self._makeClient(),
                           order=BAD_ORDER)
 
-    def test_ctor_bad_group_by(self):
-        BAD_GROUP_BY = object()
+    def test_ctor_bad_distinct_on(self):
+        BAD_DISTINCT_ON = object()
         self.assertRaises(TypeError, self._makeOne, self._makeClient(),
-                          group_by=BAD_GROUP_BY)
+                          distinct_on=BAD_DISTINCT_ON)
 
     def test_ctor_bad_filters(self):
         FILTERS_CANT_UNPACK = [('one', 'two')]
@@ -264,29 +264,29 @@ class TestQuery(unittest2.TestCase):
         query.order = ['foo', '-bar']
         self.assertEqual(query.order, ['foo', '-bar'])
 
-    def test_group_by_setter_empty(self):
-        query = self._makeOne(self._makeClient(), group_by=['foo', 'bar'])
-        query.group_by = []
-        self.assertEqual(query.group_by, [])
+    def test_distinct_on_setter_empty(self):
+        query = self._makeOne(self._makeClient(), distinct_on=['foo', 'bar'])
+        query.distinct_on = []
+        self.assertEqual(query.distinct_on, [])
 
-    def test_group_by_setter_string(self):
+    def test_distinct_on_setter_string(self):
         query = self._makeOne(self._makeClient())
-        query.group_by = 'field1'
-        self.assertEqual(query.group_by, ['field1'])
+        query.distinct_on = 'field1'
+        self.assertEqual(query.distinct_on, ['field1'])
 
-    def test_group_by_setter_non_empty(self):
+    def test_distinct_on_setter_non_empty(self):
         query = self._makeOne(self._makeClient())
-        query.group_by = ['field1', 'field2']
-        self.assertEqual(query.group_by, ['field1', 'field2'])
+        query.distinct_on = ['field1', 'field2']
+        self.assertEqual(query.distinct_on, ['field1', 'field2'])
 
-    def test_group_by_multiple_calls(self):
-        _GROUP_BY1 = ['field1', 'field2']
-        _GROUP_BY2 = ['field3']
+    def test_distinct_on_multiple_calls(self):
+        _DISTINCT_ON1 = ['field1', 'field2']
+        _DISTINCT_ON2 = ['field3']
         query = self._makeOne(self._makeClient())
-        query.group_by = _GROUP_BY1
-        self.assertEqual(query.group_by, _GROUP_BY1)
-        query.group_by = _GROUP_BY2
-        self.assertEqual(query.group_by, _GROUP_BY2)
+        query.distinct_on = _DISTINCT_ON1
+        self.assertEqual(query.distinct_on, _DISTINCT_ON1)
+        query.distinct_on = _DISTINCT_ON2
+        self.assertEqual(query.distinct_on, _DISTINCT_ON2)
 
     def test_fetch_defaults_w_client_attr(self):
         connection = _Connection()
@@ -537,7 +537,7 @@ class Test__pb_from_query(unittest2.TestCase):
         self.assertEqual(list(pb.projection), [])
         self.assertEqual(list(pb.kind), [])
         self.assertEqual(list(pb.order), [])
-        self.assertEqual(list(pb.group_by), [])
+        self.assertEqual(list(pb.distinct_on), [])
         self.assertEqual(pb.filter.property_filter.property.name, '')
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.operator, query_pb2.CompositeFilter.AND)
@@ -616,9 +616,9 @@ class Test__pb_from_query(unittest2.TestCase):
                           query_pb2.PropertyOrder.DESCENDING,
                           query_pb2.PropertyOrder.ASCENDING])
 
-    def test_group_by(self):
-        pb = self._callFUT(_Query(group_by=['a', 'b', 'c']))
-        self.assertEqual([item.name for item in pb.group_by],
+    def test_distinct_on(self):
+        pb = self._callFUT(_Query(distinct_on=['a', 'b', 'c']))
+        self.assertEqual([item.name for item in pb.distinct_on],
                          ['a', 'b', 'c'])
 
 
@@ -633,7 +633,7 @@ class _Query(object):
                  filters=(),
                  projection=(),
                  order=(),
-                 group_by=()):
+                 distinct_on=()):
         self._client = client
         self.kind = kind
         self.project = project
@@ -642,7 +642,7 @@ class _Query(object):
         self.filters = filters
         self.projection = projection
         self.order = order
-        self.group_by = group_by
+        self.distinct_on = distinct_on
 
 
 class _Connection(object):

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -407,7 +407,7 @@ class TestIterator(unittest2.TestCase):
                          [{'kind': self._KIND, 'id': self._ID}])
         self.assertEqual(entities[0]['foo'], u'Foo')
         qpb = _pb_from_query(query)
-        qpb.limit = 13
+        qpb.limit.value = 13
         qpb.offset = 29
         EXPECTED = {
             'project': self._PROJECT,
@@ -544,7 +544,7 @@ class Test__pb_from_query(unittest2.TestCase):
         self.assertEqual(list(cfilter.filter), [])
         self.assertEqual(pb.start_cursor, b'')
         self.assertEqual(pb.end_cursor, b'')
-        self.assertEqual(pb.limit, 0)
+        self.assertEqual(pb.limit.value, 0)
         self.assertEqual(pb.offset, 0)
 
     def test_projection(self):

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -372,9 +372,9 @@ class TestDatastoreQuery(TestDatastore):
         self.assertEqual(new_entities[0]['name'], 'Sansa')
         self.assertEqual(new_entities[2]['name'], 'Arya')
 
-    def test_query_group_by(self):
+    def test_query_distinct_on(self):
         query = self._base_query()
-        query.group_by = ['alive']
+        query.distinct_on = ['alive']
 
         expected_matches = 2
         # We expect 2, but allow the query to get 1 extra.


### PR DESCRIPTION
Can't be merged until `v1beta3` is released.