### PR TITLE
Removing custom dataset ID environment variable.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -162,8 +162,6 @@ Running System Tests
 
   - ``GCLOUD_TESTS_PROJECT_ID``: Developers Console project ID (e.g.
     bamboo-shift-455).
-  - ``GCLOUD_TESTS_DATASET_ID``: The name of the dataset your tests connect to.
-    This is typically the same as ``GCLOUD_TESTS_PROJECT_ID``.
   - ``GOOGLE_APPLICATION_CREDENTIALS``: The path to a JSON key file;
     see ``system_tests/app_credentials.json.sample`` as an example. Such a file
     can be downloaded directly from the developer's console by clicking
@@ -195,7 +193,7 @@ Running System Tests
 
    # Create the indexes
    $ gcloud preview datastore create-indexes system_tests/data/index.yaml \
-   > --project=$GCLOUD_TESTS_DATASET_ID
+   > --project=$GCLOUD_TESTS_PROJECT_ID
 
    # Restore your environment to its previous state.
    $ unset CLOUDSDK_PYTHON_SITEPACKAGES

--- a/gcloud/datastore/demo/__init__.py
+++ b/gcloud/datastore/demo/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-from gcloud.environment_vars import TESTS_DATASET
+from gcloud.environment_vars import TESTS_PROJECT
 
 __all__ = ['PROJECT']
 
-PROJECT = os.getenv(TESTS_DATASET)
+PROJECT = os.getenv(TESTS_PROJECT)

--- a/gcloud/environment_vars.py
+++ b/gcloud/environment_vars.py
@@ -24,9 +24,6 @@ PROJECT = 'GCLOUD_PROJECT'
 TESTS_PROJECT = 'GCLOUD_TESTS_PROJECT_ID'
 """Environment variable defining project for tests."""
 
-DATASET = 'GCLOUD_DATASET_ID'
-"""Environment variable defining default dataset ID."""
-
 GCD_DATASET = 'DATASTORE_DATASET'
 """Environment variable defining default dataset ID under GCD."""
 
@@ -35,9 +32,6 @@ GCD_HOST = 'DATASTORE_HOST'
 
 PUBSUB_EMULATOR = 'PUBSUB_EMULATOR_HOST'
 """Environment variable defining host for Pub/Sub emulator."""
-
-TESTS_DATASET = 'GCLOUD_TESTS_DATASET_ID'
-"""Environment variable defining dataset ID for tests."""
 
 CREDENTIALS = 'GOOGLE_APPLICATION_CREDENTIALS'
 """Environment variable defining location of Google credentials."""

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -74,10 +74,6 @@ load-plugins=pylint.extensions.check_docs
 #                  identical implementation but different docstrings.
 # - star-args:  standard Python idioms for varargs:
 #                  ancestor = Query().filter(*order_props)
-# - method-hidden: Decorating a method in a class (e.g. in _DefaultsContainer)
-#                      @_lazy_property_deco
-#                      def dataset_id():
-#                          ...
 # - redefined-variable-type: This error is overzealous and complains at e.g.
 #                      if some_prop:
 #                          return int(value)
@@ -100,7 +96,6 @@ disable =
     redefined-builtin,
     similarities,
     star-args,
-    method-hidden,
     redefined-variable-type,
     wrong-import-position,
 

--- a/system_tests/clear_datastore.py
+++ b/system_tests/clear_datastore.py
@@ -21,7 +21,7 @@ import os
 from six.moves import input
 
 from gcloud import datastore
-from gcloud.environment_vars import TESTS_DATASET
+from gcloud.environment_vars import TESTS_PROJECT
 
 
 FETCH_MAX = 20
@@ -90,7 +90,7 @@ def remove_kind(kind, client):
 def remove_all_entities(client=None):
     if client is None:
         # Get a client that uses the test dataset.
-        client = datastore.Client(project=os.getenv(TESTS_DATASET))
+        client = datastore.Client(project=os.getenv(TESTS_PROJECT))
     for kind in ALL_KINDS:
         remove_kind(kind, client)
 

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -19,12 +19,12 @@ import time
 import httplib2
 import unittest2
 
+from gcloud import _helpers
 from gcloud._helpers import UTC
 from gcloud import datastore
-from gcloud.datastore import client as client_mod
 from gcloud.datastore.helpers import GeoPoint
 from gcloud.environment_vars import GCD_DATASET
-from gcloud.environment_vars import TESTS_DATASET
+from gcloud.environment_vars import TESTS_PROJECT
 from gcloud.exceptions import Conflict
 # This assumes the command is being run via tox hence the
 # repository root is the current directory.
@@ -56,7 +56,7 @@ def setUpModule():
     # Isolated namespace so concurrent test runs don't collide.
     test_namespace = 'ns%d' % (1000 * time.time(),)
     if emulator_dataset is None:
-        client_mod.DATASET = TESTS_DATASET
+        _helpers.PROJECT = TESTS_PROJECT
         Config.CLIENT = datastore.Client(namespace=test_namespace)
     else:
         credentials = EmulatorCreds()

--- a/system_tests/local_test_setup.sample
+++ b/system_tests/local_test_setup.sample
@@ -1,5 +1,4 @@
 export GOOGLE_APPLICATION_CREDENTIALS="app_credentials.json.sample"
 export GCLOUD_TESTS_PROJECT_ID="my-project"
-export GCLOUD_TESTS_DATASET_ID=${GCLOUD_TESTS_PROJECT_ID}
 export GCLOUD_REMOTE_FOR_LINT="upstream"
 export GCLOUD_BRANCH_FOR_LINT="master"

--- a/system_tests/populate_datastore.py
+++ b/system_tests/populate_datastore.py
@@ -22,7 +22,7 @@ import os
 from six.moves import zip
 
 from gcloud import datastore
-from gcloud.environment_vars import TESTS_DATASET
+from gcloud.environment_vars import TESTS_PROJECT
 
 
 ANCESTOR = ('Book', 'GoT')
@@ -91,7 +91,7 @@ def print_func(message):
 def add_characters(client=None):
     if client is None:
         # Get a client that uses the test dataset.
-        client = datastore.Client(project=os.getenv(TESTS_DATASET))
+        client = datastore.Client(project=os.getenv(TESTS_PROJECT))
     with client.transaction() as xact:
         for key_path, character in zip(KEY_PATHS, CHARACTERS):
             if key_path[-1] != character['name']:

--- a/system_tests/run_system_test.py
+++ b/system_tests/run_system_test.py
@@ -25,12 +25,6 @@ from system_tests import storage
 from system_tests import system_test_utils
 
 
-REQUIREMENTS = {
-    'datastore': ['dataset_id', 'credentials'],
-    'storage': ['project', 'credentials'],
-    'pubsub': ['project', 'credentials'],
-    'bigquery': ['project', 'credentials'],
-}
 TEST_MODULES = {
     'datastore': datastore,
     'storage': storage,
@@ -43,7 +37,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         description='GCloud test runner against actual project.')
     parser.add_argument('--package', dest='package',
-                        choices=REQUIREMENTS.keys(),
+                        choices=TEST_MODULES.keys(),
                         default='datastore', help='Package to be tested.')
     parser.add_argument(
         '--ignore-requirements',
@@ -55,8 +49,7 @@ def get_parser():
 def run_module_tests(module_name, ignore_requirements=False):
     if not ignore_requirements:
         # Make sure environ is set before running test.
-        requirements = REQUIREMENTS[module_name]
-        system_test_utils.check_environ(*requirements)
+        system_test_utils.check_environ()
 
     suite = unittest2.TestSuite()
     test_mod = TEST_MODULES[module_name]

--- a/system_tests/system_test_utils.py
+++ b/system_tests/system_test_utils.py
@@ -17,13 +17,11 @@ import os
 import sys
 
 from gcloud.environment_vars import CREDENTIALS as TEST_CREDENTIALS
-from gcloud.environment_vars import TESTS_DATASET
 from gcloud.environment_vars import TESTS_PROJECT
 
 
 # From shell environ. May be None.
 PROJECT_ID = os.getenv(TESTS_PROJECT)
-DATASET_ID = os.getenv(TESTS_DATASET)
 CREDENTIALS = os.getenv(TEST_CREDENTIALS)
 
 ENVIRON_ERROR_MSG = """\
@@ -46,21 +44,14 @@ class EmulatorCreds(object):
         return False
 
 
-def check_environ(*requirements):
-
+def check_environ():
     missing = []
 
-    if 'dataset_id' in requirements:
-        if DATASET_ID is None:
-            missing.append(TESTS_DATASET)
+    if PROJECT_ID is None:
+        missing.append(TESTS_PROJECT)
 
-    if 'project' in requirements:
-        if PROJECT_ID is None:
-            missing.append(TESTS_PROJECT)
-
-    if 'credentials' in requirements:
-        if CREDENTIALS is None or not os.path.isfile(CREDENTIALS):
-            missing.append(TEST_CREDENTIALS)
+    if CREDENTIALS is None or not os.path.isfile(CREDENTIALS):
+        missing.append(TEST_CREDENTIALS)
 
     if missing:
         print(ENVIRON_ERROR_MSG % ', '.join(missing), file=sys.stderr)


### PR DESCRIPTION
This is no longer needed since the project ID is used by the datastore `v1beta3` API.