### PR TITLE
Splitting Bigtable Row into 3 classes based on the mutation type / RPC method used in commit()

### DIFF
--- a/docs/bigtable-client-intro.rst
+++ b/docs/bigtable-client-intro.rst
@@ -21,18 +21,19 @@ defaults
 However, you may over-ride them and these will be used throughout all API
 requests made with the ``client`` you create.
 
-Authorization
+Configuration
 -------------
 
 - For an overview of authentication in ``gcloud-python``,
   see :doc:`gcloud-auth`.
 
 - In addition to any authentication configuration, you can also set the
-  :envvar:`GCLOUD_PROJECT` environment variable for the project you'd like
-  to interact with. If you are Google App Engine or Google Compute Engine
-  this will be detected automatically. (Setting this environment
-  variable is not required, you may instead pass the ``project`` explicitly
-  when constructing a :class:`Client <gcloud.storage.client.Client>`).
+  :envvar:`GCLOUD_PROJECT` environment variable for the Google Cloud Console
+  project you'd like to interact with. If your code is running in Google App
+  Engine or Google Compute Engine the project will be detected automatically.
+  (Setting this environment variable is not required, you may instead pass the
+  ``project`` explicitly when constructing a
+  :class:`Client <gcloud.storage.client.Client>`).
 
 - After configuring your environment, create a
   :class:`Client <gcloud.storage.client.Client>`

--- a/docs/bigtable-cluster-api.rst
+++ b/docs/bigtable-cluster-api.rst
@@ -85,11 +85,13 @@ Check on Current Operation
 .. note::
 
     When modifying a cluster (via a `CreateCluster`_, `UpdateCluster`_ or
-    `UndeleteCluster`_ request), the Bigtable API will return a long-running
-    `Operation`_. This will be stored on the object after each of
+    `UndeleteCluster`_ request), the Bigtable API will return a
+    `long-running operation`_ and a corresponding
+    :class:`Operation <gcloud.bigtable.cluster.Operation>` object
+    will be returned by each of
     :meth:`create() <gcloud.bigtable.cluster.Cluster.create>`,
     :meth:`update() <gcloud.bigtable.cluster.Cluster.update>` and
-    :meth:`undelete() <gcloud.bigtable.cluster.Cluster.undelete>` are called.
+    :meth:`undelete() <gcloud.bigtable.cluster.Cluster.undelete>`.
 
 You can check if a long-running operation (for a
 :meth:`create() <gcloud.bigtable.cluster.Cluster.create>`,
@@ -176,4 +178,4 @@ Head next to learn about the :doc:`bigtable-table-api`.
 .. _ListClusters: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/2aae624081f652427052fb652d3ae43d8ac5bf5a/bigtable-protos/src/main/proto/google/bigtable/admin/cluster/v1/bigtable_cluster_service.proto#L44-L46
 .. _GetOperation: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/2aae624081f652427052fb652d3ae43d8ac5bf5a/bigtable-protos/src/main/proto/google/longrunning/operations.proto#L43-L45
 .. _UndeleteCluster: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/2aae624081f652427052fb652d3ae43d8ac5bf5a/bigtable-protos/src/main/proto/google/bigtable/admin/cluster/v1/bigtable_cluster_service.proto#L126-L128
-.. _Operation: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/2aae624081f652427052fb652d3ae43d8ac5bf5a/bigtable-protos/src/main/proto/google/longrunning/operations.proto#L73-L102
+.. _long-running operation: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/2aae624081f652427052fb652d3ae43d8ac5bf5a/bigtable-protos/src/main/proto/google/longrunning/operations.proto#L73-L102

--- a/docs/bigtable-row.rst
+++ b/docs/bigtable-row.rst
@@ -2,7 +2,8 @@ Bigtable Row
 ============
 
 It is possible to use a :class:`RowFilter <gcloud.bigtable.row.RowFilter>`
-when adding mutations to a :class:`Row <gcloud.bigtable.row.Row>` and when
+when adding mutations to a
+:class:`ConditionalRow <gcloud.bigtable.row.ConditionalRow>` and when
 reading row data with :meth:`read_row() <gcloud.bigtable.table.Table.read_row>`
 :meth:`read_rows() <gcloud.bigtable.table.Table.read_rows>`.
 

--- a/gcloud/bigtable/happybase/table.py
+++ b/gcloud/bigtable/happybase/table.py
@@ -603,12 +603,12 @@ class Table(object):
         :rtype: int
         :returns: Counter value after incrementing.
         """
-        row = self._low_level_table.row(row)
+        row = self._low_level_table.row(row, append=True)
         if isinstance(column, six.binary_type):
             column = column.decode('utf-8')
         column_family_id, column_qualifier = column.split(':')
         row.increment_cell_value(column_family_id, column_qualifier, value)
-        # See row.commit_modifications() will return a dictionary:
+        # See AppendRow.commit() will return a dictionary:
         # {
         #     u'col-fam-id': {
         #         b'col-name1': [
@@ -618,7 +618,7 @@ class Table(object):
         #         ...
         #     },
         # }
-        modified_cells = row.commit_modifications()
+        modified_cells = row.commit()
         # Get the cells in the modified column,
         column_cells = modified_cells[column_family_id][column_qualifier]
         # Make sure there is exactly one cell in the column.

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -91,7 +91,6 @@ class DirectRow(Row):
     def __init__(self, row_key, table):
         super(DirectRow, self).__init__(row_key, table)
         self._pb_mutations = []
-        self._pb_mutations = []
 
     def _get_mutations(self, state):  # pylint: disable=unused-argument
         """Gets the list of mutations for a given state.
@@ -586,7 +585,7 @@ class ConditionalRow(DirectRow):
         :type columns: :class:`list` of :class:`str` /
                        :func:`unicode <unicode>`, or :class:`object`
         :param columns: The columns within the column family that will have
-                        cells deleted. If :attr:`Row.ALL_COLUMNS` is used then
+                        cells deleted. If :attr:`ALL_COLUMNS` is used then
                         the entire column family will be deleted from the row.
 
         :type time_range: :class:`TimestampRange`

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -446,10 +446,12 @@ class ConditionalRow(DirectRow):
     :param filter_: Filter to be used for conditional mutations.
     """
     def __init__(self, row_key, table, filter_):
-        super(ConditionalRow, self).__init__(row_key, table)
+        super(ConditionalRow, self).__init__(row_key, table, filter_=filter_)
         self._filter = filter_
         # NOTE: We use self._pb_mutations to hold the state=True mutations.
         self._false_pb_mutations = []
+        # Temporary over-ride to re-use behavior in DirectRow constructor.
+        self._pb_mutations = self._true_pb_mutations
 
     def _get_mutations(self, state):
         """Gets the list of mutations for a given state.

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -73,10 +73,10 @@ class DirectRow(Row):
 
     .. note::
 
-        A :class:`Row` accumulates mutations locally via the :meth:`set_cell`,
-        :meth:`delete`, :meth:`delete_cell` and :meth:`delete_cells` methods.
-        To actually send these mutations to the Google Cloud Bigtable API, you
-        must call :meth:`commit`.
+        A :class:`DirectRow` accumulates mutations locally via the
+        :meth:`set_cell`, :meth:`delete`, :meth:`delete_cell` and
+        :meth:`delete_cells` methods. To actually send these mutations to the
+        Google Cloud Bigtable API, you must call :meth:`commit`.
 
     :type row_key: bytes
     :param row_key: The key for the current row.
@@ -585,8 +585,10 @@ class ConditionalRow(DirectRow):
         :type columns: :class:`list` of :class:`str` /
                        :func:`unicode <unicode>`, or :class:`object`
         :param columns: The columns within the column family that will have
-                        cells deleted. If :attr:`ALL_COLUMNS` is used then
-                        the entire column family will be deleted from the row.
+                        cells deleted. If
+                        :attr:`ALL_COLUMNS <.DirectRow.ALL_COLUMNS>` is used
+                        then the entire column family will be deleted from
+                        the row.
 
         :type time_range: :class:`TimestampRange`
         :param time_range: (Optional) The range of time within which cells
@@ -641,7 +643,7 @@ class AppendRow(Row):
         .. note::
 
             This method adds a read-modify rule protobuf to the accumulated
-            read-modify rules on this :class:`Row`, but does not make an API
+            read-modify rules on this row, but does not make an API
             request. To actually send an API request (with the rules) to the
             Google Cloud Bigtable API, call :meth:`commit`.
 
@@ -675,7 +677,7 @@ class AppendRow(Row):
         .. note::
 
             This method adds a read-modify rule protobuf to the accumulated
-            read-modify rules on this :class:`Row`, but does not make an API
+            read-modify rules on this row, but does not make an API
             request. To actually send an API request (with the rules) to the
             Google Cloud Bigtable API, call :meth:`commit`.
 
@@ -714,6 +716,8 @@ class AppendRow(Row):
         appending / incrementing. The new cell created uses either the current
         server time or the highest timestamp of a cell in that column (if it
         exceeds the server time).
+
+        After committing the accumulated mutations, resets the local mutations.
 
         .. code:: python
 

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -447,8 +447,31 @@ class ConditionalRow(DirectRow):
     """
     def __init__(self, row_key, table, filter_):
         super(ConditionalRow, self).__init__(row_key, table)
+        self._filter = filter_
         # NOTE: We use self._pb_mutations to hold the state=True mutations.
         self._false_pb_mutations = []
+
+    def _get_mutations(self, state):
+        """Gets the list of mutations for a given state.
+
+        Over-ridden so that the state can be used in:
+
+        * :meth:`set_cell`
+        * :meth:`delete`
+        * :meth:`delete_cell`
+        * :meth:`delete_cells`
+
+        :type state: bool
+        :param state: The state that the mutation should be
+                      applied in.
+
+        :rtype: list
+        :returns: The list to add new mutations to (for the current state).
+        """
+        if state:
+            return self._pb_mutations
+        else:
+            return self._false_pb_mutations
 
 
 class AppendRow(Row):

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -366,7 +366,7 @@ class DirectRow(Row):
             request_pb, client.timeout_seconds)
         return resp.predicate_matched
 
-    def clear_mutations(self):
+    def clear(self):
         """Removes all currently accumulated mutations on the current row."""
         if self._filter is None:
             del self._pb_mutations[:]
@@ -404,7 +404,7 @@ class DirectRow(Row):
             result = self._commit_check_and_mutate()
 
         # Reset mutations after commit-ing request.
-        self.clear_mutations()
+        self.clear()
 
         return result
 

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -24,6 +24,7 @@ from gcloud.bigtable._generated import (
 from gcloud.bigtable.column_family import _gc_rule_from_pb
 from gcloud.bigtable.column_family import ColumnFamily
 from gcloud.bigtable.row import AppendRow
+from gcloud.bigtable.row import ConditionalRow
 from gcloud.bigtable.row import DirectRow
 from gcloud.bigtable.row_data import PartialRowData
 from gcloud.bigtable.row_data import PartialRowsData
@@ -124,8 +125,10 @@ class Table(object):
             raise ValueError('At most one of filter_ and append can be set')
         if append:
             return AppendRow(row_key, self)
+        elif filter_ is not None:
+            return ConditionalRow(row_key, self, filter_=filter_)
         else:
-            return DirectRow(row_key, self, filter_=filter_)
+            return DirectRow(row_key, self)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -23,6 +23,7 @@ from gcloud.bigtable._generated import (
     bigtable_service_messages_pb2 as data_messages_pb2)
 from gcloud.bigtable.column_family import _gc_rule_from_pb
 from gcloud.bigtable.column_family import ColumnFamily
+from gcloud.bigtable.row import AppendRow
 from gcloud.bigtable.row import DirectRow
 from gcloud.bigtable.row_data import PartialRowData
 from gcloud.bigtable.row_data import PartialRowsData
@@ -95,8 +96,13 @@ class Table(object):
         """
         return ColumnFamily(column_family_id, self, gc_rule=gc_rule)
 
-    def row(self, row_key, filter_=None):
+    def row(self, row_key, filter_=None, append=False):
         """Factory to create a row associated with this table.
+
+        .. warning::
+
+           At most one of ``filter_`` and ``append`` can be used in a
+           :class:`Row`.
 
         :type row_key: bytes
         :param row_key: The key for the row being created.
@@ -105,10 +111,21 @@ class Table(object):
         :param filter_: (Optional) Filter to be used for conditional mutations.
                         See :class:`.DirectRow` for more details.
 
+        :type append: bool
+        :param append: (Optional) Flag to determine if the row should be used
+                       for append mutations.
+
         :rtype: :class:`.DirectRow`
         :returns: A row owned by this table.
+        :raises: :class:`ValueError <exceptions.ValueError>` if both
+                 ``filter_`` and ``append`` are used.
         """
-        return DirectRow(row_key, self, filter_=filter_)
+        if append and filter_ is not None:
+            raise ValueError('At most one of filter_ and append can be set')
+        if append:
+            return AppendRow(row_key, self)
+        else:
+            return DirectRow(row_key, self, filter_=filter_)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -23,7 +23,7 @@ from gcloud.bigtable._generated import (
     bigtable_service_messages_pb2 as data_messages_pb2)
 from gcloud.bigtable.column_family import _gc_rule_from_pb
 from gcloud.bigtable.column_family import ColumnFamily
-from gcloud.bigtable.row import Row
+from gcloud.bigtable.row import DirectRow
 from gcloud.bigtable.row_data import PartialRowData
 from gcloud.bigtable.row_data import PartialRowsData
 
@@ -103,12 +103,12 @@ class Table(object):
 
         :type filter_: :class:`.RowFilter`
         :param filter_: (Optional) Filter to be used for conditional mutations.
-                        See :class:`.Row` for more details.
+                        See :class:`.DirectRow` for more details.
 
-        :rtype: :class:`.Row`
+        :rtype: :class:`.DirectRow`
         :returns: A row owned by this table.
         """
-        return Row(row_key, self, filter_=filter_)
+        return DirectRow(row_key, self, filter_=filter_)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -16,11 +16,11 @@
 import unittest2
 
 
-class TestRow(unittest2.TestCase):
+class TestDirectRow(unittest2.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.bigtable.row import Row
-        return Row
+        from gcloud.bigtable.row import DirectRow
+        return DirectRow
 
     def _makeOne(self, *args, **kwargs):
         return self._getTargetClass()(*args, **kwargs)

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -432,14 +432,8 @@ class TestConditionalRow(unittest2.TestCase):
                 value=value1,
             ),
         )
-        value2 = b'other-bytes'
         mutation2 = data_pb2.Mutation(
-            set_cell=data_pb2.Mutation.SetCell(
-                family_name=column_family_id,
-                column_qualifier=column,
-                timestamp_micros=-1,  # Default value.
-                value=value2,
-            ),
+            delete_from_row=data_pb2.Mutation.DeleteFromRow(),
         )
         request_pb = messages_pb2.CheckAndMutateRowRequest(
             table_name=table_name,
@@ -462,7 +456,7 @@ class TestConditionalRow(unittest2.TestCase):
 
         # Perform the method and check the result.
         row.set_cell(column_family_id, column, value1, state=True)
-        row.set_cell(column_family_id, column, value2, state=False)
+        row.delete(state=False)
         result = row.commit()
         self.assertEqual(result, expected_result)
         self.assertEqual(stub.method_calls, [(

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -512,6 +512,39 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(stub.method_calls, [])
 
 
+class TestConditionalRow(unittest2.TestCase):
+
+    def _getTargetClass(self):
+        from gcloud.bigtable.row import ConditionalRow
+        return ConditionalRow
+
+    def _makeOne(self, *args, **kwargs):
+        return self._getTargetClass()(*args, **kwargs)
+
+    def test_constructor(self):
+        row_key = b'row_key'
+        table = object()
+        filter_ = object()
+
+        row = self._makeOne(row_key, table, filter_=filter_)
+        self.assertEqual(row._row_key, row_key)
+        self.assertTrue(row._table is table)
+        self.assertTrue(row._filter is filter_)
+        self.assertEqual(row._pb_mutations, [])
+        self.assertEqual(row._false_pb_mutations, [])
+
+    def test__get_mutations(self):
+        row_key = b'row_key'
+        filter_ = object()
+        row = self._makeOne(row_key, None, filter_=filter_)
+
+        row._pb_mutations = true_mutations = object()
+        row._false_pb_mutations = false_mutations = object()
+        self.assertTrue(true_mutations is row._get_mutations(True))
+        self.assertTrue(false_mutations is row._get_mutations(False))
+        self.assertTrue(false_mutations is row._get_mutations(None))
+
+
 class TestAppendRow(unittest2.TestCase):
 
     def _getTargetClass(self):

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -58,7 +58,6 @@ class TestTable(unittest2.TestCase):
 
     def test_row_factory(self):
         from gcloud.bigtable.row import DirectRow
-        from gcloud.bigtable.row import Row
 
         table_id = 'table-id'
         table = self._makeOne(table_id, None)
@@ -66,10 +65,28 @@ class TestTable(unittest2.TestCase):
         filter_ = object()
         row = table.row(row_key, filter_=filter_)
 
-        self.assertTrue(isinstance(row, Row))
+        self.assertTrue(isinstance(row, DirectRow))
         self.assertEqual(row._row_key, row_key)
         self.assertEqual(row._table, table)
         self.assertEqual(row._filter, filter_)
+
+    def test_row_factory_append(self):
+        from gcloud.bigtable.row import AppendRow
+
+        table_id = 'table-id'
+        table = self._makeOne(table_id, None)
+        row_key = b'row_key'
+        row = table.row(row_key, append=True)
+
+        self.assertTrue(isinstance(row, AppendRow))
+        self.assertEqual(row._row_key, row_key)
+        self.assertEqual(row._table, table)
+
+    def test_row_factory_failure(self):
+        table_id = 'table-id'
+        table = self._makeOne(table_id, None)
+        with self.assertRaises(ValueError):
+            table.row(b'row_key', filter_=object(), append=True)
 
     def test___eq__(self):
         table_id = 'table_id'

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -56,8 +56,20 @@ class TestTable(unittest2.TestCase):
         self.assertTrue(column_family.gc_rule is gc_rule)
         self.assertEqual(column_family._table, table)
 
-    def test_row_factory(self):
+    def test_row_factory_direct(self):
         from gcloud.bigtable.row import DirectRow
+
+        table_id = 'table-id'
+        table = self._makeOne(table_id, None)
+        row_key = b'row_key'
+        row = table.row(row_key)
+
+        self.assertTrue(isinstance(row, DirectRow))
+        self.assertEqual(row._row_key, row_key)
+        self.assertEqual(row._table, table)
+
+    def test_row_factory_conditional(self):
+        from gcloud.bigtable.row import ConditionalRow
 
         table_id = 'table-id'
         table = self._makeOne(table_id, None)
@@ -65,10 +77,9 @@ class TestTable(unittest2.TestCase):
         filter_ = object()
         row = table.row(row_key, filter_=filter_)
 
-        self.assertTrue(isinstance(row, DirectRow))
+        self.assertTrue(isinstance(row, ConditionalRow))
         self.assertEqual(row._row_key, row_key)
         self.assertEqual(row._table, table)
-        self.assertEqual(row._filter, filter_)
 
     def test_row_factory_append(self):
         from gcloud.bigtable.row import AppendRow

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -57,6 +57,7 @@ class TestTable(unittest2.TestCase):
         self.assertEqual(column_family._table, table)
 
     def test_row_factory(self):
+        from gcloud.bigtable.row import DirectRow
         from gcloud.bigtable.row import Row
 
         table_id = 'table-id'

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -200,7 +200,7 @@ no-space-check =
 # Maximum number of lines in a module
 # DEFAULT:  max-module-lines=1000
 # RATIONALE:  API-mapping
-max-module-lines=1500
+max-module-lines=1590
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -200,7 +200,7 @@ no-space-check =
 # Maximum number of lines in a module
 # DEFAULT:  max-module-lines=1000
 # RATIONALE:  API-mapping
-max-module-lines=1590
+max-module-lines=1593
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -66,7 +66,7 @@ TEST_RC_ADDITIONS = {
 }
 TEST_RC_REPLACEMENTS = {
     'FORMAT': {
-        'max-module-lines': 1800,
+        'max-module-lines': 1825,
     },
 }
 

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -332,7 +332,7 @@ class TestDataAPI(unittest2.TestCase):
 
     def tearDown(self):
         for row in self.rows_to_delete:
-            row.clear_mutations()
+            row.clear()
             row.delete()
             row.commit()
 


### PR DESCRIPTION
Docs are still being updated, but I wanted to get this out there to speed up the review. Alternate implementation based on #1550.

I strongly urge reviewers to examine this commit-by-commit. The commit messages are fairly helpful (for the most part) and the diff of the PR as a whole is not so easy on the eyes.

Fixes #1548.

/cc @jonparrott @jgeewax 