### PR TITLE
Harden pubsub client against keys omitted in back-end responses

### DIFF
--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -77,7 +77,7 @@ class Client(JSONClient):
         resp = self.connection.api_request(method='GET', path=path,
                                            query_params=params)
         topics = [Topic.from_api_repr(resource, self)
-                  for resource in resp['topics']]
+                  for resource in resp.get('topics', ())]
         return topics, resp.get('nextPageToken')
 
     def list_subscriptions(self, page_size=None, page_token=None,

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -128,7 +128,7 @@ class Client(JSONClient):
         topics = {}
         subscriptions = [Subscription.from_api_repr(resource, self,
                                                     topics=topics)
-                         for resource in resp['subscriptions']]
+                         for resource in resp.get('subscriptions', ())]
         return subscriptions, resp.get('nextPageToken')
 
     def topic(self, name, timestamp_messages=False):

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -175,6 +175,27 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['query_params'],
                          {'pageSize': SIZE, 'pageToken': TOKEN1})
 
+    def test_list_subscriptions_w_missing_key(self):
+        PROJECT = 'PROJECT'
+        CREDS = _Credentials()
+
+        CLIENT_OBJ = self._makeOne(project=PROJECT, credentials=CREDS)
+
+        RETURNED = {}
+        # Replace the connection on the client with one of our own.
+        CLIENT_OBJ.connection = _Connection(RETURNED)
+
+        # Execute request.
+        subscriptions, next_page_token = CLIENT_OBJ.list_subscriptions()
+        # Test values are correct.
+        self.assertEqual(len(subscriptions), 0)
+        self.assertEqual(next_page_token, None)
+        self.assertEqual(len(CLIENT_OBJ.connection._requested), 1)
+        req = CLIENT_OBJ.connection._requested[0]
+        self.assertEqual(req['method'], 'GET')
+        self.assertEqual(req['path'], '/projects/%s/subscriptions' % PROJECT)
+        self.assertEqual(req['query_params'], {})
+
     def test_list_subscriptions_with_topic_name(self):
         from gcloud.pubsub.subscription import Subscription
         PROJECT = 'PROJECT'

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -82,6 +82,27 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['query_params'],
                          {'pageSize': SIZE, 'pageToken': TOKEN1})
 
+    def test_list_topics_missing_key(self):
+        PROJECT = 'PROJECT'
+        CREDS = _Credentials()
+
+        CLIENT_OBJ = self._makeOne(project=PROJECT, credentials=CREDS)
+
+        RETURNED = {}
+        # Replace the connection on the client with one of our own.
+        CLIENT_OBJ.connection = _Connection(RETURNED)
+
+        # Execute request.
+        topics, next_page_token = CLIENT_OBJ.list_topics()
+        # Test values are correct.
+        self.assertEqual(len(topics), 0)
+        self.assertEqual(next_page_token, None)
+        self.assertEqual(len(CLIENT_OBJ.connection._requested), 1)
+        req = CLIENT_OBJ.connection._requested[0]
+        self.assertEqual(req['method'], 'GET')
+        self.assertEqual(req['path'], '/projects/%s/topics' % PROJECT)
+        self.assertEqual(req['query_params'], {})
+
     def test_list_subscriptions_no_paging(self):
         from gcloud.pubsub.subscription import Subscription
         PROJECT = 'PROJECT'

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -118,6 +118,9 @@ class TestPubsub(unittest2.TestCase):
         self.assertFalse(topic.exists())
         topic.create()
         self.to_delete.append(topic)
+        empty, _ = Config.CLIENT.list_subscriptions(
+            topic_name=DEFAULT_TOPIC_NAME)
+        self.assertEqual(len(empty), 0)
         subscriptions_to_create = [
             'new%d' % (1000 * time.time(),),
             'newer%d' % (1000 * time.time(),),


### PR DESCRIPTION
See #1439.