### PR TITLE
Adding nose-exclude as an AppVeyor dependency.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install wheel nose unittest2 cryptography"
+  - "%CMD_IN_ENV% pip install wheel nose nose-exclude unittest2 cryptography"
 
 build_script:
   # Build the compiled extension


### PR DESCRIPTION
[Build][1] has been broken since #1463, my bad.

[1]: https://ci.appveyor.com/project/dhermes/gcloud-python/build/1.0.199.master