### PR TITLE
Add 'Topic.list_subscriptions'.

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -186,8 +186,8 @@ List subscriptions for a topic:
 
    >>> from gcloud import pubsub
    >>> client = pubsub.Client()
-   >>> subscriptions, next_page_token = client.list_subscriptions(
-   ...     topic_name='topic_name')  # API request
+   >>> topic = client.topic('topic_name')
+   >>> subscriptions, next_page_token = topic.list_subscriptions()  # API request
    >>> [subscription.name for subscription in subscriptions]
    ['subscription_name']
 

--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -416,7 +416,7 @@ def _name_from_project_path(path, project, template):
     match = template.match(path)
 
     if not match:
-        raise ValueError('path did not match: %s' % (template.pattern))
+        raise ValueError('path did not match: %s' % (template.pattern,))
 
     found_project = match.group('project')
     if found_project != project:

--- a/gcloud/pubsub/_helpers.py
+++ b/gcloud/pubsub/_helpers.py
@@ -43,3 +43,34 @@ def topic_name_from_path(path, project):
                          'project from resource.')
 
     return path_parts[3]
+
+
+def subscription_name_from_path(path, project):
+    """Validate a subscription URI path and get the subscription name.
+
+    :type path: string
+    :param path: URI path for a subscription API request.
+
+    :type project: string
+    :param project: The project associated with the request. It is
+                    included for validation purposes.
+
+    :rtype: string
+    :returns: subscription name parsed from ``path``.
+    :raises: :class:`ValueError` if the ``path`` is ill-formed or if
+             the project from the ``path`` does not agree with the
+             ``project`` passed in.
+    """
+    # PATH = 'projects/%s/subscriptions/%s' % (PROJECT, TOPIC_NAME)
+    path_parts = path.split('/')
+    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
+            path_parts[2] != 'subscriptions'):
+        raise ValueError(
+            'Expected path to be of the form '
+            'projects/{project}/subscriptions/{subscription_name}')
+    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
+            path_parts[2] != 'subscriptions' or path_parts[1] != project):
+        raise ValueError('Project from client should agree with '
+                         'project from resource.')
+
+    return path_parts[3]

--- a/gcloud/pubsub/_helpers.py
+++ b/gcloud/pubsub/_helpers.py
@@ -14,13 +14,7 @@
 
 """Helper functions for shared behavior."""
 
-import re
-
 from gcloud._helpers import _name_from_project_path
-
-
-_TOPIC_PATH_TEMPLATE = re.compile(
-    r'projects/(?P<project>\w+)/topics/(?P<name>\w+)')
 
 
 def topic_name_from_path(path, project):
@@ -39,11 +33,8 @@ def topic_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _TOPIC_PATH_TEMPLATE)
-
-
-_SUBSCRIPTION_PATH_TEMPLATE = re.compile(
-    r'projects/(?P<project>\w+)/subscriptions/(?P<name>\w+)')
+    template = r'projects/(?P<project>\w+)/topics/(?P<name>\w+)'
+    return _name_from_project_path(path, project, template)
 
 
 def subscription_name_from_path(path, project):
@@ -62,4 +53,5 @@ def subscription_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _SUBSCRIPTION_PATH_TEMPLATE)
+    template = r'projects/(?P<project>\w+)/subscriptions/(?P<name>\w+)'
+    return _name_from_project_path(path, project, template)

--- a/gcloud/pubsub/_helpers.py
+++ b/gcloud/pubsub/_helpers.py
@@ -14,6 +14,14 @@
 
 """Helper functions for shared behavior."""
 
+import re
+
+from gcloud._helpers import _name_from_project_path
+
+
+_TOPIC_PATH_TEMPLATE = re.compile(
+    r'projects/(?P<project>\w+)/topics/(?P<name>\w+)')
+
 
 def topic_name_from_path(path, project):
     """Validate a topic URI path and get the topic name.
@@ -31,18 +39,11 @@ def topic_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    # PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-    path_parts = path.split('/')
-    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
-            path_parts[2] != 'topics'):
-        raise ValueError('Expected path to be of the form '
-                         'projects/{project}/topics/{topic_name}')
-    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
-            path_parts[2] != 'topics' or path_parts[1] != project):
-        raise ValueError('Project from client should agree with '
-                         'project from resource.')
+    return _name_from_project_path(path, project, _TOPIC_PATH_TEMPLATE)
 
-    return path_parts[3]
+
+_SUBSCRIPTION_PATH_TEMPLATE = re.compile(
+    r'projects/(?P<project>\w+)/subscriptions/(?P<name>\w+)')
 
 
 def subscription_name_from_path(path, project):
@@ -61,16 +62,4 @@ def subscription_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    # PATH = 'projects/%s/subscriptions/%s' % (PROJECT, TOPIC_NAME)
-    path_parts = path.split('/')
-    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
-            path_parts[2] != 'subscriptions'):
-        raise ValueError(
-            'Expected path to be of the form '
-            'projects/{project}/subscriptions/{subscription_name}')
-    if (len(path_parts) != 4 or path_parts[0] != 'projects' or
-            path_parts[2] != 'subscriptions' or path_parts[1] != project):
-        raise ValueError('Project from client should agree with '
-                         'project from resource.')
-
-    return path_parts[3]
+    return _name_from_project_path(path, project, _SUBSCRIPTION_PATH_TEMPLATE)

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -80,8 +80,7 @@ class Client(JSONClient):
                   for resource in resp.get('topics', ())]
         return topics, resp.get('nextPageToken')
 
-    def list_subscriptions(self, page_size=None, page_token=None,
-                           topic_name=None):
+    def list_subscriptions(self, page_size=None, page_token=None):
         """List subscriptions for the project associated with this client.
 
         See:
@@ -99,10 +98,6 @@ class Client(JSONClient):
                            passed, the API will return the first page of
                            topics.
 
-        :type topic_name: string
-        :param topic_name: limit results to subscriptions bound to the given
-                           topic.
-
         :rtype: tuple, (list, str)
         :returns: list of :class:`gcloud.pubsub.subscription.Subscription`,
                   plus a "next page token" string:  if not None, indicates that
@@ -117,11 +112,7 @@ class Client(JSONClient):
         if page_token is not None:
             params['pageToken'] = page_token
 
-        if topic_name is None:
-            path = '/projects/%s/subscriptions' % (self.project,)
-        else:
-            path = '/projects/%s/topics/%s/subscriptions' % (self.project,
-                                                             topic_name)
+        path = '/projects/%s/subscriptions' % (self.project,)
 
         resp = self.connection.api_request(method='GET', path=path,
                                            query_params=params)

--- a/gcloud/pubsub/test__helpers.py
+++ b/gcloud/pubsub/test__helpers.py
@@ -21,25 +21,7 @@ class Test_topic_name_from_path(unittest2.TestCase):
         from gcloud.pubsub._helpers import topic_name_from_path
         return topic_name_from_path(path, project)
 
-    def test_invalid_path_length(self):
-        PATH = 'projects/foo'
-        PROJECT = None
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_path_format(self):
-        TOPIC_NAME = 'TOPIC_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'foo/%s/bar/%s' % (PROJECT, TOPIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_project(self):
-        TOPIC_NAME = 'TOPIC_NAME'
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        PATH = 'projects/%s/topics/%s' % (PROJECT1, TOPIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT2)
-
-    def test_valid_data(self):
+    def test_it(self):
         TOPIC_NAME = 'TOPIC_NAME'
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
@@ -53,25 +35,7 @@ class Test_subscription_name_from_path(unittest2.TestCase):
         from gcloud.pubsub._helpers import subscription_name_from_path
         return subscription_name_from_path(path, project)
 
-    def test_invalid_path_length(self):
-        PATH = 'projects/foo'
-        PROJECT = None
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_path_format(self):
-        TOPIC_NAME = 'TOPIC_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'foo/%s/bar/%s' % (PROJECT, TOPIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_project(self):
-        TOPIC_NAME = 'TOPIC_NAME'
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        PATH = 'projects/%s/subscriptions/%s' % (PROJECT1, TOPIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT2)
-
-    def test_valid_data(self):
+    def test_it(self):
         TOPIC_NAME = 'TOPIC_NAME'
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/subscriptions/%s' % (PROJECT, TOPIC_NAME)

--- a/gcloud/pubsub/test__helpers.py
+++ b/gcloud/pubsub/test__helpers.py
@@ -45,3 +45,35 @@ class Test_topic_name_from_path(unittest2.TestCase):
         PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
         topic_name = self._callFUT(PATH, PROJECT)
         self.assertEqual(topic_name, TOPIC_NAME)
+
+
+class Test_subscription_name_from_path(unittest2.TestCase):
+
+    def _callFUT(self, path, project):
+        from gcloud.pubsub._helpers import subscription_name_from_path
+        return subscription_name_from_path(path, project)
+
+    def test_invalid_path_length(self):
+        PATH = 'projects/foo'
+        PROJECT = None
+        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
+
+    def test_invalid_path_format(self):
+        TOPIC_NAME = 'TOPIC_NAME'
+        PROJECT = 'PROJECT'
+        PATH = 'foo/%s/bar/%s' % (PROJECT, TOPIC_NAME)
+        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
+
+    def test_invalid_project(self):
+        TOPIC_NAME = 'TOPIC_NAME'
+        PROJECT1 = 'PROJECT1'
+        PROJECT2 = 'PROJECT2'
+        PATH = 'projects/%s/subscriptions/%s' % (PROJECT1, TOPIC_NAME)
+        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT2)
+
+    def test_valid_data(self):
+        TOPIC_NAME = 'TOPIC_NAME'
+        PROJECT = 'PROJECT'
+        PATH = 'projects/%s/subscriptions/%s' % (PROJECT, TOPIC_NAME)
+        subscription_name = self._callFUT(PATH, PROJECT)
+        self.assertEqual(subscription_name, TOPIC_NAME)

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -196,47 +196,6 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['path'], '/projects/%s/subscriptions' % PROJECT)
         self.assertEqual(req['query_params'], {})
 
-    def test_list_subscriptions_with_topic_name(self):
-        from gcloud.pubsub.subscription import Subscription
-        PROJECT = 'PROJECT'
-        CREDS = _Credentials()
-
-        CLIENT_OBJ = self._makeOne(project=PROJECT, credentials=CREDS)
-
-        SUB_NAME_1 = 'subscription_1'
-        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_1)
-        SUB_NAME_2 = 'subscription_2'
-        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_2)
-        TOPIC_NAME = 'topic_name'
-        TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        SUB_INFO = [{'name': SUB_PATH_1, 'topic': TOPIC_PATH},
-                    {'name': SUB_PATH_2, 'topic': TOPIC_PATH}]
-        TOKEN = 'TOKEN'
-        RETURNED = {'subscriptions': SUB_INFO, 'nextPageToken': TOKEN}
-        # Replace the connection on the client with one of our own.
-        CLIENT_OBJ.connection = _Connection(RETURNED)
-
-        # Execute request.
-        subscriptions, next_page_token = CLIENT_OBJ.list_subscriptions(
-            topic_name=TOPIC_NAME)
-        # Test values are correct.
-        self.assertEqual(len(subscriptions), 2)
-        self.assertTrue(isinstance(subscriptions[0], Subscription))
-        self.assertEqual(subscriptions[0].name, SUB_NAME_1)
-        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
-        self.assertTrue(isinstance(subscriptions[1], Subscription))
-        self.assertEqual(subscriptions[1].name, SUB_NAME_2)
-        self.assertEqual(subscriptions[1].topic.name, TOPIC_NAME)
-        self.assertTrue(subscriptions[1].topic is subscriptions[0].topic)
-        self.assertEqual(next_page_token, TOKEN)
-        self.assertEqual(len(CLIENT_OBJ.connection._requested), 1)
-        req = CLIENT_OBJ.connection._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'],
-                         '/projects/%s/topics/%s/subscriptions'
-                         % (PROJECT, TOPIC_NAME))
-        self.assertEqual(req['query_params'], {})
-
     def test_topic(self):
         PROJECT = 'PROJECT'
         TOPIC_NAME = 'TOPIC_NAME'

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -526,6 +526,41 @@ class Test__datetime_to_pb_timestamp(unittest2.TestCase):
         self.assertEqual(self._callFUT(dt_stamp), timestamp)
 
 
+class Test__name_from_project_path(unittest2.TestCase):
+
+    PROJECT = 'PROJECT'
+    THING_NAME = 'THING_NAME'
+    TEMPLATE = r'projects/(?P<project>\w+)/things/(?P<name>\w+)'
+
+    def _callFUT(self, path, project, template):
+        from gcloud._helpers import _name_from_project_path
+        return _name_from_project_path(path, project, template)
+
+    def test_w_invalid_path_length(self):
+        PATH = 'projects/foo'
+        with self.assertRaises(ValueError):
+            self._callFUT(PATH, None, self.TEMPLATE)
+
+    def test_w_invalid_path_segments(self):
+        PATH = 'foo/%s/bar/%s' % (self.PROJECT, self.THING_NAME)
+        with self.assertRaises(ValueError):
+            self._callFUT(PATH, self.PROJECT, self.TEMPLATE)
+
+    def test_w_mismatched_project(self):
+        PROJECT1 = 'PROJECT1'
+        PROJECT2 = 'PROJECT2'
+        PATH = 'projects/%s/things/%s' % (PROJECT1, self.THING_NAME)
+        with self.assertRaises(ValueError):
+            self._callFUT(PATH, PROJECT2, self.TEMPLATE)
+
+    def test_w_valid_data_w_compiled_regex(self):
+        import re
+        template = re.compile(self.TEMPLATE)
+        PATH = 'projects/%s/things/%s' % (self.PROJECT, self.THING_NAME)
+        name = self._callFUT(PATH, self.PROJECT, template)
+        self.assertEqual(name, self.THING_NAME)
+
+
 class _AppIdentity(object):
 
     def __init__(self, app_id):

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -118,8 +118,7 @@ class TestPubsub(unittest2.TestCase):
         self.assertFalse(topic.exists())
         topic.create()
         self.to_delete.append(topic)
-        empty, _ = Config.CLIENT.list_subscriptions(
-            topic_name=DEFAULT_TOPIC_NAME)
+        empty, _ = topic.list_subscriptions()
         self.assertEqual(len(empty), 0)
         subscriptions_to_create = [
             'new%d' % (1000 * time.time(),),
@@ -132,10 +131,9 @@ class TestPubsub(unittest2.TestCase):
             self.to_delete.append(subscription)
 
         # Retrieve the subscriptions.
-        all_subscriptions, _ = Config.CLIENT.list_subscriptions()
+        all_subscriptions, _ = topic.list_subscriptions()
         created = [subscription for subscription in all_subscriptions
-                   if subscription.name in subscriptions_to_create and
-                   subscription.topic.name == DEFAULT_TOPIC_NAME]
+                   if subscription.name in subscriptions_to_create]
         self.assertEqual(len(created), len(subscriptions_to_create))
 
     def test_message_pull_mode_e2e(self):


### PR DESCRIPTION
Make it handle the fact that the API returns only subscription paths,
not resources.

Drop the 'topic_name' argument to 'Client.list_subscriptions'.

Fixes #1485.