### PR TITLE
Drop look-before-leap use of protobuf-internal type checker.

### DIFF
--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -19,7 +19,6 @@ The non-private functions are part of the API.
 
 import datetime
 
-from google.protobuf.internal.type_checkers import Int64ValueChecker
 import six
 
 from gcloud._helpers import _datetime_from_microseconds
@@ -29,8 +28,6 @@ from gcloud.datastore.entity import Entity
 from gcloud.datastore.key import Key
 
 __all__ = ('entity_from_protobuf', 'key_from_protobuf')
-
-INT_VALUE_CHECKER = Int64ValueChecker()
 
 
 def find_true_project(project, connection):
@@ -318,8 +315,7 @@ def _pb_attr_value(val):
     elif isinstance(val, float):
         name, value = 'double', val
     elif isinstance(val, six.integer_types):
-        INT_VALUE_CHECKER.CheckValue(val)   # Raise an exception if invalid.
-        name, value = 'integer', int(val)  # Always cast to an integer.
+        name, value = 'integer', val
     elif isinstance(val, six.text_type):
         name, value = 'string', val
     elif isinstance(val, (bytes, str)):

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -457,14 +457,6 @@ class Test__pb_attr_value(unittest2.TestCase):
         self.assertEqual(name, 'integer_value')
         self.assertEqual(value, must_be_long)
 
-    def test_long_too_small(self):
-        too_small = -(1 << 63) - 1
-        self.assertRaises(ValueError, self._callFUT, too_small)
-
-    def test_long_too_large(self):
-        too_large = 1 << 63
-        self.assertRaises(ValueError, self._callFUT, too_large)
-
     def test_native_str(self):
         import six
         name, value = self._callFUT('str')


### PR DESCRIPTION
The protobuf itself will raise the error when an out-of-bounds int/long value is assigned.

Addresses:
https://github.com/google/protobuf/issues/1307#issuecomment-197596703.