### PR TITLE
Fix Cloud Bigtable scopes.

### DIFF
--- a/gcloud/bigtable/client.py
+++ b/gcloud/bigtable/client.py
@@ -66,12 +66,11 @@ DATA_API_PORT = 443
 
 OPERATIONS_STUB_FACTORY = operations_grpc_pb2.beta_create_Operations_stub
 
-ADMIN_SCOPE = 'https://www.googleapis.com/auth/cloud-bigtable.admin'
+ADMIN_SCOPE = 'https://www.googleapis.com/auth/bigtable.admin'
 """Scope for interacting with the Cluster Admin and Table Admin APIs."""
-DATA_SCOPE = 'https://www.googleapis.com/auth/cloud-bigtable.data'
+DATA_SCOPE = 'https://www.googleapis.com/auth/bigtable.data'
 """Scope for reading and writing table data."""
-READ_ONLY_SCOPE = ('https://www.googleapis.com/auth/'
-                   'cloud-bigtable.data.readonly')
+READ_ONLY_SCOPE = 'https://www.googleapis.com/auth/bigtable.data.readonly'
 """Scope for reading table data."""
 
 DEFAULT_TIMEOUT_SECONDS = 10


### PR DESCRIPTION
Cloud Bigtable scopes are of the form
`https://www.googleapis.com/auth/bigtable.*`
per the docs: https://cloud.google.com/bigtable/docs/creating-vm-instance

Previously, they were listed with the form
`https://www.googleapis.com/auth/cloud-bigtable.*` which are invalid,
leading to user-reported errors.