### PR TITLE
Add a template_suffix parameter to BigQuery Table.insert_data

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -654,9 +654,9 @@ class Table(object):
         :param ignore_unknown_values: ignore columns beyond schema?
 
         :type template_suffix: string or ``NoneType``
-        :param template_suffix: treat ``name`` as a template table and provide 
-                                a suffix. BigQuery will create the table 
-                                ``<name> + <template_suffix>`` based on the 
+        :param template_suffix: treat ``name`` as a template table and provide
+                                a suffix. BigQuery will create the table
+                                ``<name> + <template_suffix>`` based on the
                                 schema of the template table. See:
                                 https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
 
@@ -698,7 +698,7 @@ class Table(object):
             data['ignoreUnknownValues'] = ignore_unknown_values
 
         if template_suffix is not None:
-            data['templateSuffix'] = template_suffix            
+            data['templateSuffix'] = template_suffix
 
         response = client.connection.api_request(
             method='POST',

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -631,6 +631,7 @@ class Table(object):
                     row_ids=None,
                     skip_invalid_rows=None,
                     ignore_unknown_values=None,
+                    template_suffix=None,
                     client=None):
         """API call:  insert table data via a POST request
 
@@ -651,6 +652,13 @@ class Table(object):
 
         :type ignore_unknown_values: boolean or ``NoneType``
         :param ignore_unknown_values: ignore columns beyond schema?
+
+        :type template_suffix: string or ``NoneType``
+        :param template_suffix: treat ``name`` as a template table and provide 
+                                a suffix. BigQuery will create the table 
+                                ``<name> + <template_suffix>`` based on the 
+                                schema of the template table. See:
+                                https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
 
         :type client: :class:`gcloud.bigquery.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -688,6 +696,9 @@ class Table(object):
 
         if ignore_unknown_values is not None:
             data['ignoreUnknownValues'] = ignore_unknown_values
+
+        if template_suffix is not None:
+            data['templateSuffix'] = template_suffix            
 
         response = client.connection.api_request(
             method='POST',

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -1185,6 +1185,7 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         SENT = {
             'skipInvalidRows': True,
             'ignoreUnknownValues': True,
+            'template_suffix': '20160303',
             'rows': [{'insertId': index, 'json': _row_data(row)}
                      for index, row in enumerate(ROWS)],
         }
@@ -1194,7 +1195,9 @@ class TestTable(unittest2.TestCase, _SchemaBase):
             rows=ROWS,
             row_ids=[index for index, _ in enumerate(ROWS)],
             skip_invalid_rows=True,
-            ignore_unknown_values=True)
+            ignore_unknown_values=True,
+            template_suffix='20160303',
+        )
 
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['index'], 1)

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -1185,7 +1185,7 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         SENT = {
             'skipInvalidRows': True,
             'ignoreUnknownValues': True,
-            'template_suffix': '20160303',
+            'templateSuffix': '20160303',
             'rows': [{'insertId': index, 'json': _row_data(row)}
                      for index, row in enumerate(ROWS)],
         }


### PR DESCRIPTION
Enable the use of template tables by adding the `template_suffix` parameter. 
Documentation: https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables

Would love tips on how you feel this should be tested.