### PR TITLE
#798: Add support for auto-acknowledging pulled messages.

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -287,9 +287,8 @@ error:
    ...     batch.publish('this is the first message_payload')
    ...     batch.publish('this is the second message_payload',
    ...                   attr1='value1', attr2='value2')
-   >>> from gcloud.pubsub.subscription import AutoAck
    >>> for ack_id, message in subscription.pull(max_messages=10):  # API request
-   ...     with AutoAck(subscription, ack_id, message):
+   ...     with subscription.auto_ack(subscription, ack_id, message):
    ...         do_something_with(message)
 
 .. note::

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -84,6 +84,20 @@ class Subscription(object):
         project = self.topic.project
         return '/projects/%s/subscriptions/%s' % (project, self.name)
 
+    def auto_ack(self, ack_id, message):
+        """:class:`AutoAck` factory
+
+        :type ack_id: string
+        :param ack_id: the ID for acknowledging the message
+
+        :type message: :class:`gcloud.pubsub.message.Message`
+        :param message: the message to be acknowleged
+
+        :rtype: :class:`AutoAck`
+        :returns: the instance created for the given ``ack_id`` and ``message``
+        """
+        return AutoAck(self, ack_id, message)
+
     def _require_client(self, client):
         """Check client or verify over-ride.
 

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -263,3 +263,29 @@ class Subscription(object):
         """
         client = self._require_client(client)
         client.connection.api_request(method='DELETE', path=self.path)
+
+
+class AutoAck(object):
+    """Automatically acknowlege a single message if processed without error.
+
+    :type subscription: :class:`Subscription`
+    :param subscription: the subscription from which the message was pulled,
+                         and to which it must be acknowledged.
+
+    :type ack_id: string
+    :param ack_id: the ID for acknowledging the message
+
+    :type message: :class:`gcloud.pubsub.message.Message`
+    :param message: the message to be acknowleged
+    """
+    def __init__(self, subscription, ack_id, message):
+        self.subscription = subscription
+        self.ack_id = ack_id
+        self.message = message
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.subscription.acknowledge([self.ack_id])

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -116,6 +116,19 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(subscription.ack_deadline, DEADLINE)
         self.assertEqual(subscription.push_endpoint, ENDPOINT)
 
+    def test_autoack(self):
+        from gcloud.pubsub.subscription import AutoAck
+        SUB_NAME = 'sub_name'
+        ACK_ID = 'ACK_ID'
+        TOPIC = object()
+        MESSAGE = object
+        subscription = self._makeOne(SUB_NAME, TOPIC)
+        auto_ack = subscription.auto_ack(ACK_ID, MESSAGE)
+        self.assertTrue(isinstance(auto_ack, AutoAck))
+        self.assertTrue(auto_ack.subscription is subscription)
+        self.assertEqual(auto_ack.ack_id, ACK_ID)
+        self.assertTrue(auto_ack.message is MESSAGE)
+
     def test_create_pull_wo_ack_deadline_w_bound_client(self):
         PROJECT = 'PROJECT'
         SUB_NAME = 'sub_name'


### PR DESCRIPTION
Follows @jgeewax's [suggested implementation](https://github.com/GoogleCloudPlatform/gcloud-python/issues/798#issuecomment-135787991).

Closes #798.

Hold off merging until comparing with the alternate implementation suggested by @tmatsuo (#1636).