### PR TITLE
Allow bytes or string as project value in datastore clients.

### DIFF
--- a/gcloud/client.py
+++ b/gcloud/client.py
@@ -132,20 +132,25 @@ class _ClientProjectMixin(object):
                     passed falls back to the default inferred from the
                     environment.
 
-    :raises: :class:`ValueError` if the project is neither passed in nor
-             set in the environment.
+    :raises: :class:`EnvironmentError` if the project is neither passed in nor
+             set in the environment. :class:`ValueError` if the project value
+             is invalid.
     """
 
     def __init__(self, project=None):
-        project = _determine_default_project(project)
+        project = self._determine_default(project)
         if project is None:
-            raise ValueError('Project was not passed and could not be '
-                             'determined from the environment.')
+            raise EnvironmentError('Project was not passed and could not be '
+                                   'determined from the environment.')
         if isinstance(project, six.binary_type):
             project = project.decode('utf-8')
         if not isinstance(project, six.string_types):
             raise ValueError('Project must be a string.')
         self.project = project
+
+    @staticmethod
+    def _determine_default(project):
+        return _determine_default_project(project)
 
 
 class JSONClient(Client, _ClientProjectMixin):

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -18,6 +18,7 @@ import os
 from gcloud._helpers import _LocalStack
 from gcloud._helpers import _app_engine_id
 from gcloud._helpers import _compute_engine_id
+from gcloud.client import _ClientProjectMixin
 from gcloud.client import Client as _BaseClient
 from gcloud.datastore import helpers
 from gcloud.datastore.connection import Connection
@@ -155,7 +156,7 @@ def _extended_lookup(connection, project, key_pbs,
     return results
 
 
-class Client(_BaseClient):
+class Client(_BaseClient, _ClientProjectMixin):
     """Convenience wrapper for invoking APIs/factories w/ a project.
 
     :type project: string
@@ -180,13 +181,14 @@ class Client(_BaseClient):
 
     def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
-        project = _determine_default_project(project)
-        if project is None:
-            raise EnvironmentError('Project could not be inferred.')
-        self.project = project
+        _ClientProjectMixin.__init__(self, project=project)
         self.namespace = namespace
         self._batch_stack = _LocalStack()
         super(Client, self).__init__(credentials, http)
+
+    @staticmethod
+    def _determine_default(project):
+        return _determine_default_project(project)
 
     def _push_batch(self, batch):
         """Push a batch/transaction onto our stack.

--- a/gcloud/test_client.py
+++ b/gcloud/test_client.py
@@ -171,7 +171,7 @@ class TestJSONClient(unittest2.TestCase):
             return None
 
         with _Monkey(client, _determine_default_project=mock_determine_proj):
-            self.assertRaises(ValueError, self._makeOne)
+            self.assertRaises(EnvironmentError, self._makeOne)
 
         self.assertEqual(FUNC_CALLS, [(None, '_determine_default_project')])
 


### PR DESCRIPTION
Fixes #1625. Was "fixed" in #1505 but missed datastore.

FYI @pcostell 