### PR TITLE
Adding virtual implementations for remaining HappyBase Table methods.

### DIFF
--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -97,7 +97,7 @@ class Connection(object):
 
     The arguments ``host``, ``port``, ``compat``, ``transport`` and
     ``protocol`` are allowed (as keyword arguments) for compatibility with
-    HappyBase. However, they will not be used in anyway, and will cause a
+    HappyBase. However, they will not be used in any way, and will cause a
     warning if passed.
 
     :type timeout: int

--- a/gcloud/bigtable/happybase/test_table.py
+++ b/gcloud/bigtable/happybase/test_table.py
@@ -121,6 +121,62 @@ class TestTable(unittest2.TestCase):
         with self.assertRaises(NotImplementedError):
             table.regions()
 
+    def test_row(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.row(None)
+
+    def test_rows(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.rows(None)
+
+    def test_cells(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.cells(None, None)
+
+    def test_scan(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.scan()
+
+    def test_put(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.put(None, None)
+
+    def test_delete(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.delete(None)
+
+    def test_batch(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        with self.assertRaises(NotImplementedError):
+            table.batch()
+
     def test_counter_get(self):
         klass = self._getTargetClass()
         counter_value = 1337


### PR DESCRIPTION
@jonparrott I figured this would be good for you to get a sense of why I'd be sending PRs for helpers before actually implementing the methods themselves. The [helpers][1] themselves contain quite a bit of code (HappyBase is a nice abstraction and the work is worth it).

[1]: https://github.com/dhermes/gcloud-python-bigtable/blob/b2c61ee0d105013e4152711c8563cc3365ea58d7/gcloud_bigtable/happybase/table.py#L97-L334