### PR TITLE
Accomodating oauth2client moves of GCE/App Engine modules.

### DIFF
--- a/docs/gcloud-auth.rst
+++ b/docs/gcloud-auth.rst
@@ -91,23 +91,25 @@ you can pass it directly to a :class:`Client <gcloud.client.Client>`:
 Google App Engine Environment
 -----------------------------
 
-To create :class:`credentials <oauth2client.appengine.AppAssertionCredentials>`
+To create
+:class:`credentials <oauth2client.contrib.appengine.AppAssertionCredentials>`
 just for Google App Engine:
 
 .. code:: python
 
-    from oauth2client.appengine import AppAssertionCredentials
+    from oauth2client.contrib.appengine import AppAssertionCredentials
     credentials = AppAssertionCredentials([])
 
 Google Compute Engine Environment
 ---------------------------------
 
-To create :class:`credentials <oauth2client.gce.AppAssertionCredentials>`
+To create
+:class:`credentials <oauth2client.contrib.gce.AppAssertionCredentials>`
 just for Google Compute Engine:
 
 .. code:: python
 
-    from oauth2client.gce import AppAssertionCredentials
+    from oauth2client.contrib.gce import AppAssertionCredentials
     credentials = AppAssertionCredentials([])
 
 Service Accounts

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -31,7 +31,8 @@ from oauth2client.client import _get_application_default_credential_from_file
 from oauth2client import crypt
 from oauth2client.service_account import ServiceAccountCredentials
 try:
-    from oauth2client.appengine import AppAssertionCredentials as _GAECreds
+    from oauth2client.contrib.appengine import (
+        AppAssertionCredentials as _GAECreds)
 except ImportError:
     class _GAECreds(object):
         """Dummy class if not in App Engine environment."""


### PR DESCRIPTION
FYI @tseaver I didn't realize the App Engine import was busted. I am once and for all going to push that stuff upstream into `oauth2client` and hopefully we can get a `2.0.1` release there.