### PR TITLE
Treating DNS zone creation time as an RFC 3339 string. 

### DIFF
--- a/gcloud/dns/test_changes.py
+++ b/gcloud/dns/test_changes.py
@@ -33,8 +33,8 @@ class TestChanges(unittest2.TestCase):
         self.WHEN = _NOW().replace(tzinfo=UTC)
 
     def _makeResource(self):
-        from gcloud._helpers import _RFC3339_MICROS
-        when_str = self.WHEN.strftime(_RFC3339_MICROS)
+        from gcloud._helpers import _datetime_to_rfc3339
+        when_str = _datetime_to_rfc3339(self.WHEN)
         return {
             'kind': 'dns#change',
             'id': self.CHANGES_NAME,
@@ -55,12 +55,10 @@ class TestChanges(unittest2.TestCase):
         }
 
     def _verifyResourceProperties(self, changes, resource, zone):
-        import datetime
+        from gcloud._helpers import _rfc3339_to_datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _RFC3339_MICROS
         self.assertEqual(changes.name, resource['id'])
-        started = datetime.datetime.strptime(
-            resource['startTime'], _RFC3339_MICROS).replace(tzinfo=UTC)
+        started = _rfc3339_to_datetime(resource['startTime'])
         self.assertEqual(changes.started, started)
         self.assertEqual(changes.status, resource['status'])
 

--- a/gcloud/dns/test_zone.py
+++ b/gcloud/dns/test_zone.py
@@ -32,9 +32,18 @@ class TestManagedZone(unittest2.TestCase):
         import datetime
         from gcloud._helpers import UTC
 
-        self.WHEN_TS = 1437767599.006
-        self.WHEN = datetime.datetime.utcfromtimestamp(self.WHEN_TS).replace(
-            tzinfo=UTC)
+        year = 2015
+        month = 7
+        day = 24
+        hour = 19
+        minute = 53
+        seconds = 19
+        micros = 6000
+
+        self.WHEN_STR = '%d-%02d-%02dT%02d:%02d:%02d.%06dZ' % (
+            year, month, day, hour, minute, seconds, micros)
+        self.WHEN = datetime.datetime(
+            year, month, day, hour, minute, seconds, micros, tzinfo=UTC)
         self.ZONE_ID = 12345
 
     def _makeResource(self):
@@ -44,7 +53,7 @@ class TestManagedZone(unittest2.TestCase):
             'dnsName': self.DNS_NAME,
             'description': self.DESCRIPTION,
             'id': self.ZONE_ID,
-            'creationTime': self.WHEN_TS * 1000,
+            'creationTime': self.WHEN_STR,
             'nameServers': [
                 'ns-cloud1.googledomains.com',
                 'ns-cloud2.googledomains.com',
@@ -440,7 +449,7 @@ class TestManagedZone(unittest2.TestCase):
                          {'maxResults': 3, 'pageToken': TOKEN})
 
     def test_list_changes_defaults(self):
-        from gcloud._helpers import _RFC3339_MICROS
+        from gcloud._helpers import _datetime_to_rfc3339
         from gcloud.dns.changes import Changes
         from gcloud.dns.resource_record_set import ResourceRecordSet
         self._setUpConstants()
@@ -462,7 +471,7 @@ class TestManagedZone(unittest2.TestCase):
                 'kind': 'dns#change',
                 'id': CHANGES_NAME,
                 'status': 'pending',
-                'startTime': self.WHEN.strftime(_RFC3339_MICROS),
+                'startTime': _datetime_to_rfc3339(self.WHEN),
                 'additions': [
                     {'kind': 'dns#resourceRecordSet',
                      'name': NAME_1,
@@ -516,7 +525,7 @@ class TestManagedZone(unittest2.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_changes_explicit(self):
-        from gcloud._helpers import _RFC3339_MICROS
+        from gcloud._helpers import _datetime_to_rfc3339
         from gcloud.dns.changes import Changes
         from gcloud.dns.resource_record_set import ResourceRecordSet
         self._setUpConstants()
@@ -537,7 +546,7 @@ class TestManagedZone(unittest2.TestCase):
                 'kind': 'dns#change',
                 'id': CHANGES_NAME,
                 'status': 'pending',
-                'startTime': self.WHEN.strftime(_RFC3339_MICROS),
+                'startTime': _datetime_to_rfc3339(self.WHEN),
                 'additions': [
                     {'kind': 'dns#resourceRecordSet',
                      'name': NAME_1,

--- a/gcloud/dns/zone.py
+++ b/gcloud/dns/zone.py
@@ -15,7 +15,7 @@
 """Define API ManagedZones."""
 import six
 
-from gcloud._helpers import _datetime_from_microseconds
+from gcloud._helpers import _rfc3339_to_datetime
 from gcloud.exceptions import NotFound
 from gcloud.dns.changes import Changes
 from gcloud.dns.resource_record_set import ResourceRecordSet
@@ -92,10 +92,7 @@ class ManagedZone(object):
         :rtype: ``datetime.datetime``, or ``NoneType``
         :returns: the creation time (None until set from the server).
         """
-        creation_time = self._properties.get('creationTime')
-        if creation_time is not None:
-            # creation_time will be in milliseconds.
-            return _datetime_from_microseconds(1000.0 * creation_time)
+        return self._properties.get('creationTime')
 
     @property
     def name_servers(self):
@@ -215,7 +212,8 @@ class ManagedZone(object):
         self._properties.clear()
         cleaned = api_response.copy()
         if 'creationTime' in cleaned:
-            cleaned['creationTime'] = float(cleaned['creationTime'])
+            cleaned['creationTime'] = _rfc3339_to_datetime(
+                cleaned['creationTime'])
         self._properties.update(cleaned)
 
     def _build_resource(self):


### PR DESCRIPTION
Was previously assumed to be a float (seconds from the epoch). Also using core timestamp utilities in `dns` tests.

Fixes #1362.

----

@kvdb I found I couldn't even create a managed zone to test if this was possible. How did you create your pre-existing zones? (I'm curious if you have a test domain or if you are actually using the service to manage DNS rules for a live domain.)