### PR TITLE
Rename suppressed pylint error to match value expected by 1.5.4.

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -389,7 +389,7 @@ def _datetime_to_pb_timestamp(when):
 
 
 try:
-    from pytz import UTC  # pylint: disable=unused-import,wrong-import-position
+    from pytz import UTC  # pylint: disable=unused-import,wrong-import-order
 except ImportError:
     UTC = _UTC()  # Singleton instance to be used throughout.
 


### PR DESCRIPTION
Suppresses output from pylint 1.5.4 like:

```
lint runtests: commands[1] | python /home/tseaver/projects/agendaless/Google/src/gcloud-python/scripts/run_pylint.py
Diff base not specified, listing all files in repository.
************* Module gcloud._helpers
I: 28, 0: Locally disabling import-error (E0401) (locally-disabled)
I: 90, 0: Locally disabling unused-argument (W0613) (locally-disabled)
I:100, 0: Locally disabling unused-argument (W0613) (locally-disabled)
I:104, 0: Locally disabling unused-argument (W0613) (locally-disabled)
I:392, 0: Locally disabling unused-import (W0611) (locally-disabled)
I:392, 0: Locally disabling wrong-import-position (C0413) (locally-disabled)
C:392, 4: external import "from pytz import UTC" comes before "from gcloud.environment_vars import PROJECT" (wrong-import-order)
```