### PR TITLE
Making the content length header a string.

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -225,7 +225,8 @@ class JSONConnection(Connection):
         else:
             content_length = 0
 
-        headers['Content-Length'] = content_length
+        # NOTE: str is intended, bytes are sufficient for headers.
+        headers['Content-Length'] = str(content_length)
 
         if content_type:
             headers['Content-Type'] = content_type

--- a/gcloud/storage/test_batch.py
+++ b/gcloud/storage/test_batch.py
@@ -115,7 +115,7 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(http._requests, [])
         EXPECTED_HEADERS = [
             ('Accept-Encoding', 'gzip'),
-            ('Content-Length', 0),
+            ('Content-Length', '0'),
         ]
         solo_request, = batch._requests
         self.assertEqual(solo_request[0], 'GET')
@@ -140,7 +140,7 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(http._requests, [])
         EXPECTED_HEADERS = [
             ('Accept-Encoding', 'gzip'),
-            ('Content-Length', 10),
+            ('Content-Length', '10'),
         ]
         solo_request, = batch._requests
         self.assertEqual(solo_request[0], 'POST')
@@ -165,7 +165,7 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(http._requests, [])
         EXPECTED_HEADERS = [
             ('Accept-Encoding', 'gzip'),
-            ('Content-Length', 10),
+            ('Content-Length', '10'),
         ]
         solo_request, = batch._requests
         self.assertEqual(solo_request[0], 'PATCH')
@@ -190,7 +190,7 @@ class TestBatch(unittest2.TestCase):
         self.assertEqual(http._requests, [])
         EXPECTED_HEADERS = [
             ('Accept-Encoding', 'gzip'),
-            ('Content-Length', 0),
+            ('Content-Length', '0'),
         ]
         solo_request, = batch._requests
         self.assertEqual(solo_request[0], 'DELETE')

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -163,7 +163,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], None)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
@@ -181,7 +181,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], {})
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'Content-Type': 'application/json',
             'User-Agent': conn.USER_AGENT,
         }
@@ -200,7 +200,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], None)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'X-Foo': 'foo',
             'User-Agent': conn.USER_AGENT,
         }
@@ -225,7 +225,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], None)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
@@ -274,7 +274,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], None)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
@@ -301,7 +301,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], DATAJ)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': len(DATAJ),
+            'Content-Length': str(len(DATAJ)),
             'Content-Type': 'application/json',
             'User-Agent': conn.USER_AGENT,
         }
@@ -345,7 +345,7 @@ class TestJSONConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'], None)
         expected_headers = {
             'Accept-Encoding': 'gzip',
-            'Content-Length': 0,
+            'Content-Length': '0',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(http._called_with['headers'], expected_headers)


### PR DESCRIPTION
@tseaver I discovered this while outfitting the Pub/Sub system tests to run with the emulator. When using an un-authorized client [like in `datastore`][1], it caused an error in `httplib2`. We have never experience this because `oauth2client` has [bailed us out][2] until this point.

[1]: https://github.com/GoogleCloudPlatform/gcloud-python/blob/ffe5869aa7c31bd82483e4d52adacbf83cf0fd69/system_tests/datastore.py#L75
[2]: https://github.com/google/oauth2client/blob/8f8df1f5977ec76d50cb3dca9a31044cfd1fb9b4/oauth2client/client.py#L464-L465