### PR TITLE
Get blob download_url if not already available

### DIFF
--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -287,7 +287,13 @@ class Blob(_PropertyMixin):
         :raises: :class:`gcloud.exceptions.NotFound`
         """
         client = self._require_client(client)
-        download_url = self.media_link
+
+        if not self.media_link:
+            response = client.connection.api_request(
+                method='GET', path=self.path, _target_object=self)
+            download_url = response['media_link']
+        else:
+            download_url = self.media_link
 
         # Use apitools 'Download' facility.
         download = Download.from_stream(file_obj)


### PR DESCRIPTION
Closes #1555

If `media_link` isn’t available (meaning this blob is just a placeholder object), query the API for the `download_url`. Otherwise, the download will fail because `self.media_link` is `None`.

