### PR TITLE
Changing use of PUBSUB_HOST env. var. to PUBSUB_EMULATOR_HOST.

### DIFF
--- a/gcloud/environment_vars.py
+++ b/gcloud/environment_vars.py
@@ -33,7 +33,7 @@ GCD_DATASET = 'DATASTORE_DATASET'
 GCD_HOST = 'DATASTORE_HOST'
 """Environment variable defining host for GCD dataset server."""
 
-PUBSUB_EMULATOR = 'PUBSUB_HOST'
+PUBSUB_EMULATOR = 'PUBSUB_EMULATOR_HOST'
 """Environment variable defining host for Pub/Sub emulator."""
 
 TESTS_DATASET = 'GCLOUD_TESTS_DATASET_ID'

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -51,8 +51,11 @@ class Connection(base_connection.JSONConnection):
     def __init__(self, credentials=None, http=None, api_base_url=None):
         super(Connection, self).__init__(credentials=credentials, http=http)
         if api_base_url is None:
-            api_base_url = os.getenv(PUBSUB_EMULATOR,
-                                     self.__class__.API_BASE_URL)
+            emulator_host = os.getenv(PUBSUB_EMULATOR)
+            if emulator_host is None:
+                api_base_url = self.__class__.API_BASE_URL
+            else:
+                api_base_url = 'http://' + emulator_host
         self.api_base_url = api_base_url
 
     def build_api_url(self, path, query_params=None,

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -34,7 +34,7 @@ class TestConnection(unittest2.TestCase):
         from gcloud._testing import _Monkey
         from gcloud.environment_vars import PUBSUB_EMULATOR
 
-        HOST = object()
+        HOST = 'localhost:8187'
         fake_environ = {PUBSUB_EMULATOR: HOST}
 
         with _Monkey(os, getenv=fake_environ.get):
@@ -42,7 +42,7 @@ class TestConnection(unittest2.TestCase):
 
         klass = self._getTargetClass()
         self.assertNotEqual(conn.api_base_url, klass.API_BASE_URL)
-        self.assertEqual(conn.api_base_url, HOST)
+        self.assertEqual(conn.api_base_url, 'http://' + HOST)
 
     def test_custom_url_from_constructor(self):
         HOST = object()


### PR DESCRIPTION
Also changing how the variable is used. Now, pre-pending the protocol in front. (Assumes the user does something like `localhost:8888`.)

/cc @hbchai