### PR TITLE
Dropping Py33 support, adding Py35.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -362,13 +362,13 @@ We support:
 
 -  `Python 2.6`_
 -  `Python 2.7`_
--  `Python 3.3`_
 -  `Python 3.4`_
+-  `Python 3.5`_
 
 .. _Python 2.6: https://docs.python.org/2.6/
 .. _Python 2.7: https://docs.python.org/2.7/
-.. _Python 3.3: https://docs.python.org/3.3/
 .. _Python 3.4: https://docs.python.org/3.4/
+.. _Python 3.5: https://docs.python.org/3.5/
 
 Supported versions can be found in our ``tox.ini`` `config`_.
 
@@ -385,13 +385,14 @@ We may `drop 2.6`_ as a supported version as well since Python 2.6 is no
 longer supported by the core development team.
 
 We also explicitly decided to support Python 3 beginning with version
-3.3. Reasons for this include:
+3.4. Reasons for this include:
 
 -  Encouraging use of newest versions of Python 3
--  Taking the lead of prominent open-source `projects`_
+-  Taking the lead of `prominent`_ open-source `projects`_
 -  `Unicode literal support`_ which allows for a cleaner codebase that
    works in both Python 2 and Python 3
 
+.. _prominent: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
 .. _projects: http://flask.pocoo.org/docs/0.10/python3/
 .. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
 .. _drop 2.6: https://github.com/GoogleCloudPlatform/gcloud-python/issues/995

--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,16 @@ We support:
 
 -  `Python 2.6`_
 -  `Python 2.7`_
--  `Python 3.3`_
 -  `Python 3.4`_
+-  `Python 3.5`_
 
 For more information, see `Supported Python Versions`_ in
 ``CONTRIBUTING``.
 
 .. _Python 2.6: https://docs.python.org/2.6/
 .. _Python 2.7: https://docs.python.org/2.7/
-.. _Python 3.3: https://docs.python.org/3.3/
 .. _Python 3.4: https://docs.python.org/3.4/
+.. _Python 3.5: https://docs.python.org/3.5/
 .. _Supported Python Versions: https://github.com/GoogleCloudPlatform/gcloud-python/blob/master/CONTRIBUTING.rst#supported-python-versions
 
 Example Applications

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py33,py34,cover,docs,lint
+    py26,py27,py34,py35,cover,docs,lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Fixes #1410.

NOTE: We never ran `tox -e py33` in Travis and this does not add `tox -e py35` (for now). It seems it'd be best to wait until https://github.com/travis-ci/travis-ci/issues/4794 is resolved before adding it.