### PR TITLE
Upgrading version to 0.10.1.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'googleapis-common-protos',
-    'oauth2client >= 2.0.0',
+    'oauth2client >= 2.0.0.post1',
     'protobuf >= 3.0.0b2',
     'pyOpenSSL',
     'six',
@@ -22,7 +22,7 @@ REQUIREMENTS = [
 
 setup(
     name='gcloud',
-    version='0.10.0',
+    version='0.10.1',
     description='API Client library for Google Cloud',
     author='Google Cloud Platform',
     author_email='jjg+gcloud-python@google.com',


### PR DESCRIPTION
This is necessitated by the broken GCE support in oauth2client 2.0.0.

Fixes #1484 

/cc @jgeewax @JeremyGrosser