### PR TITLE
Adding HappyBase system tests for families and counters.

### DIFF
--- a/gcloud/bigtable/happybase/test_table.py
+++ b/gcloud/bigtable/happybase/test_table.py
@@ -1265,8 +1265,8 @@ class Test__filter_chain_helper(unittest2.TestCase):
 
         # Relies on the fact that RowFilter instances can
         # only have one value set.
-        self.assertEqual(fam_filter.regex, col_fam)
-        self.assertEqual(qual_filter.regex, qual)
+        self.assertEqual(fam_filter.regex, col_fam.encode('utf-8'))
+        self.assertEqual(qual_filter.regex, qual.encode('utf-8'))
 
         return result
 
@@ -1356,14 +1356,14 @@ class Test__columns_filter_helper(unittest2.TestCase):
         filter2 = result.filters[1]
 
         self.assertTrue(isinstance(filter1, FamilyNameRegexFilter))
-        self.assertEqual(filter1.regex, col_fam1)
+        self.assertEqual(filter1.regex, col_fam1.encode('utf-8'))
 
         self.assertTrue(isinstance(filter2, RowFilterChain))
         filter2a, filter2b = filter2.filters
         self.assertTrue(isinstance(filter2a, FamilyNameRegexFilter))
-        self.assertEqual(filter2a.regex, col_fam2)
+        self.assertEqual(filter2a.regex, col_fam2.encode('utf-8'))
         self.assertTrue(isinstance(filter2b, ColumnQualifierRegexFilter))
-        self.assertEqual(filter2b.regex, col_qual2)
+        self.assertEqual(filter2b.regex, col_qual2.encode('utf-8'))
 
 
 class Test__row_keys_filter_helper(unittest2.TestCase):

--- a/gcloud/bigtable/row_filters.py
+++ b/gcloud/bigtable/row_filters.py
@@ -119,7 +119,7 @@ class _RegexFilter(RowFilter):
     """
 
     def __init__(self, regex):
-        self.regex = regex
+        self.regex = _to_bytes(regex)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/gcloud/bigtable/test_row_filters.py
+++ b/gcloud/bigtable/test_row_filters.py
@@ -117,24 +117,29 @@ class Test_RegexFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_constructor(self):
-        regex = object()
+        regex = b'abc'
         row_filter = self._makeOne(regex)
         self.assertTrue(row_filter.regex is regex)
 
+    def test_constructor_non_bytes(self):
+        regex = u'abc'
+        row_filter = self._makeOne(regex)
+        self.assertEqual(row_filter.regex, b'abc')
+
     def test___eq__type_differ(self):
-        regex = object()
+        regex = b'def-rgx'
         row_filter1 = self._makeOne(regex)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
-        regex = object()
+        regex = b'trex-regex'
         row_filter1 = self._makeOne(regex)
         row_filter2 = self._makeOne(regex)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___ne__same_value(self):
-        regex = object()
+        regex = b'abc'
         row_filter1 = self._makeOne(regex)
         row_filter2 = self._makeOne(regex)
         comparison_val = (row_filter1 != row_filter2)


### PR DESCRIPTION
These tests exposed an issue with regex filters. When a protobuf bytes field received a unicode object, bad things happened.