### PR TITLE
Making common subclass for Bigtable DirectRow and ConditionalRow.

### DIFF
--- a/docs/bigtable-row.rst
+++ b/docs/bigtable-row.rst
@@ -5,3 +5,4 @@ Bigtable Row
   :members:
   :undoc-members:
   :show-inheritance:
+  :inherited-members:


### PR DESCRIPTION
This is a follow-up to #1557 and prevents strange-ly true statements like `isinstance(cond_row, DirectRow)`.

Sorry it took me so many days. Code has been completely written for 2+ days but I haven't ever had my laptop near internet long enough to push it.