### PR TITLE
Moving Bigtable Row.commit_modifications() into commit().

### DIFF
--- a/docs/bigtable-data-api.rst
+++ b/docs/bigtable-data-api.rst
@@ -70,13 +70,6 @@ in a batch via :meth:`commit() <gcloud.bigtable.row.Row.commit>`:
 
     row.commit()
 
-To send **append** mutations in batch, use
-:meth:`commit_modifications() <gcloud.bigtable.row.Row.commit_modifications>`:
-
-.. code:: python
-
-    row.commit_modifications()
-
 We have a small set of methods on the :class:`Row <gcloud.bigtable.row.Row>`
 to build these mutations up.
 
@@ -213,13 +206,6 @@ If accumulated mutations need to be dropped, use
 .. code:: python
 
     row.clear_mutations()
-
-To clear **append** mutations, use
-:meth:`clear_modification_rules() <gcloud.bigtable.row.Row.clear_modification_rules>`
-
-.. code:: python
-
-    row.clear_modification_rules()
 
 Reading Data
 ++++++++++++

--- a/gcloud/bigtable/happybase/table.py
+++ b/gcloud/bigtable/happybase/table.py
@@ -603,12 +603,12 @@ class Table(object):
         :rtype: int
         :returns: Counter value after incrementing.
         """
-        row = self._low_level_table.row(row)
+        row = self._low_level_table.row(row, append=True)
         if isinstance(column, six.binary_type):
             column = column.decode('utf-8')
         column_family_id, column_qualifier = column.split(':')
         row.increment_cell_value(column_family_id, column_qualifier, value)
-        # See row.commit_modifications() will return a dictionary:
+        # See row._commit_modifications() will return a dictionary:
         # {
         #     u'col-fam-id': {
         #         b'col-name1': [
@@ -618,7 +618,7 @@ class Table(object):
         #         ...
         #     },
         # }
-        modified_cells = row.commit_modifications()
+        modified_cells = row.commit()
         # Get the cells in the modified column,
         column_cells = modified_cells[column_family_id][column_qualifier]
         # Make sure there is exactly one cell in the column.

--- a/gcloud/bigtable/happybase/test_table.py
+++ b/gcloud/bigtable/happybase/test_table.py
@@ -871,10 +871,12 @@ class TestTable(unittest2.TestCase):
         table = self._makeOne(name, connection)
         # Mock the return values.
         table._low_level_table = _MockLowLevelTable()
-        table._low_level_table.row_values[row] = _MockLowLevelRow(
+        table._low_level_table.row_values[row] = row_obj = _MockLowLevelRow(
             row, commit_result=commit_result)
 
+        self.assertFalse(row_obj._append)
         result = table.counter_inc(row, column, value=value)
+        self.assertTrue(row_obj._append)
 
         incremented_value = value + _MockLowLevelRow.COUNTER_DEFAULT
         self.assertEqual(result, incremented_value)
@@ -1431,8 +1433,10 @@ class _MockLowLevelTable(object):
         self.list_column_families_calls += 1
         return self.column_families
 
-    def row(self, row_key):
-        return self.row_values[row_key]
+    def row(self, row_key, append=None):
+        result = self.row_values[row_key]
+        result._append = append
+        return result
 
     def read_row(self, *args, **kwargs):
         self.read_row_calls.append((args, kwargs))
@@ -1447,8 +1451,9 @@ class _MockLowLevelRow(object):
 
     COUNTER_DEFAULT = 0
 
-    def __init__(self, row_key, commit_result=None):
+    def __init__(self, row_key, append=None, commit_result=None):
         self.row_key = row_key
+        self._append = append
         self.counts = {}
         self.commit_result = commit_result
 
@@ -1457,7 +1462,7 @@ class _MockLowLevelRow(object):
                                        self.COUNTER_DEFAULT)
         self.counts[(column_family_id, column)] = count + int_value
 
-    def commit_modifications(self):
+    def commit(self):
         return self.commit_result
 
 

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -95,7 +95,7 @@ class Table(object):
         """
         return ColumnFamily(column_family_id, self, gc_rule=gc_rule)
 
-    def row(self, row_key, filter_=None):
+    def row(self, row_key, filter_=None, append=False):
         """Factory to create a row associated with this table.
 
         :type row_key: bytes
@@ -105,10 +105,14 @@ class Table(object):
         :param filter_: (Optional) Filter to be used for conditional mutations.
                         See :class:`.Row` for more details.
 
+        :type append: bool
+        :param append: (Optional) Flag to determine if the row should be used
+                       for append mutations.
+
         :rtype: :class:`.Row`
         :returns: A row owned by this table.
         """
-        return Row(row_key, self, filter_=filter_)
+        return Row(row_key, self, filter_=filter_, append=append)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -69,6 +69,21 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(row._row_key, row_key)
         self.assertEqual(row._table, table)
         self.assertEqual(row._filter, filter_)
+        self.assertFalse(row._append)
+
+    def test_row_factory_append(self):
+        from gcloud.bigtable.row import Row
+
+        table_id = 'table-id'
+        table = self._makeOne(table_id, None)
+        row_key = b'row_key'
+        row = table.row(row_key, append=True)
+
+        self.assertTrue(isinstance(row, Row))
+        self.assertEqual(row._row_key, row_key)
+        self.assertEqual(row._table, table)
+        self.assertEqual(row._filter, None)
+        self.assertTrue(row._append)
 
     def test___eq__(self):
         table_id = 'table_id'

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -66,7 +66,7 @@ TEST_RC_ADDITIONS = {
 }
 TEST_RC_REPLACEMENTS = {
     'FORMAT': {
-        'max-module-lines': 1800,
+        'max-module-lines': 1875,
     },
 }
 


### PR DESCRIPTION
Fixes #1548.