### PR TITLE
Removing get_for_service_account_* helpers.

### DIFF
--- a/gcloud/client.py
+++ b/gcloud/client.py
@@ -14,13 +14,12 @@
 
 """Base classes for client used to interact with Google Cloud APIs."""
 
+from oauth2client.service_account import ServiceAccountCredentials
 import six
 
 from gcloud._helpers import _determine_default_project
 from gcloud.connection import Connection
 from gcloud.credentials import get_credentials
-from gcloud.credentials import get_for_service_account_json
-from gcloud.credentials import get_for_service_account_p12
 
 
 class _ClientFactoryMixin(object):
@@ -56,7 +55,8 @@ class _ClientFactoryMixin(object):
         """
         if 'credentials' in kwargs:
             raise TypeError('credentials must not be in keyword arguments')
-        credentials = get_for_service_account_json(json_credentials_path)
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+            json_credentials_path)
         kwargs['credentials'] = credentials
         return cls(*args, **kwargs)
 
@@ -90,8 +90,8 @@ class _ClientFactoryMixin(object):
         """
         if 'credentials' in kwargs:
             raise TypeError('credentials must not be in keyword arguments')
-        credentials = get_for_service_account_p12(client_email,
-                                                  private_key_path)
+        credentials = ServiceAccountCredentials.from_p12_keyfile(
+            client_email, private_key_path)
         kwargs['credentials'] = credentials
         return cls(*args, **kwargs)
 

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -102,63 +102,6 @@ def get_credentials():
     return client.GoogleCredentials.get_application_default()
 
 
-def get_for_service_account_json(json_credentials_path, scope=None):
-    """Gets the credentials for a service account with JSON key.
-
-    :type json_credentials_path: string
-    :param json_credentials_path: The path to a private key file (this file was
-                                  given to you when you created the service
-                                  account). This file must contain a JSON
-                                  object with a private key and other
-                                  credentials information (downloaded from the
-                                  Google APIs console).
-
-    :type scope: string or tuple of string
-    :param scope: The scope against which to authenticate. (Different services
-                  require different scopes, check the documentation for which
-                  scope is required for the different levels of access to any
-                  particular API.)
-
-    :rtype: :class:`oauth2client.client.GoogleCredentials`,
-            :class:`oauth2client.service_account.ServiceAccountCredentials`
-    :returns: New service account or Google (for a user JSON key file)
-              credentials object.
-    """
-    return ServiceAccountCredentials.from_json_keyfile_name(
-        json_credentials_path, scopes=scope)
-
-
-def get_for_service_account_p12(client_email, private_key_path, scope=None):
-    """Gets the credentials for a service account with PKCS12 / p12 key.
-
-    .. note::
-      This method is not used by default, instead :func:`get_credentials`
-      is used. This method is intended to be used when the environment is
-      known explicitly and detecting the environment implicitly would be
-      superfluous.
-
-    :type client_email: string
-    :param client_email: The e-mail attached to the service account.
-
-    :type private_key_path: string
-    :param private_key_path: The path to a private key file (this file was
-                             given to you when you created the service
-                             account). This file must be in P12 format.
-
-    :type scope: string or tuple of string
-    :param scope: The scope against which to authenticate. (Different services
-                  require different scopes, check the documentation for which
-                  scope is required for the different levels of access to any
-                  particular API.)
-
-    :rtype: :class:`oauth2client.service_account.ServiceAccountCredentials`
-    :returns: A new ``ServiceAccountCredentials`` instance with the
-              needed service account settings.
-    """
-    return ServiceAccountCredentials.from_p12_keyfile(
-        client_email, private_key_path, scopes=scope)
-
-
 def _get_pem_key(credentials):
     """Gets private key for a PEM payload from a credentials object.
 

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -80,75 +80,6 @@ class Test_get_credentials(unittest2.TestCase):
         self.assertTrue(client._get_app_default_called)
 
 
-class Test_get_for_service_account_p12(unittest2.TestCase):
-
-    def _callFUT(self, client_email, private_key_path, scope=None):
-        from gcloud.credentials import get_for_service_account_p12
-        return get_for_service_account_p12(client_email, private_key_path,
-                                           scope=scope)
-
-    def test_it(self):
-        from gcloud import credentials as MUT
-        from gcloud._testing import _Monkey
-
-        CLIENT_EMAIL = 'phred@example.com'
-        MOCK_FILENAME = 'foo.path'
-        MOCK_CRED_CLASS = _MockServiceAccountCredentials()
-        with _Monkey(MUT, ServiceAccountCredentials=MOCK_CRED_CLASS):
-            found = self._callFUT(CLIENT_EMAIL, MOCK_FILENAME)
-
-        self.assertTrue(found is MOCK_CRED_CLASS._result)
-        self.assertEqual(MOCK_CRED_CLASS.p12_called,
-                         [(CLIENT_EMAIL, MOCK_FILENAME, None)])
-
-    def test_it_with_scope(self):
-        from gcloud import credentials as MUT
-        from gcloud._testing import _Monkey
-
-        CLIENT_EMAIL = 'phred@example.com'
-        SCOPE = 'SCOPE'
-        MOCK_FILENAME = 'foo.path'
-        MOCK_CRED_CLASS = _MockServiceAccountCredentials()
-        with _Monkey(MUT, ServiceAccountCredentials=MOCK_CRED_CLASS):
-            found = self._callFUT(CLIENT_EMAIL, MOCK_FILENAME, SCOPE)
-
-        self.assertTrue(found is MOCK_CRED_CLASS._result)
-        self.assertEqual(MOCK_CRED_CLASS.p12_called,
-                         [(CLIENT_EMAIL, MOCK_FILENAME, SCOPE)])
-
-
-class Test_get_for_service_account_json(unittest2.TestCase):
-
-    def _callFUT(self, json_credentials_path, scope=None):
-        from gcloud.credentials import get_for_service_account_json
-        return get_for_service_account_json(json_credentials_path, scope=scope)
-
-    def test_it(self):
-        from gcloud._testing import _Monkey
-        from gcloud import credentials as MUT
-
-        FILENAME = object()
-        MOCK_CRED_CLASS = _MockServiceAccountCredentials()
-        with _Monkey(MUT, ServiceAccountCredentials=MOCK_CRED_CLASS):
-            result = self._callFUT(FILENAME)
-
-        self.assertEqual(result, MOCK_CRED_CLASS._result)
-        self.assertEqual(MOCK_CRED_CLASS.json_called, [(FILENAME, None)])
-
-    def test_it_with_scope(self):
-        from gcloud._testing import _Monkey
-        from gcloud import credentials as MUT
-
-        FILENAME = object()
-        SCOPE = object()
-        MOCK_CRED_CLASS = _MockServiceAccountCredentials()
-        with _Monkey(MUT, ServiceAccountCredentials=MOCK_CRED_CLASS):
-            result = self._callFUT(FILENAME, scope=SCOPE)
-
-        self.assertEqual(result, MOCK_CRED_CLASS._result)
-        self.assertEqual(MOCK_CRED_CLASS.json_called, [(FILENAME, SCOPE)])
-
-
 class Test_generate_signed_url(unittest2.TestCase):
 
     def _callFUT(self, *args, **kwargs):
@@ -665,19 +596,3 @@ class _MockDB(object):
         def do_nothing_wrapper(func):
             return func
         return do_nothing_wrapper
-
-
-class _MockServiceAccountCredentials(object):
-
-    def __init__(self):
-        self.p12_called = []
-        self.json_called = []
-        self._result = _Credentials()
-
-    def from_p12_keyfile(self, email, path, scopes=None):
-        self.p12_called.append((email, path, scopes))
-        return self._result
-
-    def from_json_keyfile_name(self, path, scopes=None):
-        self.json_called.append((path, scopes))
-        return self._result


### PR DESCRIPTION
After `oauth2client` 2.0.0 the are just thin wrappers around factory constructors, so no longer needed.

Note that `gcloud.credentials.get_credentials()` is also a very thin wrapper, however, it has useful documentation.

----

@tseaver Do you think I should also remove `get_credentials()` and try to push to documentation into `oauth2client`? (I need to do a side-by-side, I can't quite remember the state of things.)