### PR TITLE
Handling datastore renames key -> keys

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -193,7 +193,7 @@ class Connection(connection.Connection):
         """
         lookup_request = _datastore_pb2.LookupRequest()
         _set_read_options(lookup_request, eventual, transaction_id)
-        _add_keys_to_request(lookup_request.key, key_pbs)
+        _add_keys_to_request(lookup_request.keys, key_pbs)
 
         lookup_response = self._rpc(project, 'lookup', lookup_request,
                                     _datastore_pb2.LookupResponse)

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -362,11 +362,11 @@ class Connection(connection.Connection):
         :returns: An equal number of keys,  with IDs filled in by the backend.
         """
         request = _datastore_pb2.AllocateIdsRequest()
-        _add_keys_to_request(request.key, key_pbs)
+        _add_keys_to_request(request.keys, key_pbs)
         # Nothing to do with this response, so just execute the method.
         response = self._rpc(project, 'allocateIds', request,
                              _datastore_pb2.AllocateIdsResponse)
-        return list(response.key)
+        return list(response.keys)
 
 
 def _set_read_options(request, eventual, transaction_id):

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -807,7 +807,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.AllocateIdsRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(list(request.key), [])
+        self.assertEqual(list(request.keys), [])
 
     def test_allocate_ids_non_empty(self):
         from gcloud.datastore._generated import datastore_pb2
@@ -822,8 +822,8 @@ class TestConnection(unittest2.TestCase):
             self._make_key_pb(PROJECT, id=2345),
             ]
         rsp_pb = datastore_pb2.AllocateIdsResponse()
-        rsp_pb.key.add().CopyFrom(after_key_pbs[0])
-        rsp_pb.key.add().CopyFrom(after_key_pbs[1])
+        rsp_pb.keys.add().CopyFrom(after_key_pbs[0])
+        rsp_pb.keys.add().CopyFrom(after_key_pbs[1])
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
@@ -841,8 +841,8 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.AllocateIdsRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(len(request.key), len(before_key_pbs))
-        for key_before, key_after in zip(before_key_pbs, request.key):
+        self.assertEqual(len(request.keys), len(before_key_pbs))
+        for key_before, key_after in zip(before_key_pbs, request.keys):
             _compare_key_pb_after_request(self, key_before, key_after)
 
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -258,7 +258,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 1)
         _compare_key_pb_after_request(self, key_pb, keys[0])
 
@@ -288,7 +288,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 1)
         _compare_key_pb_after_request(self, key_pb, keys[0])
         self.assertEqual(request.read_options.read_consistency,
@@ -330,7 +330,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 1)
         _compare_key_pb_after_request(self, key_pb, keys[0])
         self.assertEqual(request.read_options.transaction, TRANSACTION)
@@ -365,7 +365,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 1)
         _compare_key_pb_after_request(self, key_pb, keys[0])
 
@@ -395,7 +395,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 2)
         _compare_key_pb_after_request(self, key_pb1, keys[0])
         _compare_key_pb_after_request(self, key_pb2, keys[1])
@@ -431,7 +431,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 2)
         _compare_key_pb_after_request(self, key_pb1, keys[0])
         _compare_key_pb_after_request(self, key_pb2, keys[1])
@@ -469,7 +469,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.LookupRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        keys = list(request.key)
+        keys = list(request.keys)
         self.assertEqual(len(keys), 2)
         _compare_key_pb_after_request(self, key_pb1, keys[0])
         _compare_key_pb_after_request(self, key_pb2, keys[1])


### PR DESCRIPTION
A repeated `Key` field occurs on:

- `AllocateIdsResponse`
- `AllocateIdsRequest`
- `LookupRequest`

----

Can't be merged until `v1beta3` is released.