### PR TITLE
Adding cluster argument to Bigtable HappyBase connection.

### DIFF
--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -15,6 +15,8 @@
 """Google Cloud Bigtable HappyBase connection module."""
 
 
+import warnings
+
 import six
 
 from gcloud.bigtable.client import Client
@@ -30,6 +32,9 @@ DEFAULT_PORT = None
 DEFAULT_TRANSPORT = None
 DEFAULT_COMPAT = None
 DEFAULT_PROTOCOL = None
+
+_LEGACY_ARGS = frozenset(('host', 'port', 'compat', 'transport', 'protocol'))
+_WARN = warnings.warn
 
 
 def _get_cluster(timeout=None):
@@ -84,13 +89,10 @@ class Connection(object):
         :class:`Credentials <oauth2client.client.Credentials>` stored on the
         client.
 
-    :type host: :data:`NoneType <types.NoneType>`
-    :param host: Unused parameter. Provided for compatibility with HappyBase,
-                 but irrelevant for Cloud Bigtable since it has a fixed host.
-
-    :type port: :data:`NoneType <types.NoneType>`
-    :param port: Unused parameter. Provided for compatibility with HappyBase,
-                 but irrelevant for Cloud Bigtable since it has a fixed host.
+    The arguments ``host``, ``port``, ``compat``, ``transport`` and
+    ``protocol`` are allowed (as keyword arguments) for compatibility with
+    HappyBase. However, they will not be used in anyway, and will cause a
+    warning if passed.
 
     :type timeout: int
     :param timeout: (Optional) The socket timeout in milliseconds.
@@ -106,21 +108,6 @@ class Connection(object):
     :param table_prefix_separator: (Optional) Separator used with
                                    ``table_prefix``. Defaults to ``_``.
 
-    :type compat: :data:`NoneType <types.NoneType>`
-    :param compat: Unused parameter. Provided for compatibility with
-                   HappyBase, but irrelevant for Cloud Bigtable since there
-                   is only one version.
-
-    :type transport: :data:`NoneType <types.NoneType>`
-    :param transport: Unused parameter. Provided for compatibility with
-                      HappyBase, but irrelevant for Cloud Bigtable since the
-                      transport is fixed.
-
-    :type protocol: :data:`NoneType <types.NoneType>`
-    :param protocol: Unused parameter. Provided for compatibility with
-                     HappyBase, but irrelevant for Cloud Bigtable since the
-                     protocol is fixed.
-
     :type cluster: :class:`gcloud.bigtable.cluster.Cluster`
     :param cluster: (Optional) A Cloud Bigtable cluster. The instance also
                     owns a client for making gRPC requests to the Cloud
@@ -132,16 +119,17 @@ class Connection(object):
                     Then that client is used to retrieve all the clusters
                     owned by the client's project.
 
+    :type kwargs: dict
+    :param kwargs: Remaining keyword arguments. Provided for HappyBase
+                   compatibility.
+
     :raises: :class:`ValueError <exceptions.ValueError>` if any of the unused
              parameters are specified with a value other than the defaults.
     """
 
-    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, timeout=None,
-                 autoconnect=True, table_prefix=None,
-                 table_prefix_separator='_', compat=DEFAULT_COMPAT,
-                 transport=DEFAULT_TRANSPORT, protocol=DEFAULT_PROTOCOL,
-                 cluster=None):
-        self._reject_legacy_args(host, port, compat, transport, protocol)
+    def __init__(self, timeout=None, autoconnect=True, table_prefix=None,
+                 table_prefix_separator='_', cluster=None, **kwargs):
+        self._handle_legacy_args(kwargs)
         if table_prefix is not None:
             if not isinstance(table_prefix, six.string_types):
                 raise TypeError('table_prefix must be a string', 'received',
@@ -165,23 +153,24 @@ class Connection(object):
             self._cluster = cluster.copy()
 
     @staticmethod
-    def _reject_legacy_args(host, port, compat, transport, protocol):
-        """Check legacy HappyBase arguments and raise if set.
+    def _handle_legacy_args(arguments_dict):
+        """Check legacy HappyBase arguments and warn if set.
 
-        :raises: :class:`ValueError <exceptions.ValueError>` if any of the
-                 legacy parameters are specified with a value other than
-                 the defaults.
+        :type arguments_dict: dict
+        :param arguments_dict: Unused keyword arguments.
+
+        :raises: :class:`TypeError <exceptions.TypeError>` if a keyword other
+                 than ``host``, ``port``, ``compat``, ``transport`` or
+                 ``protocol`` is used.
         """
-        if host is not DEFAULT_HOST:
-            raise ValueError('Host cannot be set for gcloud HappyBase module')
-        if port is not DEFAULT_PORT:
-            raise ValueError('Port cannot be set for gcloud HappyBase module')
-        if compat is not DEFAULT_COMPAT:
-            raise ValueError('Compat cannot be set for gcloud '
-                             'HappyBase module')
-        if transport is not DEFAULT_TRANSPORT:
-            raise ValueError('Transport cannot be set for gcloud '
-                             'HappyBase module')
-        if protocol is not DEFAULT_PROTOCOL:
-            raise ValueError('Protocol cannot be set for gcloud '
-                             'HappyBase module')
+        common_args = _LEGACY_ARGS.intersection(six.iterkeys(arguments_dict))
+        if common_args:
+            all_args = ', '.join(common_args)
+            message = ('The HappyBase legacy arguments %s were used. These '
+                       'arguments are unused by gcloud.' % (all_args,))
+            _WARN(message)
+        for arg_name in common_args:
+            arguments_dict.pop(arg_name)
+        if arguments_dict:
+            unexpected_names = arguments_dict.keys()
+            raise TypeError('Received unexpected arguments', unexpected_names)

--- a/gcloud/bigtable/happybase/test_connection.py
+++ b/gcloud/bigtable/happybase/test_connection.py
@@ -16,6 +16,60 @@
 import unittest2
 
 
+class Test__get_cluster(unittest2.TestCase):
+
+    def _callFUT(self, timeout=None):
+        from gcloud.bigtable.happybase.connection import _get_cluster
+        return _get_cluster(timeout=timeout)
+
+    def _helper(self, timeout=None, clusters=(), failed_zones=()):
+        from functools import partial
+        from gcloud._testing import _Monkey
+        from gcloud.bigtable.happybase import connection as MUT
+
+        client_with_clusters = partial(_Client, clusters=clusters,
+                                       failed_zones=failed_zones)
+        with _Monkey(MUT, Client=client_with_clusters):
+            result = self._callFUT(timeout=timeout)
+
+        # If we've reached this point, then _callFUT didn't fail, so we know
+        # there is exactly one cluster.
+        cluster, = clusters
+        self.assertEqual(result, cluster)
+        client = cluster.client
+        self.assertEqual(client.args, ())
+        expected_kwargs = {'admin': True}
+        if timeout is not None:
+            expected_kwargs['timeout_seconds'] = timeout / 1000.0
+        self.assertEqual(client.kwargs, expected_kwargs)
+        self.assertEqual(client.start_calls, 1)
+        self.assertEqual(client.stop_calls, 1)
+
+    def test_default(self):
+        cluster = _Cluster()
+        self._helper(clusters=[cluster])
+
+    def test_with_timeout(self):
+        cluster = _Cluster()
+        self._helper(timeout=2103, clusters=[cluster])
+
+    def test_with_no_clusters(self):
+        with self.assertRaises(ValueError):
+            self._helper()
+
+    def test_with_too_many_clusters(self):
+        clusters = [_Cluster(), _Cluster()]
+        with self.assertRaises(ValueError):
+            self._helper(clusters=clusters)
+
+    def test_with_failed_zones(self):
+        cluster = _Cluster()
+        failed_zone = 'us-central1-c'
+        with self.assertRaises(ValueError):
+            self._helper(clusters=[cluster],
+                         failed_zones=[failed_zone])
+
+
 class TestConnection(unittest2.TestCase):
 
     def _getTargetClass(self):
@@ -26,24 +80,47 @@ class TestConnection(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_constructor_defaults(self):
-        connection = self._makeOne()
-        self.assertEqual(connection.timeout, None)
+        cluster = _Cluster()  # Avoid implicit environ check.
+        connection = self._makeOne(cluster=cluster)
+
         self.assertTrue(connection.autoconnect)
+        self.assertEqual(connection._cluster, cluster)
         self.assertEqual(connection.table_prefix, None)
         self.assertEqual(connection.table_prefix_separator, '_')
 
+    def test_constructor_missing_cluster(self):
+        from gcloud._testing import _Monkey
+        from gcloud.bigtable.happybase import connection as MUT
+
+        cluster = _Cluster()
+        timeout = object()
+        get_cluster_called = []
+
+        def mock_get_cluster(timeout):
+            get_cluster_called.append(timeout)
+            return cluster
+
+        with _Monkey(MUT, _get_cluster=mock_get_cluster):
+            connection = self._makeOne(autoconnect=False, cluster=None,
+                                       timeout=timeout)
+            self.assertEqual(connection.table_prefix, None)
+            self.assertEqual(connection.table_prefix_separator, '_')
+            self.assertEqual(connection._cluster, cluster)
+
+        self.assertEqual(get_cluster_called, [timeout])
+
     def test_constructor_explicit(self):
-        timeout = 12345
         autoconnect = False
         table_prefix = 'table-prefix'
         table_prefix_separator = 'sep'
+        cluster_copy = _Cluster()
+        cluster = _Cluster(copies=[cluster_copy])
 
         connection = self._makeOne(
-            timeout=timeout,
             autoconnect=autoconnect,
             table_prefix=table_prefix,
-            table_prefix_separator=table_prefix_separator)
-        self.assertEqual(connection.timeout, timeout)
+            table_prefix_separator=table_prefix_separator,
+            cluster=cluster)
         self.assertFalse(connection.autoconnect)
         self.assertEqual(connection.table_prefix, table_prefix)
         self.assertEqual(connection.table_prefix_separator,
@@ -69,6 +146,10 @@ class TestConnection(unittest2.TestCase):
         with self.assertRaises(ValueError):
             self._makeOne(protocol=object())
 
+    def test_constructor_with_timeout_and_cluster(self):
+        with self.assertRaises(ValueError):
+            self._makeOne(cluster=object(), timeout=object())
+
     def test_constructor_non_string_prefix(self):
         table_prefix = object()
 
@@ -82,3 +163,42 @@ class TestConnection(unittest2.TestCase):
         with self.assertRaises(TypeError):
             self._makeOne(autoconnect=False,
                           table_prefix_separator=table_prefix_separator)
+
+
+class _Client(object):
+
+    def __init__(self, *args, **kwargs):
+        self.clusters = kwargs.pop('clusters', [])
+        for cluster in self.clusters:
+            cluster.client = self
+        self.failed_zones = kwargs.pop('failed_zones', [])
+        self.args = args
+        self.kwargs = kwargs
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start(self):
+        self.start_calls += 1
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def list_clusters(self):
+        return self.clusters, self.failed_zones
+
+
+class _Cluster(object):
+
+    def __init__(self, copies=(), list_tables_result=()):
+        self.copies = list(copies)
+        # Included to support Connection.__del__
+        self._client = _Client()
+        self.list_tables_result = list_tables_result
+
+    def copy(self):
+        if self.copies:
+            result = self.copies[0]
+            self.copies[:] = self.copies[1:]
+            return result
+        else:
+            return self


### PR DESCRIPTION
~~@tseaver By adding this I go from 10 to 11 arguments (10 are part of the [original interface][1]) and I make [`pylint` angry][2].~~

----

Would you prefer I

- Use `**kwargs` for supporting the legacy signature (this breaks any argument order unless we also use `*args` and manually do the mapping, which would break existing code that uses `happybase`)
- Raise the global limit from 10 to 11
- `pylint: disable=` locally

----

@jgeewax How important is having the signature of our `gcloud.bigtable.happybase.Connection` the same as `happybase.Connection`?

[1]: https://github.com/wbolster/happybase/blob/9cbd718c10a3089f234f1eac1236b631e1f8e7cd/happybase/connection.py#L105-L108
[2]: https://github.com/GoogleCloudPlatform/gcloud-python/blob/896044579b5dfaddb75e8c7cbf72b614b0d04c5e/scripts/pylintrc_default#L377