### PR TITLE
Hide 'six' and 'google.protobuf' from pylint's borked import sniffing.

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -25,7 +25,7 @@ import sys
 
 from google.protobuf import timestamp_pb2
 import six
-from six.moves.http_client import HTTPConnection  # pylint: disable=F0401
+from six.moves.http_client import HTTPConnection
 
 from gcloud.environment_vars import PROJECT
 

--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -17,7 +17,7 @@
 import json
 from pkg_resources import get_distribution
 import six
-from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
+from six.moves.urllib.parse import urlencode
 
 import httplib2
 

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -17,7 +17,7 @@
 import base64
 import datetime
 import six
-from six.moves.urllib.parse import urlencode  # pylint: disable=F0401
+from six.moves.urllib.parse import urlencode
 
 from oauth2client import client
 

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -22,7 +22,7 @@ import os
 import time
 
 import six
-from six.moves.urllib.parse import quote  # pylint: disable=F0401
+from six.moves.urllib.parse import quote
 
 from gcloud._helpers import _rfc3339_to_datetime
 from gcloud.credentials import generate_signed_url

--- a/gcloud/streaming/http_wrapper.py
+++ b/gcloud/streaming/http_wrapper.py
@@ -12,8 +12,8 @@ import time
 
 import httplib2
 import six
-from six.moves import http_client   # pylint: disable=F0401
-from six.moves.urllib import parse  # pylint: disable=F0401
+from six.moves import http_client
+from six.moves.urllib import parse
 
 from gcloud.streaming.exceptions import BadStatusCodeError
 from gcloud.streaming.exceptions import RequestError

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -320,6 +320,9 @@ good-names = i, j, k, ex, Run, _,
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis
 # DEFAULT:  ignored-modules=
+# RATIONALE:  six aliases stuff for compatibility.
+#             google.protobuf fixes up namespace package "late".
+ignored-modules = six, google.protobuf
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).


### PR DESCRIPTION
Nice bonus:  we get to remove a bunch of '# pylint: disable=E0401'.