### PR TITLE
Ignored datastore/_generated directory in lint.

### DIFF
--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -30,6 +30,7 @@ import sys
 
 IGNORED_DIRECTORIES = [
     'gcloud/bigtable/_generated',
+    'gcloud/datastore/_generated',
 ]
 IGNORED_FILES = [
     'gcloud/datastore/_datastore_v1_pb2.py',

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps = {[testenv:docs]deps}
 passenv = {[testenv:docs]passenv}
 
 [pep8]
-exclude = gcloud/datastore/_datastore_v1_pb2.py,gcloud/bigtable/_generated/*,docs/conf.py
+exclude = gcloud/datastore/_generated/*,gcloud/datastore/_datastore_v1_pb2.py,gcloud/bigtable/_generated/*,docs/conf.py,
 verbose = 1
 
 [testenv:lint]


### PR DESCRIPTION
It's unclear why this wasn't failing sooner, but it is causing the build to fail.