### PR TITLE
Excluding system tests from being installed.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 graft gcloud
 global-exclude *.pyc
+recursive-exclude system_tests *

--- a/scripts/attempt_system_tests.py
+++ b/scripts/attempt_system_tests.py
@@ -26,9 +26,6 @@ import os
 import subprocess
 import sys
 
-from system_tests.run_system_test import run_module_tests
-
-
 MODULES = (
     'datastore',
     'storage',
@@ -36,8 +33,8 @@ MODULES = (
     'bigquery',
 )
 SCRIPTS_DIR = os.path.dirname(__file__)
-ENCRYPTED_KEYFILE = os.path.abspath(
-    os.path.join(SCRIPTS_DIR, '..', 'system_tests', 'key.json.enc'))
+ROOT_DIR = os.path.abspath(os.path.join(SCRIPTS_DIR, '..'))
+ENCRYPTED_KEYFILE = os.path.join(ROOT_DIR, 'system_tests', 'key.json.enc')
 
 
 def check_environment():
@@ -105,6 +102,9 @@ def prepare_to_run():
 def main():
     """Run all the system tests if necessary."""
     prepare_to_run()
+
+    sys.path.append(ROOT_DIR)
+    from system_tests.run_system_test import run_module_tests
     for module in MODULES:
         run_module_tests(module)
 


### PR DESCRIPTION
@tseaver I noticed this while trying to `from system_tests import populate_datastore` and the import failed due to reasons that were "resolved" in #1349.

Then I peaked and realized that the error was coming from

```
/usr/local/lib/python2.7/dist-packages/system_tests/populate_datastore.py
/usr/local/lib/python2.7/dist-packages/gcloud/datastore/client.py
```

Notice that in our repo:

```python
>>> from setuptools import find_packages
>>> find_packages()
['gcloud',
 'system_tests',
 'gcloud.storage',
 'gcloud.pubsub',
 'gcloud.dns',
 'gcloud.bigtable',
 'gcloud.bigquery',
 'gcloud.resource_manager',
 'gcloud.search',
 'gcloud.datastore',
 'gcloud.streaming',
 'gcloud.storage.demo',
 'gcloud.bigtable.happybase',
 'gcloud.bigtable._generated',
 'gcloud.datastore.demo',
 'gcloud.datastore._generated']
```

(This is due to the fact that `system_tests/__init__.py` was added in #954 / #273)