### PR TITLE
Initial sketch of logging API usage docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,13 @@
 .. toctree::
   :maxdepth: 0
   :hidden:
+  :caption: Cloud Logging
+
+  logging-usage
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
   :caption: External Links
 
   GitHub <https://github.com/GoogleCloudPlatform/gcloud-python/>

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -81,7 +81,7 @@ Fetch entries across multiple projects.
 
 Filter entries retrieved using the `Advanced Logs Filters`_ syntax
 
-.. Advanced Logs Filters: https://cloud.google.com/logging/docs/view/advanced_filters
+.. _Advanced Logs Filters: https://cloud.google.com/logging/docs/view/advanced_filters
 
 .. doctest::
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -163,7 +163,7 @@ Refresh local information about a metric:
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> metric = client.metric("robots")
-   >>> metric.get()  # API call
+   >>> metric.reload()  # API call
    >>> metric.description
    "Robots all up in your server"
    >>> metric.filter
@@ -178,7 +178,7 @@ Update a metric:
    >>> metric = client.metric("robots")
    >>> metric.exists()  # API call
    True
-   >>> metric.get()  # API call
+   >>> metric.reload()  # API call
    >>> metric.description = "Danger, Will Robinson!"
    >>> metric.update()  # API call
 
@@ -269,7 +269,7 @@ Refresh local information about a sink:
    >>> sink = client.sink('robots-storage')
    >>> sink.filter is None
    True
-   >>> sink.get()  # API call
+   >>> sink.reload()  # API call
    >>> sink.filter
    'log:apache-access AND textPayload:robot'
    >>> sink.destination
@@ -282,7 +282,7 @@ Update a sink:
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> sink = client.sink("robots")
-   >>> sink.get()  # API call
+   >>> sink.reload()  # API call
    >>> sink.filter = "log:apache-access"
    >>> sink.update()  # API call
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -60,10 +60,11 @@ Fetch entries for the default project.
    >>> client = logging.Client()
    >>> entries, token = client.list_entries()  # API call
    >>> for entry in entries:
-   ...    timestamp = entry.timestamp.ISO()
-   ...    print(timestamp, entry.text_payload, entry.struct_payload)
-   ('2016-02-17T20:35:49.031864072Z', 'A simple entry', None)
-   ('2016-02-17T20:38:15.944418531Z,' None, {'message': 'My second entry', 'weather': 'partly cloudy'})
+   ...    timestamp = entry.timestamp.isoformat()
+   ...    print('%sZ: %s | %s" %
+   ...          (timestamp, entry.text_payload, entry.struct_payload))
+   2016-02-17T20:35:49.031864072Z: A simple entry | None
+   2016-02-17T20:38:15.944418531Z: None | {'message': 'My second entry', 'weather': 'partly cloudy'}
 
 
 Fetch entries across multiple projects.
@@ -252,10 +253,10 @@ List all sinks for a project:
    >>> client = logging.Client()
    >>> sinks, token = client.list_sinks()
    >>> for sink in sinks:
-   ...     print(sink.name, sink.destination)
-   ('robots-storage', 'storage.googleapis.com/my-bucket-name')
-   ('robots-bq', 'bigquery.googleapis.com/projects/my-project/datasets/my-dataset')
-   ('robots-pubsub', 'pubsub.googleapis.com/projects/my-project/topics/my-topic')
+   ...     print('%s: %s' % (sink.name, sink.destination))
+   robots-storage: storage.googleapis.com/my-bucket-name
+   robots-bq: bigquery.googleapis.com/projects/my-project/datasets/my-dataset
+   robots-pubsub: pubsub.googleapis.com/projects/my-project/topics/my-topic
 
 Refresh local information about a sink:
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -1,28 +1,31 @@
 Using the API
 =============
 
-Authentication / Configuration
-------------------------------
+Authentication and Configuration
+--------------------------------
 
-- Use :class:`Client <gcloud.logging.client.Client>` objects to configure
-  your applications.
+- For an overview of authentication in ``gcloud-python``,
+  see :doc:`gcloud-auth`.
 
-- :class:`Client <gcloud.logging.client.Client>` objects hold both a ``project``
-  and an authenticated connection to the Logging service.
+- In addition to any authentication configuration, you should also set the
+  :envvar:`GCLOUD_PROJECT` environment variable for the project you'd like
+  to interact with. If you are Google App Engine or Google Compute Engine
+  this will be detected automatically.
 
-- The authentication credentials can be implicitly determined from the
-  environment or directly via
-  :meth:`from_service_account_json <gcloud.logging.client.Client.from_service_account_json>`
-  and
-  :meth:`from_service_account_p12 <gcloud.logging.client.Client.from_service_account_p12>`.
-
-- After setting ``GOOGLE_APPLICATION_CREDENTIALS`` and ``GCLOUD_PROJECT``
-  environment variables, create a :class:`Client <gcloud.logging.client.Client>`
+- After configuring your environment, create a
+  :class:`Client <gcloud.logging.client.Client>`
 
   .. doctest::
 
      >>> from gcloud import logging
      >>> client = logging.Client()
+
+  or pass in ``credentials`` and ``project`` explicitly
+
+  .. doctest::
+
+     >>> from gcloud import logging
+     >>> client = logging.Client(project='my-project', credentials=creds)
 
 Writing log entries
 -------------------

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -121,7 +121,7 @@ Delete all entries for a logger
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> logger = client.logger('log_name')
-   >>> logger.delete()  # API call
+   >>> logger.delete_entries()  # API call
 
 
 Manage log metrics

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -151,7 +151,7 @@ List all metrics for a project:
    >>> client = logging.Client()
    >>> metrics, token = client.list_metrics()
    >>> len(metrics)
-   0
+   1
    >>> metric = metrics[0]
    >>> metric.name
    "robots"

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -273,7 +273,7 @@ Refresh local information about a sink:
    >>> sink.filter
    'log:apache-access AND textPayload:robot'
    >>> sink.destination
-   'storage.googleapis.com/my-bucket-name')
+   'storage.googleapis.com/my-bucket-name'
 
 Update a sink:
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -107,7 +107,7 @@ Retrieve entities in batches of 10, iterating until done.
    >>> retrieved = []
    >>> token = None
    >>> while True:
-   ...     entries, token = client.list_entries(page_size=10)  # API call
+   ...     entries, token = client.list_entries(page_size=10, page_token=token)  # API call
    ...     retrieved.extend(entries)
    ...     if token is None:
    ...         break

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -96,7 +96,7 @@ Sort entries in descending timestamp order.
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> entries, token = client.list_entries(order_by='timestamp desc')  # API call
+   >>> entries, token = client.list_entries(order_by=Client.DESCENDING)  # API call
 
 Retrieve entities in batches of 10, iterating until done.
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -78,8 +78,9 @@ Fetch entries across multiple projects.
    >>> entries, token = client.list_entries(
    ...     project_ids=['one-project', 'another-project'])  # API call
 
-Filter entries retrieved using the "Advance Logs Filters" syntax (see
-https://cloud.google.com/logging/docs/view/advanced_filters).
+Filter entries retrieved using the `Advanced Logs Filters`_ syntax
+
+.. Advanced Logs Filters: https://cloud.google.com/logging/docs/view/advanced_filters
 
 .. doctest::
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -48,7 +48,8 @@ Write a dictionary entry to a log.
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> log = client.log('log_name')
-   >>> log.struct(message="My second entry",
+   >>> log.struct(
+   ...     message="My second entry",
    ...     weather="partly cloudy")  # API call
 
 
@@ -135,7 +136,8 @@ Create a metric:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> metric = client.metric("robots", "Robots all up in your server",
+   >>> metric = client.metric(
+   ...     "robots", "Robots all up in your server",
    ...     filter='log:apache-access AND textPayload:robot')
    >>> metric.exists()  # API call
    False
@@ -208,7 +210,8 @@ Create a Cloud Storage sink:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> sink = client.sink("robots-storage",
+   >>> sink = client.sink(
+   ...     "robots-storage",
    ...     filter='log:apache-access AND textPayload:robot')
    >>> sink.storage_bucket = "my-bucket-name"
    >>> sink.exists()  # API call
@@ -223,7 +226,8 @@ Create a BigQuery sink:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> sink = client.sink("robots-bq",
+   >>> sink = client.sink(
+   ...     "robots-bq",
    ...     filter='log:apache-access AND textPayload:robot')
    >>> sink.bigquery_dataset = "projects/my-project/datasets/my-dataset"
    >>> sink.exists()  # API call
@@ -238,7 +242,8 @@ Create a Cloud Pub/Sub sink:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> sink = client.sink("robots-pubsub",
+   >>> sink = client.sink(
+   ...     "robots-pubsub",
    ...     filter='log:apache-access AND textPayload:robot')
    >>> sink.pubsub_topic = 'projects/my-project/topics/my-topic'
    >>> sink.exists()  # API call
@@ -292,7 +297,8 @@ Delete a sink:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> sink = client.sink("robots",
+   >>> sink = client.sink(
+   ...     "robots",
    ...     filter='log:apache-access AND textPayload:robot')
    >>> sink.exists()  # API call
    True

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -39,7 +39,7 @@ Write a simple text entry to a logger.
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> logger = client.logger('log_name')
-   >>> logger.text("A simple entry")  # API call
+   >>> logger.log_text("A simple entry")  # API call
 
 Write a dictionary entry to a logger.
 
@@ -48,7 +48,7 @@ Write a dictionary entry to a logger.
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> logger = client.logger('log_name')
-   >>> logger.struct(
+   >>> logger.log_struct(
    ...     message="My second entry",
    ...     weather="partly cloudy")  # API call
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -32,23 +32,23 @@ Authentication and Configuration
 Writing log entries
 -------------------
 
-Write a simple text entry to a log.
+Write a simple text entry to a logger.
 
 .. doctest::
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> log = client.log('log_name')
-   >>> log.text("A simple entry")  # API call
+   >>> logger = client.logger('log_name')
+   >>> logger.text("A simple entry")  # API call
 
-Write a dictionary entry to a log.
+Write a dictionary entry to a logger.
 
 .. doctest::
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> log = client.log('log_name')
-   >>> log.struct(
+   >>> logger = client.logger('log_name')
+   >>> logger.struct(
    ...     message="My second entry",
    ...     weather="partly cloudy")  # API call
 
@@ -113,15 +113,15 @@ Retrieve entities in batches of 10, iterating until done.
    ...         break
 
 
-Delete all entries for a log
-----------------------------
+Delete all entries for a logger
+-------------------------------
 
 .. doctest::
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> log = client.log('log_name')
-   >>> log.delete()  # API call
+   >>> logger = client.logger('log_name')
+   >>> logger.delete()  # API call
 
 
 Manage log metrics

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -1,0 +1,295 @@
+Using the API
+=============
+
+Authentication / Configuration
+------------------------------
+
+- Use :class:`Client <gcloud.logging.client.Client>` objects to configure
+  your applications.
+
+- :class:`Client <gcloud.logging.client.Client>` objects hold both a ``project``
+  and an authenticated connection to the Logging service.
+
+- The authentication credentials can be implicitly determined from the
+  environment or directly via
+  :meth:`from_service_account_json <gcloud.logging.client.Client.from_service_account_json>`
+  and
+  :meth:`from_service_account_p12 <gcloud.logging.client.Client.from_service_account_p12>`.
+
+- After setting ``GOOGLE_APPLICATION_CREDENTIALS`` and ``GCLOUD_PROJECT``
+  environment variables, create a :class:`Client <gcloud.logging.client.Client>`
+
+  .. doctest::
+
+     >>> from gcloud import logging
+     >>> client = logging.Client()
+
+Writing log entries
+-------------------
+
+Write a simple text entry to a log.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> log = client.log('log_name')
+   >>> log.text("A simple entry")  # API call
+
+Write a dictionary entry to a log.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> log = client.log('log_name')
+   >>> log.struct(message="My second entry",
+   ...     weather="partly cloudy")  # API call
+
+Retrieving log entries
+----------------------
+
+Fetch entries for the default project.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> entries, token = client.list_entries()  # API call
+   >>> for entry in entries:
+   ...    timestamp = entry.timestamp.ISO()
+   ...    print(timestamp, entry.text_payload, entry.struct_payload)
+   ('2016-02-17T20:35:49.031864072Z', 'A simple entry', None)
+   ('2016-02-17T20:38:15.944418531Z,' None, {'message': 'My second entry', 'weather': 'partly cloudy'})
+
+
+Fetch entries across multiple projects.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> entries, token = client.list_entries(
+   ...     project_ids=['one-project', 'another-project'])  # API call
+
+
+Filter entries retrieved using the "Advance Logs Filters" syntax (see
+https://cloud.google.com/logging/docs/view/advanced_filters).
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> FILTER = "log:log_name AND textPayload:simple"
+   >>> entries, token = client.list_entries(filter=FILTER)  # API call
+
+Sort entries in descending timestamp order.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> entries, token = client.list_entries(order_by='timestamp desc')  # API call
+
+Retrieve entities in batches of 10, iterating until done.
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> retrieved = []
+   >>> token = None
+   >>> while True:
+   ...     entries, token = client.list_entries(page_size=10)  # API call
+   ...     retrieved.extend(entries)
+   ...     if token is None:
+   ...         break
+
+
+Deleting all entries for a log
+------------------------------
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> log = client.log('log_name')
+   >>> log.delete()  # API call
+
+
+Manage log metrics
+------------------
+
+Metrics are counters of entries which match a given filter.  They can be
+used within Cloud Monitoring to create charts and alerts.
+
+Create a metric:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> metric = client.metric("robots", "Robots all up in your server",
+   ...     filter='log:apache-access AND textPayload:robot')
+   >>> metric.exists()  # API call
+   False
+   >>> metric.create()  # API call
+   >>> metric.exists()  # API call
+   True
+
+List all metrics for a project:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> metrics, token = client.list_metrics()
+   >>> len(metrics)
+   0
+   >>> metric = metrics[0]
+   >>> metric.name
+   "robots"
+
+Refresh local information about a metric:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> metric = client.metric("robots")
+   >>> metric.get()  # API call
+   >>> metric.description
+   "Robots all up in your server"
+   >>> metric.filter
+   "log:apache-access AND textPayload:robot"
+
+Update a metric:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> metric = client.metric("robots")
+   >>> metric.exists()  # API call
+   True
+   >>> metric.get()  # API call
+   >>> metric.description = "Danger, Will Robinson!"
+   >>> metric.update()  # API call
+
+Delete a metric:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> metric = client.metric("robots")
+   >>> metric.exists()  # API call
+   True
+   >>> metric.delete()  # API call
+   >>> metric.exists()  # API call
+   False
+
+
+Export log entries using sinks
+------------------------------
+
+Sinks allow exporting entries which match a given filter to Cloud Storage
+buckets, BigQuery datasets, or Pubsub topics.
+
+Create a CloudStorage sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink("robots-storage",
+   ...     filter='log:apache-access AND textPayload:robot')
+   >>> sink.storage_bucket = "my-bucket-name"
+   >>> sink.exists()  # API call
+   False
+   >>> sink.create()  # API call
+   >>> sink.exists()  # API call
+   True
+
+Create a BigQuery sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink("robots-bq",
+   ...     filter='log:apache-access AND textPayload:robot')
+   >>> sink.bigquery_dataset = "projects/my-project/datasets/my-dataset"
+   >>> sink.exists()  # API call
+   False
+   >>> sink.create()  # API call
+   >>> sink.exists()  # API call
+   True
+
+Create a Pubsub sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink("robots-pubsub",
+   ...     filter='log:apache-access AND textPayload:robot')
+   >>> sink.pubsub_topic = 'projects/my-project/topics/my-topic'
+   >>> sink.exists()  # API call
+   False
+   >>> sink.create()  # API call
+   >>> sink.exists()  # API call
+   True
+
+List all sinks for a project:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sinks, token = client.list_sinks()
+   >>> for sink in sinks:
+   ...     print(sink.name, sink.destination)
+   ('robots-storage', 'storage.googleapis.com/my-bucket-name')
+   ('robots-bq', 'bigquery.googleapis.com/projects/my-project/datasets/my-dataset')
+   ('robots-pubsub', 'pubsub.googleapis.com/projects/my-project/topics/my-topic')
+
+Refresh local information about a sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink('robots-storage')
+   >>> sink.filter is None
+   True
+   >>> sink.get()  # API call
+   >>> sink.filter
+   'log:apache-access AND textPayload:robot'
+   >>> sink.destination
+   'storage.googleapis.com/my-bucket-name')
+
+Update a sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink("robots")
+   >>> sink.get()  # API call
+   >>> sink.filter = "log:apache-access"
+   >>> sink.update()  # API call
+
+Delete a sink:
+
+.. doctest::
+
+   >>> from gcloud import logging
+   >>> client = logging.Client()
+   >>> sink = client.sink("robots",
+   ...     filter='log:apache-access AND textPayload:robot')
+   >>> sink.exists()  # API call
+   True
+   >>> sink.delete()  # API call
+   >>> sink.exists()  # API call
+   False

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -200,9 +200,9 @@ Export log entries using sinks
 ------------------------------
 
 Sinks allow exporting entries which match a given filter to Cloud Storage
-buckets, BigQuery datasets, or Pub/Sub topics.
+buckets, BigQuery datasets, or Cloud Pub/Sub topics.
 
-Create a CloudStorage sink:
+Create a Cloud Storage sink:
 
 .. doctest::
 
@@ -232,7 +232,7 @@ Create a BigQuery sink:
    >>> sink.exists()  # API call
    True
 
-Create a Pub/Sub sink:
+Create a Cloud Pub/Sub sink:
 
 .. doctest::
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -64,7 +64,7 @@ Fetch entries for the default project.
    >>> entries, token = client.list_entries()  # API call
    >>> for entry in entries:
    ...    timestamp = entry.timestamp.isoformat()
-   ...    print('%sZ: %s | %s" %
+   ...    print('%sZ: %s | %s' %
    ...          (timestamp, entry.text_payload, entry.struct_payload))
    2016-02-17T20:35:49.031864072Z: A simple entry | None
    2016-02-17T20:38:15.944418531Z: None | {'message': 'My second entry', 'weather': 'partly cloudy'}

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -96,7 +96,7 @@ Sort entries in descending timestamp order.
 
    >>> from gcloud import logging
    >>> client = logging.Client()
-   >>> entries, token = client.list_entries(order_by=Client.DESCENDING)  # API call
+   >>> entries, token = client.list_entries(order_by=logging.DESCENDING)  # API call
 
 Retrieve entities in batches of 10, iterating until done.
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -200,7 +200,7 @@ Export log entries using sinks
 ------------------------------
 
 Sinks allow exporting entries which match a given filter to Cloud Storage
-buckets, BigQuery datasets, or Pubsub topics.
+buckets, BigQuery datasets, or Pub/Sub topics.
 
 Create a CloudStorage sink:
 
@@ -232,7 +232,7 @@ Create a BigQuery sink:
    >>> sink.exists()  # API call
    True
 
-Create a Pubsub sink:
+Create a Pub/Sub sink:
 
 .. doctest::
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -1,6 +1,7 @@
 Using the API
 =============
 
+
 Authentication and Configuration
 --------------------------------
 
@@ -27,6 +28,7 @@ Authentication and Configuration
      >>> from gcloud import logging
      >>> client = logging.Client(project='my-project', credentials=creds)
 
+
 Writing log entries
 -------------------
 
@@ -49,6 +51,7 @@ Write a dictionary entry to a log.
    >>> log.struct(message="My second entry",
    ...     weather="partly cloudy")  # API call
 
+
 Retrieving log entries
 ----------------------
 
@@ -66,7 +69,6 @@ Fetch entries for the default project.
    2016-02-17T20:35:49.031864072Z: A simple entry | None
    2016-02-17T20:38:15.944418531Z: None | {'message': 'My second entry', 'weather': 'partly cloudy'}
 
-
 Fetch entries across multiple projects.
 
 .. doctest::
@@ -75,7 +77,6 @@ Fetch entries across multiple projects.
    >>> client = logging.Client()
    >>> entries, token = client.list_entries(
    ...     project_ids=['one-project', 'another-project'])  # API call
-
 
 Filter entries retrieved using the "Advance Logs Filters" syntax (see
 https://cloud.google.com/logging/docs/view/advanced_filters).
@@ -110,8 +111,8 @@ Retrieve entities in batches of 10, iterating until done.
    ...         break
 
 
-Deleting all entries for a log
-------------------------------
+Delete all entries for a log
+----------------------------
 
 .. doctest::
 


### PR DESCRIPTION
@jgeewax @dhermes please review the usage patterns here.  Note that I've left out the API methods for listing `monitoredResourceDescriptors`:  I couldn't quite figure why they are part of this API, rather than a more generic one (such as `resource_manager`).

I don't intend to merge this PR directly, but will incorporate the updated usage doc in the initial PR for logging.  BTW, should we adopt the pattern of targeting such PRs at a long-lived `logging-api` branch, rather than master?  We would then land the whole API at once by merging that branch.