### PR TITLE
Add system test for 'Client.list_metrics'.

### DIFF
--- a/gcloud/logging/metric.py
+++ b/gcloud/logging/metric.py
@@ -106,11 +106,8 @@ class Metric(object):
 
         :rtype: :class:`gcloud.logging.metric.Metric`
         :returns: Metric parsed from ``resource``.
-        :raises: :class:`ValueError` if ``client`` is not ``None`` and the
-                 project from the resource does not agree with the project
-                 from the client.
         """
-        metric_name = _metric_name_from_path(resource['name'], client.project)
+        metric_name = resource['name']
         filter_ = resource['filter']
         description = resource.get('description', '')
         return cls(metric_name, filter_, client=client,

--- a/gcloud/logging/test_client.py
+++ b/gcloud/logging/test_client.py
@@ -294,11 +294,9 @@ class TestClient(unittest2.TestCase):
 
         CLIENT_OBJ = self._makeOne(project=PROJECT, credentials=CREDS)
 
-        METRIC_PATH = 'projects/%s/metrics/%s' % (PROJECT, self.METRIC_NAME)
-
         RETURNED = {
             'metrics': [{
-                'name': METRIC_PATH,
+                'name': self.METRIC_NAME,
                 'filter': self.FILTER,
                 'description': self.DESCRIPTION,
             }],
@@ -329,13 +327,12 @@ class TestClient(unittest2.TestCase):
 
         CLIENT_OBJ = self._makeOne(project=PROJECT, credentials=CREDS)
 
-        METRIC_PATH = 'projects/%s/metrics/%s' % (PROJECT, self.METRIC_NAME)
         TOKEN1 = 'TOKEN1'
         TOKEN2 = 'TOKEN2'
         SIZE = 1
         RETURNED = {
             'metrics': [{
-                'name': METRIC_PATH,
+                'name': self.METRIC_NAME,
                 'filter': self.FILTER,
                 'description': self.DESCRIPTION,
             }],

--- a/gcloud/logging/test_metric.py
+++ b/gcloud/logging/test_metric.py
@@ -92,7 +92,7 @@ class TestMetric(unittest2.TestCase):
         CLIENT = _Client(project=self.PROJECT)
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         RESOURCE = {
-            'name': FULL,
+            'name': self.METRIC_NAME,
             'filter': self.FILTER,
         }
         klass = self._getTargetClass()
@@ -109,7 +109,7 @@ class TestMetric(unittest2.TestCase):
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         DESCRIPTION = 'DESCRIPTION'
         RESOURCE = {
-            'name': FULL,
+            'name': self.METRIC_NAME,
             'filter': self.FILTER,
             'description': DESCRIPTION,
         }
@@ -121,16 +121,6 @@ class TestMetric(unittest2.TestCase):
         self.assertTrue(metric._client is CLIENT)
         self.assertEqual(metric.project, self.PROJECT)
         self.assertEqual(metric.full_name, FULL)
-
-    def test_from_api_repr_with_mismatched_project(self):
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        CLIENT = _Client(project=PROJECT1)
-        FULL = 'projects/%s/metrics/%s' % (PROJECT2, self.METRIC_NAME)
-        RESOURCE = {'name': FULL, 'filter': self.FILTER}
-        klass = self._getTargetClass()
-        self.assertRaises(ValueError, klass.from_api_repr,
-                          RESOURCE, client=CLIENT)
 
     def test_create_w_bound_client(self):
         TARGET = 'projects/%s/metrics' % (self.PROJECT,)

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -80,3 +80,17 @@ class TestLogging(unittest2.TestCase):
         metric.create()
         self.to_delete.append(metric)
         self.assertTrue(metric.exists())
+
+    def test_list_metrics(self):
+        metric = Config.CLIENT.metric(
+            DEFAULT_METRIC_NAME, DEFAULT_FILTER, DEFAULT_DESCRIPTION)
+        self.assertFalse(metric.exists())
+        before_metrics, _ = Config.CLIENT.list_metrics()
+        before_names = set(metric.name for metric in before_metrics)
+        metric.create()
+        self.to_delete.append(metric)
+        self.assertTrue(metric.exists())
+        after_metrics, _ = Config.CLIENT.list_metrics()
+        after_names = set(metric.name for metric in after_metrics)
+        self.assertEqual(after_names - before_names,
+                         set([DEFAULT_METRIC_NAME]))


### PR DESCRIPTION
~~Uses #1610 as a base.~~

Note the changes to `gcloud.logging`:  the system test revealed that the API [returns "simple" names for the `LogMetric` resource](https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics#LogMetric) (as documented, but which I misread as returning fully-qualified paths).