### PR TITLE
Allowing credentials that don't implement create_scoped().

### DIFF
--- a/gcloud/bigtable/client.py
+++ b/gcloud/bigtable/client.py
@@ -144,7 +144,11 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
             scopes.append(ADMIN_SCOPE)
 
         self._admin = bool(admin)
-        self._credentials = credentials.create_scoped(scopes)
+        try:
+            credentials = credentials.create_scoped(scopes)
+        except AttributeError:
+            pass
+        self._credentials = credentials
         self.user_agent = user_agent
         self.timeout_seconds = timeout_seconds
 

--- a/gcloud/bigtable/test_client.py
+++ b/gcloud/bigtable/test_client.py
@@ -41,7 +41,8 @@ class TestClient(unittest2.TestCase):
 
         expected_creds = expected_creds or creds
         self.assertTrue(client._credentials is expected_creds)
-        self.assertEqual(client._credentials.scopes, expected_scopes)
+        if expected_scopes is not None:
+            self.assertEqual(client._credentials.scopes, expected_scopes)
 
         self.assertEqual(client.project, PROJECT)
         self.assertEqual(client.timeout_seconds, timeout_seconds)
@@ -90,7 +91,7 @@ class TestClient(unittest2.TestCase):
             self._constructor_test_helper([], creds, admin=True,
                                           read_only=True)
 
-    def test_constructor_implict_credentials(self):
+    def test_constructor_implicit_credentials(self):
         from gcloud._testing import _Monkey
         from gcloud.bigtable import client as MUT
 
@@ -103,6 +104,11 @@ class TestClient(unittest2.TestCase):
         with _Monkey(MUT, get_credentials=mock_get_credentials):
             self._constructor_test_helper(expected_scopes, None,
                                           expected_creds=creds)
+
+    def test_constructor_credentials_wo_create_scoped(self):
+        creds = object()
+        expected_scopes = None
+        self._constructor_test_helper(expected_scopes, creds)
 
     def _copy_test_helper(self, read_only=False, admin=False):
         credentials = _Credentials('value')

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -115,8 +115,12 @@ class Connection(object):
                 :class:`NoneType`
         :returns: A new credentials object that has a scope added (if needed).
         """
-        if credentials and credentials.create_scoped_required():
-            credentials = credentials.create_scoped(scope)
+        if credentials:
+            try:
+                if credentials.create_scoped_required():
+                    credentials = credentials.create_scoped(scope)
+            except AttributeError:
+                pass
         return credentials
 
 

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -27,7 +27,6 @@ except ImportError:  # pragma: NO COVER
     crypto = None
 
 from oauth2client import client
-from oauth2client.client import _get_application_default_credential_from_file
 from oauth2client import crypt
 from oauth2client.service_account import ServiceAccountCredentials
 try:
@@ -125,11 +124,8 @@ def get_for_service_account_json(json_credentials_path, scope=None):
     :returns: New service account or Google (for a user JSON key file)
               credentials object.
     """
-    credentials = _get_application_default_credential_from_file(
-        json_credentials_path)
-    if scope is not None:
-        credentials = credentials.create_scoped(scope)
-    return credentials
+    return ServiceAccountCredentials.from_json_keyfile_name(
+        json_credentials_path, scopes=scope)
 
 
 def get_for_service_account_p12(client_email, private_key_path, scope=None):

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -30,7 +30,9 @@ class TestConnection(unittest2.TestCase):
 
     def test_ctor_explicit(self):
         credentials = _Credentials()
+        self.assertEqual(credentials._create_scoped_calls, 0)
         conn = self._makeOne(credentials)
+        self.assertEqual(credentials._create_scoped_calls, 1)
         self.assertTrue(conn.credentials is credentials)
         self.assertEqual(conn._http, None)
 
@@ -39,6 +41,12 @@ class TestConnection(unittest2.TestCase):
         conn = self._makeOne(http=http)
         self.assertEqual(conn.credentials, None)
         self.assertTrue(conn.http is http)
+
+    def test_ctor_credentials_wo_create_scoped(self):
+        credentials = object()
+        conn = self._makeOne(credentials)
+        self.assertTrue(conn.credentials is credentials)
+        self.assertEqual(conn._http, None)
 
     def test_http_w_existing(self):
         conn = self._makeOne()
@@ -371,11 +379,12 @@ class _Credentials(object):
 
     def __init__(self, authorized=None):
         self._authorized = authorized
+        self._create_scoped_calls = 0
 
     def authorize(self, http):
         self._called_with = http
         return self._authorized
 
-    @staticmethod
-    def create_scoped_required():
+    def create_scoped_required(self):
+        self._create_scoped_calls += 1
         return False


### PR DESCRIPTION
@tseaver 

1. Maybe this isn't the best way to solve #1412? Happy to hear suggestions.
1. I also realized that we don't really need the `get_for_service_account_p12` and `get_for_service_account_json` helpers any more since the `ServiceAccountCredentials` factories do everything in a nice short way.