### PR TITLE
Handle datastore renames on PartitionId

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -402,10 +402,10 @@ def _prepare_key_for_request(key_pb):  # pragma: NO COVER copied from helpers
     :returns: A key which will be added to a request. It will be the
               original if nothing needs to be changed.
     """
-    if _has_field(key_pb.partition_id, 'dataset_id'):
+    if _has_field(key_pb.partition_id, 'project_id'):
         new_key_pb = _entity_pb2.Key()
         new_key_pb.CopyFrom(key_pb)
-        new_key_pb.partition_id.ClearField('dataset_id')
+        new_key_pb.partition_id.ClearField('project_id')
         key_pb = new_key_pb
     return key_pb
 

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -264,7 +264,7 @@ class Connection(connection.Connection):
         _set_read_options(request, eventual, transaction_id)
 
         if namespace:
-            request.partition_id.namespace = namespace
+            request.partition_id.namespace_id = namespace
 
         request.query.CopyFrom(query_pb)
         response = self._rpc(project, 'runQuery', request,

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -271,8 +271,8 @@ def key_from_protobuf(pb):
     if _has_field(pb.partition_id, 'project_id'):
         project = pb.partition_id.project_id
     namespace = None
-    if _has_field(pb.partition_id, 'namespace'):
-        namespace = pb.partition_id.namespace
+    if _has_field(pb.partition_id, 'namespace_id'):
+        namespace = pb.partition_id.namespace_id
 
     return Key(*path_args, namespace=namespace, project=project)
 

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -62,7 +62,7 @@ def find_true_project(project, connection):
     # the project so the backend won't complain.
     bogus_key_pb = Key('__MissingLookupKind', 1,
                        project=project).to_protobuf()
-    bogus_key_pb.partition_id.ClearField('dataset_id')
+    bogus_key_pb.partition_id.ClearField('project_id')
 
     found_pbs, missing_pbs, _ = connection.lookup(project, [bogus_key_pb])
     # By not passing in `deferred`, lookup will continue until
@@ -71,7 +71,7 @@ def find_true_project(project, connection):
     # We only asked for one, so should only receive one.
     returned_pb, = all_pbs
 
-    return returned_pb.key.partition_id.dataset_id
+    return returned_pb.key.partition_id.project_id
 
 
 def _get_meaning(value_pb, is_list=False):
@@ -268,8 +268,8 @@ def key_from_protobuf(pb):
             path_args.append(element.name)
 
     project = None
-    if _has_field(pb.partition_id, 'dataset_id'):
-        project = pb.partition_id.dataset_id
+    if _has_field(pb.partition_id, 'project_id'):
+        project = pb.partition_id.project_id
     namespace = None
     if _has_field(pb.partition_id, 'namespace'):
         namespace = pb.partition_id.namespace
@@ -429,18 +429,18 @@ def _prepare_key_for_request(key_pb):
     :returns: A key which will be added to a request. It will be the
               original if nothing needs to be changed.
     """
-    if _has_field(key_pb.partition_id, 'dataset_id'):
-        # We remove the dataset_id from the protobuf. This is because
+    if _has_field(key_pb.partition_id, 'project_id'):
+        # We remove the project_id from the protobuf. This is because
         # the backend fails a request if the key contains un-prefixed
         # project. The backend fails because requests to
-        #     /datastore/.../datasets/foo/...
+        #     /v1beta3/projects/foo:...
         # and
-        #     /datastore/.../datasets/s~foo/...
+        #     /v1beta3/projects/s~foo:...
         # both go to the datastore given by 's~foo'. So if the key
-        # protobuf in the request body has dataset_id='foo', the
+        # protobuf in the request body has project_id='foo', the
         # backend will reject since 'foo' != 's~foo'.
         new_key_pb = _entity_pb2.Key()
         new_key_pb.CopyFrom(key_pb)
-        new_key_pb.partition_id.ClearField('dataset_id')
+        new_key_pb.partition_id.ClearField('project_id')
         key_pb = new_key_pb
     return key_pb

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -240,7 +240,7 @@ class Key(object):
         :returns: The protobuf representing the key.
         """
         key = _entity_pb2.Key()
-        key.partition_id.dataset_id = self.project
+        key.partition_id.project_id = self.project
 
         if self.namespace:
             key.partition_id.namespace = self.namespace

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -243,7 +243,7 @@ class Key(object):
         key.partition_id.project_id = self.project
 
         if self.namespace:
-            key.partition_id.namespace = self.namespace
+            key.partition_id.namespace_id = self.namespace
 
         for item in self.path:
             element = key.path_element.add()

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -388,7 +388,7 @@ class _Key(object):
         from gcloud.datastore._generated import entity_pb2
         key = self._key = entity_pb2.Key()
         # Don't assign it, because it will just get ripped out
-        # key.partition_id.dataset_id = self.project
+        # key.partition_id.project_id = self.project
 
         element = key.path_element.add()
         element.kind = self._kind

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -20,7 +20,7 @@ def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
     from gcloud.datastore.helpers import _new_value_pb
 
     entity_pb = entity_pb2.Entity()
-    entity_pb.key.partition_id.dataset_id = project
+    entity_pb.key.partition_id.project_id = project
     path_element = entity_pb.key.path_element.add()
     path_element.kind = kind
     path_element.id = integer_id
@@ -322,7 +322,7 @@ class TestClient(unittest2.TestCase):
 
         # Make a missing entity pb to be returned from mock backend.
         missed = entity_pb2.Entity()
-        missed.key.partition_id.dataset_id = self.PROJECT
+        missed.key.partition_id.project_id = self.PROJECT
         path_element = missed.key.path_element.add()
         path_element.kind = KIND
         path_element.id = ID

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -901,7 +901,7 @@ class Http(object):
 
 def _compare_key_pb_after_request(test, key_before, key_after):
     from gcloud._helpers import _has_field
-    test.assertFalse(_has_field(key_after.partition_id, 'dataset_id'))
+    test.assertFalse(_has_field(key_after.partition_id, 'project_id'))
     test.assertEqual(key_before.partition_id.namespace,
                      key_after.partition_id.namespace)
     test.assertEqual(len(key_before.path_element),

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -508,7 +508,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.RunQueryRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.partition_id.namespace, '')
+        self.assertEqual(request.partition_id.namespace_id, '')
         self.assertEqual(request.query, q_pb)
         self.assertEqual(request.read_options.read_consistency,
                          datastore_pb2.ReadOptions.EVENTUAL)
@@ -549,7 +549,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.RunQueryRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.partition_id.namespace, '')
+        self.assertEqual(request.partition_id.namespace_id, '')
         self.assertEqual(request.query, q_pb)
         self.assertEqual(request.read_options.read_consistency,
                          datastore_pb2.ReadOptions.DEFAULT)
@@ -606,7 +606,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.RunQueryRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.partition_id.namespace, '')
+        self.assertEqual(request.partition_id.namespace_id, '')
         self.assertEqual(request.query, q_pb)
 
     def test_run_query_w_namespace_nonempty_result(self):
@@ -638,7 +638,7 @@ class TestConnection(unittest2.TestCase):
         rq_class = datastore_pb2.RunQueryRequest
         request = rq_class()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.partition_id.namespace, 'NS')
+        self.assertEqual(request.partition_id.namespace_id, 'NS')
         self.assertEqual(request.query, q_pb)
 
     def test_begin_transaction(self):
@@ -902,8 +902,8 @@ class Http(object):
 def _compare_key_pb_after_request(test, key_before, key_after):
     from gcloud._helpers import _has_field
     test.assertFalse(_has_field(key_after.partition_id, 'project_id'))
-    test.assertEqual(key_before.partition_id.namespace,
-                     key_after.partition_id.namespace)
+    test.assertEqual(key_before.partition_id.namespace_id,
+                     key_after.partition_id.namespace_id)
     test.assertEqual(len(key_before.path_element),
                      len(key_after.path_element))
     for elt1, elt2 in zip(key_before.path_element, key_after.path_element):

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -358,7 +358,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         if project is not None:
             pb.partition_id.project_id = project
         if namespace is not None:
-            pb.partition_id.namespace = namespace
+            pb.partition_id.namespace_id = namespace
         for elem in path:
             added = pb.path_element.add()
             added.kind = elem['kind']

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -70,7 +70,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         _KIND = 'KIND'
         _ID = 1234
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = _PROJECT
+        entity_pb.key.partition_id.project_id = _PROJECT
         entity_pb.key.path_element.add(kind=_KIND, id=_ID)
 
         value_pb = _new_value_pb(entity_pb, 'foo')
@@ -117,7 +117,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         _KIND = 'KIND'
         _ID = 1234
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = _PROJECT
+        entity_pb.key.partition_id.project_id = _PROJECT
         entity_pb.key.path_element.add(kind=_KIND, id=_ID)
 
         list_val_pb = _new_value_pb(entity_pb, 'baz')
@@ -173,7 +173,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         inside_val_pb.integer_value = INSIDE_VALUE
 
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = PROJECT
+        entity_pb.key.partition_id.project_id = PROJECT
         element = entity_pb.key.path_element.add()
         element.kind = KIND
 
@@ -236,7 +236,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         entity_pb = self._callFUT(entity)
 
         expected_pb = entity_pb2.Entity()
-        expected_pb.key.partition_id.dataset_id = project
+        expected_pb.key.partition_id.project_id = project
         path_elt = expected_pb.key.path_element.add()
         path_elt.kind = kind
         path_elt.name = name
@@ -280,7 +280,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
 
         original_pb = entity_pb2.Entity()
         # Add a key.
-        original_pb.key.partition_id.dataset_id = project = 'PROJECT'
+        original_pb.key.partition_id.project_id = project = 'PROJECT'
         elem1 = original_pb.key.path_element.add()
         elem1.kind = 'Family'
         elem1.id = 1234
@@ -323,7 +323,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         new_pb = self._callFUT(entity)
 
         # NOTE: entity_to_protobuf() strips the project so we "cheat".
-        new_pb.key.partition_id.dataset_id = project
+        new_pb.key.partition_id.project_id = project
         self._compareEntityProto(original_pb, new_pb)
 
     def test_meaning_with_change(self):
@@ -356,7 +356,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         from gcloud.datastore._generated import entity_pb2
         pb = entity_pb2.Key()
         if project is not None:
-            pb.partition_id.dataset_id = project
+            pb.partition_id.project_id = project
         if namespace is not None:
             pb.partition_id.namespace = namespace
         for elem in path:
@@ -564,7 +564,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
         pb = entity_pb2.Value()
         entity_pb = pb.entity_value
         entity_pb.key.path_element.add(kind='KIND')
-        entity_pb.key.partition_id.dataset_id = 'PROJECT'
+        entity_pb.key.partition_id.project_id = 'PROJECT'
 
         value_pb = _new_value_pb(entity_pb, 'foo')
         value_pb.string_value = 'Foo'
@@ -741,7 +741,7 @@ class Test__prepare_key_for_request(unittest2.TestCase):
     def test_prepare_project_valid(self):
         from gcloud.datastore._generated import entity_pb2
         key = entity_pb2.Key()
-        key.partition_id.dataset_id = 'foo'
+        key.partition_id.project_id = 'foo'
         new_key = self._callFUT(key)
         self.assertFalse(new_key is key)
 
@@ -912,7 +912,7 @@ class _Connection(object):
 
         response = entity_pb2.Entity()
         response.key.CopyFrom(key_pb)
-        response.key.partition_id.dataset_id = self.prefix + project
+        response.key.partition_id.project_id = self.prefix + project
 
         missing = []
         deferred = []

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -343,8 +343,8 @@ class TestKey(unittest2.TestCase):
 
         # Check partition ID.
         self.assertEqual(pb.partition_id.project_id, self._DEFAULT_PROJECT)
-        self.assertEqual(pb.partition_id.namespace, '')
-        self.assertFalse(_has_field(pb.partition_id, 'namespace'))
+        self.assertEqual(pb.partition_id.namespace_id, '')
+        self.assertFalse(_has_field(pb.partition_id, 'namespace_id'))
 
         # Check the element PB matches the partial key and kind.
         elem, = list(pb.path_element)
@@ -365,7 +365,7 @@ class TestKey(unittest2.TestCase):
         key = self._makeOne('KIND', namespace=_NAMESPACE,
                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.namespace, _NAMESPACE)
+        self.assertEqual(pb.partition_id.namespace_id, _NAMESPACE)
 
     def test_to_protobuf_w_explicit_path(self):
         _PARENT = 'PARENT'

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -342,7 +342,7 @@ class TestKey(unittest2.TestCase):
         self.assertTrue(isinstance(pb, entity_pb2.Key))
 
         # Check partition ID.
-        self.assertEqual(pb.partition_id.dataset_id, self._DEFAULT_PROJECT)
+        self.assertEqual(pb.partition_id.project_id, self._DEFAULT_PROJECT)
         self.assertEqual(pb.partition_id.namespace, '')
         self.assertFalse(_has_field(pb.partition_id, 'namespace'))
 
@@ -358,7 +358,7 @@ class TestKey(unittest2.TestCase):
         _PROJECT = 'PROJECT-ALT'
         key = self._makeOne('KIND', project=_PROJECT)
         pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, _PROJECT)
+        self.assertEqual(pb.partition_id.project_id, _PROJECT)
 
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -334,7 +334,7 @@ class TestIterator(unittest2.TestCase):
         NO_MORE = query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT
         _ID = 123
         entity_pb = entity_pb2.Entity()
-        entity_pb.key.partition_id.dataset_id = self._PROJECT
+        entity_pb.key.partition_id.project_id = self._PROJECT
         path_element = entity_pb.key.path_element.add()
         path_element.kind = self._KIND
         path_element.id = _ID

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -166,7 +166,7 @@ def _make_key(kind, id_, project):
     from gcloud.datastore._generated import entity_pb2
 
     key = entity_pb2.Key()
-    key.partition_id.dataset_id = project
+    key.partition_id.project_id = project
     elem = key.path_element.add()
     elem.kind = kind
     elem.id = id_


### PR DESCRIPTION
~~**NOTE**: Has #1330 as diffbase. (Also relies on #1329 being merged, I just used `_has_field` even though it hadn't been implemented yet since I knew the tests would fail anyway)~~

Can't be merged until `v1beta3` is released.