### PR TITLE
Fix verb / target for 'Metric.create' / 'Sink.create'.

### DIFF
--- a/gcloud/logging/metric.py
+++ b/gcloud/logging/metric.py
@@ -141,13 +141,14 @@ class Metric(object):
                        ``client`` stored on the current metric.
         """
         client = self._require_client(client)
+        target = '/projects/%s/metrics' % (self.project,)
         data = {
             'name': self.name,
             'filter': self.filter_,
         }
         if self.description:
             data['description'] = self.description
-        client.connection.api_request(method='PUT', path=self.path, data=data)
+        client.connection.api_request(method='POST', path=target, data=data)
 
     def exists(self, client=None):
         """API call:  test for the existence of the metric via a GET request

--- a/gcloud/logging/sink.py
+++ b/gcloud/logging/sink.py
@@ -137,12 +137,13 @@ class Sink(object):
                        ``client`` stored on the current sink.
         """
         client = self._require_client(client)
+        target = '/projects/%s/sinks' % (self.project,)
         data = {
             'name': self.name,
             'filter': self.filter_,
             'destination': self.destination,
         }
-        client.connection.api_request(method='PUT', path=self.path, data=data)
+        client.connection.api_request(method='POST', path=target, data=data)
 
     def exists(self, client=None):
         """API call:  test for the existence of the sink via a GET request

--- a/gcloud/logging/test_metric.py
+++ b/gcloud/logging/test_metric.py
@@ -133,31 +133,31 @@ class TestMetric(unittest2.TestCase):
                           RESOURCE, client=CLIENT)
 
     def test_create_w_bound_client(self):
-        FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
+        TARGET = 'projects/%s/metrics' % (self.PROJECT,)
         RESOURCE = {
             'name': self.METRIC_NAME,
             'filter': self.FILTER,
         }
-        conn = _Connection({'name': FULL})
+        conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client)
         metric.create()
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % FULL)
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % TARGET)
         self.assertEqual(req['data'], RESOURCE)
 
     def test_create_w_alternate_client(self):
-        FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
+        TARGET = 'projects/%s/metrics' % (self.PROJECT,)
         RESOURCE = {
             'name': self.METRIC_NAME,
             'filter': self.FILTER,
             'description': self.DESCRIPTION,
         }
-        conn1 = _Connection({'name': FULL})
+        conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
-        conn2 = _Connection({'name': FULL})
+        conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1,
                                description=self.DESCRIPTION)
@@ -165,8 +165,8 @@ class TestMetric(unittest2.TestCase):
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % FULL)
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % TARGET)
         self.assertEqual(req['data'], RESOURCE)
 
     def test_exists_miss_w_bound_client(self):

--- a/gcloud/logging/test_sink.py
+++ b/gcloud/logging/test_sink.py
@@ -124,25 +124,25 @@ class TestSink(unittest2.TestCase):
                           RESOURCE, client=CLIENT)
 
     def test_create_w_bound_client(self):
-        FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
+        TARGET = 'projects/%s/sinks' % (self.PROJECT,)
         RESOURCE = {
             'name': self.SINK_NAME,
             'filter': self.FILTER,
             'destination': self.DESTINATION_URI,
         }
-        conn = _Connection({'name': FULL})
+        conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
         sink.create()
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % FULL)
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % TARGET)
         self.assertEqual(req['data'], RESOURCE)
 
     def test_create_w_alternate_client(self):
-        FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
+        TARGET = 'projects/%s/sinks' % (self.PROJECT,)
         RESOURCE = {
             'name': self.SINK_NAME,
             'filter': self.FILTER,
@@ -150,7 +150,7 @@ class TestSink(unittest2.TestCase):
         }
         conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
-        conn2 = _Connection({'name': FULL})
+        conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
@@ -158,8 +158,8 @@ class TestSink(unittest2.TestCase):
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % FULL)
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % TARGET)
         self.assertEqual(req['data'], RESOURCE)
 
     def test_exists_miss_w_bound_client(self):


### PR DESCRIPTION
- Spec mandates 'POST' to the container, rather than 'PUT' to the putative URL of the entity itself.

- Note that metric creation worked before;  sink creation is blocked due to permission issues (see #1614).