### PR TITLE
Use status_pb2.Status to parse error messages from Datastore

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -20,6 +20,7 @@ from gcloud import connection
 from gcloud.environment_vars import GCD_HOST
 from gcloud.exceptions import make_exception
 from gcloud.datastore._generated import datastore_pb2 as _datastore_pb2
+from google.rpc import status_pb2
 
 
 class Connection(connection.Connection):
@@ -89,7 +90,8 @@ class Connection(connection.Connection):
 
         status = headers['status']
         if status != '200':
-            raise make_exception(headers, content, use_json=False)
+            error_status = status_pb2.Status.FromString(content)
+            raise make_exception(headers, error_status.message, use_json=False)
 
         return content
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -153,12 +153,17 @@ class TestConnection(unittest2.TestCase):
 
     def test__request_not_200(self):
         from gcloud.exceptions import BadRequest
+        from google.rpc import status_pb2
+
+        error = status_pb2.Status()
+        error.message = 'Entity value is indexed.'
+        error.code = 9  # FAILED_PRECONDITION
 
         PROJECT = 'PROJECT'
         METHOD = 'METHOD'
         DATA = 'DATA'
         conn = self._makeOne()
-        conn._http = Http({'status': '400'}, b'Entity value is indexed.')
+        conn._http = Http({'status': '400'}, error.SerializeToString())
         with self.assertRaises(BadRequest) as e:
             conn._request(PROJECT, METHOD, DATA)
         expected_message = '400 Entity value is indexed.'


### PR DESCRIPTION
Addresses #1617 

Note that status has other information too that likely should get exposed. This is just an example of what the expected response is.
