### PR TITLE
Updating datastore URI template for v1beta3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ writes, strong consistency for reads and ancestor queries, and eventual
 consistency for all other queries.
 
 .. _Cloud Datastore: https://cloud.google.com/datastore/docs
-.. _Datastore API docs: https://cloud.google.com/datastore/docs/apis/v1beta2/
+.. _Datastore API docs: https://cloud.google.com/datastore/docs/apis/v1beta3/
 
 See the ``gcloud-python`` API `datastore documentation`_ to learn how to
 interact with the Cloud Datastore using this Client Library.

--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -41,18 +41,17 @@ class Connection(connection.Connection):
                          :attr:`API_BASE_URL`.
     """
 
-    API_BASE_URL = 'https://www.googleapis.com'
+    API_BASE_URL = 'https://datastore.googleapis.com'
     """The base of the API call URL."""
 
-    API_VERSION = 'v1beta2'
+    API_VERSION = 'v1beta3'
     """The version of the API, used in building the API call's URL."""
 
-    API_URL_TEMPLATE = ('{api_base}/datastore/{api_version}'
-                        '/datasets/{project}/{method}')
+    API_URL_TEMPLATE = ('{api_base}/{api_version}/projects'
+                        '/{project}:{method}')
     """A template for the URL of a particular API call."""
 
-    SCOPE = ('https://www.googleapis.com/auth/datastore',
-             'https://www.googleapis.com/auth/userinfo.email')
+    SCOPE = ('https://www.googleapis.com/auth/datastore',)
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
     def __init__(self, credentials=None, http=None, api_base_url=None):

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -47,10 +47,9 @@ class TestConnection(unittest2.TestCase):
                          conn.USER_AGENT)
 
     def test_default_url(self):
-        from gcloud.connection import API_BASE_URL
-
+        klass = self._getTargetClass()
         conn = self._makeOne()
-        self.assertEqual(conn.api_base_url, API_BASE_URL)
+        self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
     def test_custom_url_from_env(self):
         import os
@@ -143,11 +142,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            METHOD,
+            'projects',
+            PROJECT + ':' + METHOD,
         ])
         http = conn._http = Http({'status': '200'}, 'CONTENT')
         self.assertEqual(conn._request(PROJECT, METHOD, DATA), 'CONTENT')
@@ -189,11 +186,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            METHOD,
+            'projects',
+            PROJECT + ':' + METHOD,
         ])
         http = conn._http = Http({'status': '200'}, 'CONTENT')
         response = conn._rpc(PROJECT, METHOD, ReqPB(), RspPB)
@@ -208,11 +203,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            METHOD,
+            'projects',
+            PROJECT + ':' + METHOD,
         ])
         self.assertEqual(conn.build_api_url(PROJECT, METHOD), URI)
 
@@ -224,11 +217,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             BASE,
-            'datastore',
             VER,
-            'datasets',
-            PROJECT,
-            METHOD,
+            'projects',
+            PROJECT + ':' + METHOD,
         ])
         self.assertEqual(conn.build_api_url(PROJECT, METHOD, BASE, VER),
                          URI)
@@ -242,11 +233,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         found, missing, deferred = conn.lookup(PROJECT, [key_pb])
@@ -271,11 +260,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         found, missing, deferred = conn.lookup(PROJECT, [key_pb],
@@ -313,11 +300,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         found, missing, deferred = conn.lookup(PROJECT, [key_pb],
@@ -348,11 +333,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         (found,), missing, deferred = conn.lookup(PROJECT, [key_pb])
@@ -379,11 +362,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         found, missing, deferred = conn.lookup(PROJECT, [key_pb1, key_pb2])
@@ -414,11 +395,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         result, missing, deferred = conn.lookup(PROJECT, [key_pb1, key_pb2])
@@ -448,11 +427,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'lookup',
+            'projects',
+            PROJECT + ':lookup',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         result, missing, deferred = conn.lookup(PROJECT, [key_pb1, key_pb2])
@@ -490,11 +467,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'runQuery',
+            'projects',
+            PROJECT + ':runQuery',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         pbs, end, more, skipped = conn.run_query(PROJECT, q_pb,
@@ -531,11 +506,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'runQuery',
+            'projects',
+            PROJECT + ':runQuery',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         pbs, end, more, skipped = conn.run_query(
@@ -589,11 +562,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'runQuery',
+            'projects',
+            PROJECT + ':runQuery',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         pbs, end, more, skipped = conn.run_query(PROJECT, q_pb)
@@ -624,11 +595,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'runQuery',
+            'projects',
+            PROJECT + ':runQuery',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         pbs = conn.run_query(PROJECT, q_pb, 'NS')[0]
@@ -651,11 +620,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'beginTransaction',
+            'projects',
+            PROJECT + ':beginTransaction',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         self.assertEqual(conn.begin_transaction(PROJECT), TRANSACTION)
@@ -684,11 +651,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'commit',
+            'projects',
+            PROJECT + ':commit',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
 
@@ -732,11 +697,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'commit',
+            'projects',
+            PROJECT + ':commit',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
 
@@ -771,11 +734,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'rollback',
+            'projects',
+            PROJECT + ':rollback',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         self.assertEqual(conn.rollback(PROJECT, TRANSACTION), None)
@@ -794,11 +755,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'allocateIds',
+            'projects',
+            PROJECT + ':allocateIds',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         self.assertEqual(conn.allocate_ids(PROJECT, []), [])
@@ -827,11 +786,9 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne()
         URI = '/'.join([
             conn.api_base_url,
-            'datastore',
             conn.API_VERSION,
-            'datasets',
-            PROJECT,
-            'allocateIds',
+            'projects',
+            PROJECT + ':allocateIds',
         ])
         http = conn._http = Http({'status': '200'}, rsp_pb.SerializeToString())
         self.assertEqual(conn.allocate_ids(PROJECT, before_key_pbs),


### PR DESCRIPTION
Also updating the docs link in the README.

Was #1339 but this PR targets the `v1beta3` branch instead.