### PR TITLE
Renaming path_element->path in Key.

### DIFF
--- a/gcloud/datastore/batch.py
+++ b/gcloud/datastore/batch.py
@@ -242,7 +242,7 @@ class Batch(object):
         # order) directly ``_partial_key_entities``.
         for new_key_pb, entity in zip(updated_keys,
                                       self._partial_key_entities):
-            new_id = new_key_pb.path_element[-1].id
+            new_id = new_key_pb.path[-1].id
             entity.key = entity.key.completed_key(new_id)
 
     def commit(self):

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -416,7 +416,7 @@ class Client(_BaseClient):
         conn = self.connection
         allocated_key_pbs = conn.allocate_ids(incomplete_key.project,
                                               incomplete_key_pbs)
-        allocated_ids = [allocated_key_pb.path_element[-1].id
+        allocated_ids = [allocated_key_pb.path[-1].id
                          for allocated_key_pb in allocated_key_pbs]
         return [incomplete_key.completed_key(allocated_id)
                 for allocated_id in allocated_ids]

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -258,7 +258,7 @@ def key_from_protobuf(pb):
     :returns: a new `Key` instance
     """
     path_args = []
-    for element in pb.path_element:
+    for element in pb.path:
         path_args.append(element.kind)
         if _has_field(element, 'id'):
             path_args.append(element.id)

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -246,7 +246,7 @@ class Key(object):
             key.partition_id.namespace = self.namespace
 
         for item in self.path:
-            element = key.path_element.add()
+            element = key.path.add()
             if 'kind' in item:
                 element.kind = item['kind']
             if 'id' in item:

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -346,7 +346,7 @@ class _PathElementPB(object):
 class _KeyPB(object):
 
     def __init__(self, id):
-        self.path_element = [_PathElementPB(id)]
+        self.path = [_PathElementPB(id)]
 
 
 class _Connection(object):
@@ -390,7 +390,7 @@ class _Key(object):
         # Don't assign it, because it will just get ripped out
         # key.partition_id.dataset_id = self.project
 
-        element = key.path_element.add()
+        element = key.path.add()
         element.kind = self._kind
         if self._id is not None:
             element.id = self._id

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -21,7 +21,7 @@ def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
 
     entity_pb = entity_pb2.Entity()
     entity_pb.key.partition_id.dataset_id = project
-    path_element = entity_pb.key.path_element.add()
+    path_element = entity_pb.key.path.add()
     path_element.kind = kind
     path_element.id = integer_id
     if name is not None and str_val is not None:
@@ -323,7 +323,7 @@ class TestClient(unittest2.TestCase):
         # Make a missing entity pb to be returned from mock backend.
         missed = entity_pb2.Entity()
         missed.key.partition_id.dataset_id = self.PROJECT
-        path_element = missed.key.path_element.add()
+        path_element = missed.key.path.add()
         path_element.kind = KIND
         path_element.id = ID
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -358,8 +358,8 @@ class TestConnection(unittest2.TestCase):
         (found,), missing, deferred = conn.lookup(PROJECT, [key_pb])
         self.assertEqual(len(missing), 0)
         self.assertEqual(len(deferred), 0)
-        self.assertEqual(found.key.path_element[0].kind, 'Kind')
-        self.assertEqual(found.key.path_element[0].id, 1234)
+        self.assertEqual(found.key.path[0].kind, 'Kind')
+        self.assertEqual(found.key.path[0].id, 1234)
         cw = http._called_with
         self._verifyProtobufCall(cw, URI, conn)
         rq_class = datastore_pb2.LookupRequest
@@ -859,7 +859,7 @@ class Test__parse_commit_response(unittest2.TestCase):
         index_updates = 1337
         keys = [
             entity_pb2.Key(
-                path_element=[
+                path=[
                     entity_pb2.Key.PathElement(
                         kind='Foo',
                         id=1234,
@@ -867,7 +867,7 @@ class Test__parse_commit_response(unittest2.TestCase):
                 ],
             ),
             entity_pb2.Key(
-                path_element=[
+                path=[
                     entity_pb2.Key.PathElement(
                         kind='Bar',
                         name='baz',
@@ -904,9 +904,9 @@ def _compare_key_pb_after_request(test, key_before, key_after):
     test.assertFalse(_has_field(key_after.partition_id, 'dataset_id'))
     test.assertEqual(key_before.partition_id.namespace,
                      key_after.partition_id.namespace)
-    test.assertEqual(len(key_before.path_element),
-                     len(key_after.path_element))
-    for elt1, elt2 in zip(key_before.path_element, key_after.path_element):
+    test.assertEqual(len(key_before.path),
+                     len(key_after.path))
+    for elt1, elt2 in zip(key_before.path, key_after.path):
         test.assertEqual(elt1, elt2)
 
 
@@ -919,4 +919,4 @@ class _PathElementProto(object):
 class _KeyProto(object):
 
     def __init__(self, id_):
-        self.path_element = [_PathElementProto(id_)]
+        self.path = [_PathElementProto(id_)]

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -71,7 +71,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         _ID = 1234
         entity_pb = entity_pb2.Entity()
         entity_pb.key.partition_id.dataset_id = _PROJECT
-        entity_pb.key.path_element.add(kind=_KIND, id=_ID)
+        entity_pb.key.path.add(kind=_KIND, id=_ID)
 
         value_pb = _new_value_pb(entity_pb, 'foo')
         value_pb.string_value = 'Foo'
@@ -118,7 +118,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         _ID = 1234
         entity_pb = entity_pb2.Entity()
         entity_pb.key.partition_id.dataset_id = _PROJECT
-        entity_pb.key.path_element.add(kind=_KIND, id=_ID)
+        entity_pb.key.path.add(kind=_KIND, id=_ID)
 
         list_val_pb = _new_value_pb(entity_pb, 'baz')
         list_pb = list_val_pb.list_value
@@ -174,7 +174,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
 
         entity_pb = entity_pb2.Entity()
         entity_pb.key.partition_id.dataset_id = PROJECT
-        element = entity_pb.key.path_element.add()
+        element = entity_pb.key.path.add()
         element.kind = KIND
 
         outside_val_pb = _new_value_pb(entity_pb, OUTSIDE_NAME)
@@ -237,7 +237,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
 
         expected_pb = entity_pb2.Entity()
         expected_pb.key.partition_id.dataset_id = project
-        path_elt = expected_pb.key.path_element.add()
+        path_elt = expected_pb.key.path.add()
         path_elt.kind = kind
         path_elt.name = name
 
@@ -281,10 +281,10 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         original_pb = entity_pb2.Entity()
         # Add a key.
         original_pb.key.partition_id.dataset_id = project = 'PROJECT'
-        elem1 = original_pb.key.path_element.add()
+        elem1 = original_pb.key.path.add()
         elem1.kind = 'Family'
         elem1.id = 1234
-        elem2 = original_pb.key.path_element.add()
+        elem2 = original_pb.key.path.add()
         elem2.kind = 'King'
         elem2.name = 'Spades'
 
@@ -360,7 +360,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         if namespace is not None:
             pb.partition_id.namespace = namespace
         for elem in path:
-            added = pb.path_element.add()
+            added = pb.path.add()
             added.kind = elem['kind']
             if 'id' in elem:
                 added.id = elem['id']
@@ -563,7 +563,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
 
         pb = entity_pb2.Value()
         entity_pb = pb.entity_value
-        entity_pb.key.path_element.add(kind='KIND')
+        entity_pb.key.path.add(kind='KIND')
         entity_pb.key.partition_id.dataset_id = 'PROJECT'
 
         value_pb = _new_value_pb(entity_pb, 'foo')
@@ -781,7 +781,7 @@ class Test_find_true_project(unittest2.TestCase):
 
         # Make sure just one.
         called_key_pb, = CONNECTION._called_key_pbs
-        path_element = called_key_pb.path_element
+        path_element = called_key_pb.path
         self.assertEqual(len(path_element), 1)
         self.assertEqual(path_element[0].kind, '__MissingLookupKind')
         self.assertEqual(path_element[0].id, 1)
@@ -803,7 +803,7 @@ class Test_find_true_project(unittest2.TestCase):
 
         # Make sure just one.
         called_key_pb, = CONNECTION._called_key_pbs
-        path_element = called_key_pb.path_element
+        path_element = called_key_pb.path
         self.assertEqual(len(path_element), 1)
         self.assertEqual(path_element[0].kind, '__MissingLookupKind')
         self.assertEqual(path_element[0].id, 1)

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -347,7 +347,7 @@ class TestKey(unittest2.TestCase):
         self.assertFalse(_has_field(pb.partition_id, 'namespace'))
 
         # Check the element PB matches the partial key and kind.
-        elem, = list(pb.path_element)
+        elem, = list(pb.path)
         self.assertEqual(elem.kind, _KIND)
         self.assertEqual(elem.name, '')
         self.assertFalse(_has_field(elem, 'name'))
@@ -375,7 +375,7 @@ class TestKey(unittest2.TestCase):
         key = self._makeOne(_PARENT, _NAME, _CHILD, _ID,
                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
-        elems = list(pb.path_element)
+        elems = list(pb.path)
         self.assertEqual(len(elems), 2)
         self.assertEqual(elems[0].kind, _PARENT)
         self.assertEqual(elems[0].name, _NAME)
@@ -390,7 +390,7 @@ class TestKey(unittest2.TestCase):
         # on this? The backend certainly will.
         key._path[-1].pop('kind')
         pb = key.to_protobuf()
-        self.assertFalse(_has_field(pb.path_element[0], 'kind'))
+        self.assertFalse(_has_field(pb.path[0], 'kind'))
 
     def test_is_partial_no_name_or_id(self):
         key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -335,7 +335,7 @@ class TestIterator(unittest2.TestCase):
         _ID = 123
         entity_pb = entity_pb2.Entity()
         entity_pb.key.partition_id.dataset_id = self._PROJECT
-        path_element = entity_pb.key.path_element.add()
+        path_element = entity_pb.key.path.add()
         path_element.kind = self._KIND
         path_element.id = _ID
         value_pb = _new_value_pb(entity_pb, 'foo')

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -167,7 +167,7 @@ def _make_key(kind, id_, project):
 
     key = entity_pb2.Key()
     key.partition_id.dataset_id = project
-    elem = key.path_element.add()
+    elem = key.path.add()
     elem.kind = kind
     elem.id = id_
     return key


### PR DESCRIPTION
Can't be merged until `v1beta3` is released.

As with #1359, relies on #1329 being merged, I just used `_has_field` even though it hadn't been implemented yet since I knew the tests would fail anyway.