### PR TITLE
Adding HappyBase Table.counter_set().

### DIFF
--- a/gcloud/bigtable/happybase/table.py
+++ b/gcloud/bigtable/happybase/table.py
@@ -495,6 +495,30 @@ class Table(object):
         # is correctly initialized if didn't exist yet.
         return self.counter_inc(row, column, value=0)
 
+    def counter_set(self, row, column, value=0):
+        """Set a counter column to a specific value.
+
+        This method is provided in HappyBase, but we do not provide it here
+        because it defeats the purpose of using atomic increment and decrement
+        of a counter.
+
+        :type row: str
+        :param row: Row key for the row we are setting a counter in.
+
+        :type column: str
+        :param column: Column we are setting a value in; of
+                       the form ``fam:col``.
+
+        :type value: int
+        :param value: Value to set the counter to.
+
+        :raises: :class:`NotImplementedError <exceptions.NotImplementedError>`
+                 always
+        """
+        raise NotImplementedError('Table.counter_set will not be implemented. '
+                                  'Instead use the increment/decrement '
+                                  'methods along with counter_get.')
+
     def counter_inc(self, row, column, value=1):
         """Atomically increment a counter column.
 

--- a/gcloud/bigtable/happybase/test_table.py
+++ b/gcloud/bigtable/happybase/test_table.py
@@ -539,6 +539,17 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(row_obj.counts,
                          {tuple(column.split(':')): incremented_value})
 
+    def test_counter_set(self):
+        name = 'table-name'
+        connection = None
+        table = self._makeOne(name, connection)
+
+        row = 'row-key'
+        column = 'fam:col1'
+        value = 42
+        with self.assertRaises(NotImplementedError):
+            table.counter_set(row, column, value=value)
+
     def test_counter_inc(self):
         import struct
 


### PR DESCRIPTION
I took the [note][1] from HappyBase

> Note that application code should *never* store a incremented or decremented counter value directly; use the atomic `Table.counter_inc` and `Table.counter_dec` methods for that.

one step further and just made this `NotImplemented`.

[1]: https://github.com/wbolster/happybase/blob/9cbd718c10a3089f234f1eac1236b631e1f8e7cd/happybase/table.py#L531-L534