### PR TITLE
Adding grpcio to setup.py as an extra.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-
 from setuptools import setup
 from setuptools import find_packages
 
@@ -19,6 +18,7 @@ REQUIREMENTS = [
     'pyOpenSSL',
     'six',
 ]
+GRPC_EXTRAS = ['grpcio >= 0.13.0']
 
 setup(
     name='gcloud',
@@ -35,6 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIREMENTS,
+    extras_require={'grpc': GRPC_EXTRAS},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,15 @@ covercmd =
       --cover-branches \
       --nocapture
 
+[testenv:py27]
+basepython =
+    python2.7
+deps =
+    {[testenv]deps}
+    grpcio >= 0.13.0
+setenv =
+    PYTHONPATH =
+
 [testenv:cover]
 basepython =
     python2.7


### PR DESCRIPTION
`grpcio` can only be installed with Python 2.7, so the `py27` tox environment is the only one that doesn't need to run without mocks.

FYI @jgeewax the `grpcio` install [fails][1] on Python 2.6 and 3.4 (didn't try 3.5).

- This won't run Py2.7 tests on AppVeyor with `grpcio` but will at least install it. I tried to tackle but can't write faithful powershell without a test machine
- If this works, I'll conditionally add the Bigtable tests (in Py2.7) in `attempt_system_tests.py`

[1]: https://gist.github.com/dhermes/74e5b8641375951f188a