### PR TITLE
Adding Bigtable Row.append_cell_value.

### DIFF
--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -42,6 +42,38 @@ class Row(object):
         self._row_key = _to_bytes(row_key)
         self._table = table
         self._filter = filter_
+        self._rule_pb_list = []
+
+    def append_cell_value(self, column_family_id, column, value):
+        """Appends a value to an existing cell.
+
+        .. note::
+
+            This method adds a read-modify rule protobuf to the accumulated
+            read-modify rules on this :class:`Row`, but does not make an API
+            request. To actually send an API request (with the rules) to the
+            Google Cloud Bigtable API, call :meth:`commit_modifications`.
+
+        :type column_family_id: str
+        :param column_family_id: The column family that contains the column.
+                                 Must be of the form
+                                 ``[_a-zA-Z0-9][-_.a-zA-Z0-9]*``.
+
+        :type column: bytes
+        :param column: The column within the column family where the cell
+                       is located.
+
+        :type value: bytes
+        :param value: The value to append to the existing value in the cell. If
+                      the targeted cell is unset, it will be treated as
+                      containing the empty string.
+        """
+        column = _to_bytes(column)
+        value = _to_bytes(value)
+        rule_pb = data_pb2.ReadModifyWriteRule(family_name=column_family_id,
+                                               column_qualifier=column,
+                                               append_value=value)
+        self._rule_pb_list.append(rule_pb)
 
 
 class RowFilter(object):

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -49,6 +49,23 @@ class TestRow(unittest2.TestCase):
         with self.assertRaises(TypeError):
             self._makeOne(row_key, None)
 
+    def test_append_cell_value(self):
+        from gcloud.bigtable._generated import bigtable_data_pb2 as data_pb2
+
+        table = object()
+        row_key = b'row_key'
+        row = self._makeOne(row_key, table)
+        self.assertEqual(row._rule_pb_list, [])
+
+        column = b'column'
+        column_family_id = u'column_family_id'
+        value = b'bytes-val'
+        row.append_cell_value(column_family_id, column, value)
+        expected_pb = data_pb2.ReadModifyWriteRule(
+            family_name=column_family_id, column_qualifier=column,
+            append_value=value)
+        self.assertEqual(row._rule_pb_list, [expected_pb])
+
 
 class Test_BoolFilter(unittest2.TestCase):
 


### PR DESCRIPTION
This accumulates a row mutation without actually sending a request (this is similar to a batch in datastore).