### PR TITLE
Adding Bigtable system tests to tox environment (for Py2.7 only).

### DIFF
--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -35,6 +35,9 @@ MODULES = (
     'pubsub',
     'bigquery',
 )
+if sys.version_info[:2] == (2, 7):
+    MODULES += ('bigtable', 'bigtable-happybase')
+
 SCRIPTS_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.abspath(os.path.join(SCRIPTS_DIR, '..'))
 ENCRYPTED_KEYFILE = os.path.join(ROOT_DIR, 'system_tests', 'key.json.enc')

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,11 @@ basepython =
     python2.7
 commands =
     python {toxinidir}/system_tests/attempt_system_tests.py
+setenv =
+    PYTHONPATH =
+deps =
+    {[testenv]deps}
+    grpcio >= 0.13.0
 passenv = GOOGLE_* GCLOUD_* TRAVIS* encrypted_*
 
 [testenv:system-tests3]


### PR DESCRIPTION
Second (and third) attempt at #1633