### PR TITLE
Implementing open()/close() on HappyBase connection.

### DIFF
--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -127,6 +127,8 @@ class Connection(object):
              parameters are specified with a value other than the defaults.
     """
 
+    _cluster = None
+
     def __init__(self, timeout=None, autoconnect=True, table_prefix=None,
                  table_prefix_separator='_', cluster=None, **kwargs):
         self._handle_legacy_args(kwargs)
@@ -198,10 +200,5 @@ class Connection(object):
         self._cluster._client.stop()
 
     def __del__(self):
-        try:
-            self._initialized
-        except AttributeError:
-            # Failure from constructor
-            return
-        else:
+        if self._cluster is not None:
             self.close()

--- a/gcloud/bigtable/happybase/test_connection.py
+++ b/gcloud/bigtable/happybase/test_connection.py
@@ -197,20 +197,18 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cluster._client.stop_calls, 1)
         self.assertEqual(cluster._client.start_calls, 0)
 
-    def test___del__good_initialization(self):
+    def test___del__with_cluster(self):
         cluster = _Cluster()  # Avoid implicit environ check.
         connection = self._makeOne(autoconnect=False, cluster=cluster)
         self.assertEqual(cluster._client.stop_calls, 0)
         connection.__del__()
         self.assertEqual(cluster._client.stop_calls, 1)
 
-    def test___del__bad_initialization(self):
+    def test___del__no_cluster(self):
         cluster = _Cluster()  # Avoid implicit environ check.
         connection = self._makeOne(autoconnect=False, cluster=cluster)
-        # Fake that initialization failed.
-        del connection._initialized
-
         self.assertEqual(cluster._client.stop_calls, 0)
+        del connection._cluster
         connection.__del__()
         self.assertEqual(cluster._client.stop_calls, 0)
 


### PR DESCRIPTION
Also using `open()` in constructor and `close()` in destructor, as is done in the thrift version of HappyBase.