### PR TITLE
Adding Bigtable Cell class.

### DIFF
--- a/gcloud/bigtable/row_data.py
+++ b/gcloud/bigtable/row_data.py
@@ -1,0 +1,63 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container for Google Cloud Bigtable Cells and Streaming Row Contents."""
+
+
+from gcloud._helpers import _datetime_from_microseconds
+
+
+class Cell(object):
+    """Representation of a Google Cloud Bigtable Cell.
+
+    :type value: bytes
+    :param value: The value stored in the cell.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp: The timestamp when the cell was stored.
+
+    :type labels: list
+    :param labels: (Optional) List of strings. Labels applied to the cell.
+    """
+
+    def __init__(self, value, timestamp, labels=()):
+        self.value = value
+        self.timestamp = timestamp
+        self.labels = list(labels)
+
+    @classmethod
+    def from_pb(cls, cell_pb):
+        """Create a new cell from a Cell protobuf.
+
+        :type cell_pb: :class:`._generated.bigtable_data_pb2.Cell`
+        :param cell_pb: The protobuf to convert.
+
+        :rtype: :class:`Cell`
+        :returns: The cell corresponding to the protobuf.
+        """
+        timestamp = _datetime_from_microseconds(cell_pb.timestamp_micros)
+        if cell_pb.labels:
+            return cls(cell_pb.value, timestamp, labels=cell_pb.labels)
+        else:
+            return cls(cell_pb.value, timestamp)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return (other.value == self.value and
+                other.timestamp == self.timestamp and
+                other.labels == self.labels)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/gcloud/bigtable/test_row_data.py
+++ b/gcloud/bigtable/test_row_data.py
@@ -1,0 +1,91 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest2
+
+
+class TestCell(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud.bigtable.row_data import Cell
+        return Cell
+
+    def _makeOne(self, *args, **kwargs):
+        return self._getTargetClass()(*args, **kwargs)
+
+    def _from_pb_test_helper(self, labels=None):
+        import datetime
+        from gcloud._helpers import _EPOCH
+        from gcloud.bigtable._generated import bigtable_data_pb2 as data_pb2
+
+        timestamp_micros = 18738724000  # Make sure millis granularity
+        timestamp = _EPOCH + datetime.timedelta(microseconds=timestamp_micros)
+        value = b'value-bytes'
+
+        if labels is None:
+            cell_pb = data_pb2.Cell(value=value,
+                                    timestamp_micros=timestamp_micros)
+            cell_expected = self._makeOne(value, timestamp)
+        else:
+            cell_pb = data_pb2.Cell(value=value,
+                                    timestamp_micros=timestamp_micros,
+                                    labels=labels)
+            cell_expected = self._makeOne(value, timestamp, labels=labels)
+
+        klass = self._getTargetClass()
+        result = klass.from_pb(cell_pb)
+        self.assertEqual(result, cell_expected)
+
+    def test_from_pb(self):
+        self._from_pb_test_helper()
+
+    def test_from_pb_with_labels(self):
+        labels = [u'label1', u'label2']
+        self._from_pb_test_helper(labels)
+
+    def test_constructor(self):
+        value = object()
+        timestamp = object()
+        cell = self._makeOne(value, timestamp)
+        self.assertEqual(cell.value, value)
+        self.assertEqual(cell.timestamp, timestamp)
+
+    def test___eq__(self):
+        value = object()
+        timestamp = object()
+        cell1 = self._makeOne(value, timestamp)
+        cell2 = self._makeOne(value, timestamp)
+        self.assertEqual(cell1, cell2)
+
+    def test___eq__type_differ(self):
+        cell1 = self._makeOne(None, None)
+        cell2 = object()
+        self.assertNotEqual(cell1, cell2)
+
+    def test___ne__same_value(self):
+        value = object()
+        timestamp = object()
+        cell1 = self._makeOne(value, timestamp)
+        cell2 = self._makeOne(value, timestamp)
+        comparison_val = (cell1 != cell2)
+        self.assertFalse(comparison_val)
+
+    def test___ne__(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        timestamp = object()
+        cell1 = self._makeOne(value1, timestamp)
+        cell2 = self._makeOne(value2, timestamp)
+        self.assertNotEqual(cell1, cell2)

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -35,6 +35,7 @@ IGNORED_MODULES = frozenset([
     'gcloud.bigtable.column_family',
     'gcloud.bigtable.happybase.connection',
     'gcloud.bigtable.row',
+    'gcloud.bigtable.row_data',
     'gcloud.bigtable.table',
     'gcloud.datastore.demo.demo',
     'gcloud.demo',


### PR DESCRIPTION
Used to hold data in rows retrieved.

@tseaver This module could definitely use some design review (none of the content here yet, but worth discussing now or at least thinking about).

Right now, the implementation is as follows:
- Rows are read from a `Table` (and a `Cell` is like a "column" in a row, so there can be many), so the helpers needed to parse a row that was read are in `row_data.py`
- Mutations (in rows) are created directly on a `Row`, and this is all done in `row.py` (all code submitted or merged)