### PR TITLE
Add system tests for topic/subscription IAM policy get/set methods.

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -99,12 +99,12 @@ Test permissions allowed by the current IAM policy on a topic:
 .. doctest::
 
    >>> from gcloud import pubsub
-   >>> from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+   >>> from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
    >>> client = pubsub.Client()
    >>> topic = client.topic('topic_name')
    >>> allowed = topic.check_iam_permissions(
-   ...     [READER_ROLE, WRITER_ROLE, OWNER_ROLE])  # API request
-   >>> allowed == [READER_ROLE, WRITER_ROLE]
+   ...     [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE])  # API request
+   >>> allowed == [VIEWER_ROLE, EDITOR_ROLE]
    True
 
 
@@ -349,11 +349,11 @@ Test permissions allowed by the current IAM policy on a subscription:
 .. doctest::
 
    >>> from gcloud import pubsub
-   >>> from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+   >>> from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
    >>> client = pubsub.Client()
    >>> topic = client.topic('topic_name')
    >>> subscription = topic.subscription('subscription_name')
    >>> allowed = subscription.check_iam_permissions(
-   ...     [READER_ROLE, WRITER_ROLE, OWNER_ROLE])  # API request
-   >>> allowed == [READER_ROLE, WRITER_ROLE]
+   ...     [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE])  # API request
+   >>> allowed == [VIEWER_ROLE, EDITOR_ROLE]
    True

--- a/gcloud/pubsub/iam.py
+++ b/gcloud/pubsub/iam.py
@@ -40,8 +40,8 @@ class Policy(object):
         self.etag = etag
         self.version = version
         self.owners = set()
-        self.writers = set()
-        self.readers = set()
+        self.editors = set()
+        self.viewers = set()
 
     @staticmethod
     def user(email):
@@ -128,9 +128,9 @@ class Policy(object):
             if role == OWNER_ROLE:
                 policy.owners = members
             elif role == EDITOR_ROLE:
-                policy.writers = members
+                policy.editors = members
             elif role == VIEWER_ROLE:
-                policy.readers = members
+                policy.viewers = members
             else:
                 raise ValueError('Unknown role: %s' % (role,))
         return policy
@@ -155,13 +155,13 @@ class Policy(object):
             bindings.append(
                 {'role': OWNER_ROLE, 'members': sorted(self.owners)})
 
-        if self.writers:
+        if self.editors:
             bindings.append(
-                {'role': EDITOR_ROLE, 'members': sorted(self.writers)})
+                {'role': EDITOR_ROLE, 'members': sorted(self.editors)})
 
-        if self.readers:
+        if self.viewers:
             bindings.append(
-                {'role': VIEWER_ROLE, 'members': sorted(self.readers)})
+                {'role': VIEWER_ROLE, 'members': sorted(self.viewers)})
 
         if bindings:
             resource['bindings'] = bindings

--- a/gcloud/pubsub/iam.py
+++ b/gcloud/pubsub/iam.py
@@ -16,10 +16,10 @@
 OWNER_ROLE = 'roles/owner'
 """IAM permission implying all rights to an object."""
 
-WRITER_ROLE = 'roles/writer'
+EDITOR_ROLE = 'roles/editor'
 """IAM permission implying rights to modify an object."""
 
-READER_ROLE = 'roles/reader'
+VIEWER_ROLE = 'roles/viewer'
 """IAM permission implying rights to access an object without modifying it."""
 
 
@@ -127,9 +127,9 @@ class Policy(object):
             members = set(binding['members'])
             if role == OWNER_ROLE:
                 policy.owners = members
-            elif role == WRITER_ROLE:
+            elif role == EDITOR_ROLE:
                 policy.writers = members
-            elif role == READER_ROLE:
+            elif role == VIEWER_ROLE:
                 policy.readers = members
             else:
                 raise ValueError('Unknown role: %s' % (role,))
@@ -157,11 +157,11 @@ class Policy(object):
 
         if self.writers:
             bindings.append(
-                {'role': WRITER_ROLE, 'members': sorted(self.writers)})
+                {'role': EDITOR_ROLE, 'members': sorted(self.writers)})
 
         if self.readers:
             bindings.append(
-                {'role': READER_ROLE, 'members': sorted(self.readers)})
+                {'role': VIEWER_ROLE, 'members': sorted(self.readers)})
 
         if bindings:
             resource['bindings'] = bindings

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -305,8 +305,9 @@ class Subscription(object):
         client = self._require_client(client)
         path = '%s:setIamPolicy' % (self.path,)
         resource = policy.to_api_repr()
+        wrapped = {'policy': resource}
         resp = client.connection.api_request(
-            method='POST', path=path, data=resource)
+            method='POST', path=path, data=wrapped)
         return Policy.from_api_repr(resp)
 
     def check_iam_permissions(self, permissions, client=None):

--- a/gcloud/pubsub/test_iam.py
+++ b/gcloud/pubsub/test_iam.py
@@ -29,8 +29,8 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(policy.etag, None)
         self.assertEqual(policy.version, None)
         self.assertEqual(list(policy.owners), [])
-        self.assertEqual(list(policy.writers), [])
-        self.assertEqual(list(policy.readers), [])
+        self.assertEqual(list(policy.editors), [])
+        self.assertEqual(list(policy.viewers), [])
 
     def test_ctor_explicit(self):
         VERSION = 17
@@ -39,8 +39,8 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(policy.etag, ETAG)
         self.assertEqual(policy.version, VERSION)
         self.assertEqual(list(policy.owners), [])
-        self.assertEqual(list(policy.writers), [])
-        self.assertEqual(list(policy.readers), [])
+        self.assertEqual(list(policy.editors), [])
+        self.assertEqual(list(policy.viewers), [])
 
     def test_user(self):
         EMAIL = 'phred@example.com'
@@ -83,24 +83,24 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(policy.etag, 'ACAB')
         self.assertEqual(policy.version, None)
         self.assertEqual(list(policy.owners), [])
-        self.assertEqual(list(policy.writers), [])
-        self.assertEqual(list(policy.readers), [])
+        self.assertEqual(list(policy.editors), [])
+        self.assertEqual(list(policy.viewers), [])
 
     def test_from_api_repr_complete(self):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         RESOURCE = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         klass = self._getTargetClass()
@@ -108,8 +108,8 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(policy.etag, 'DEADBEEF')
         self.assertEqual(policy.version, 17)
         self.assertEqual(sorted(policy.owners), [OWNER2, OWNER1])
-        self.assertEqual(sorted(policy.writers), [WRITER1, WRITER2])
-        self.assertEqual(sorted(policy.readers), [READER1, READER2])
+        self.assertEqual(sorted(policy.editors), [EDITOR1, EDITOR2])
+        self.assertEqual(sorted(policy.viewers), [VIEWER1, VIEWER2])
 
     def test_from_api_repr_bad_role(self):
         BOGUS1 = 'user:phred@example.com'
@@ -137,24 +137,24 @@ class TestPolicy(unittest2.TestCase):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         EXPECTED = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         policy = self._makeOne('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
-        policy.writers.add(WRITER1)
-        policy.writers.add(WRITER2)
-        policy.readers.add(READER1)
-        policy.readers.add(READER2)
+        policy.editors.add(EDITOR1)
+        policy.editors.add(EDITOR2)
+        policy.viewers.add(VIEWER1)
+        policy.viewers.add(VIEWER2)
         self.assertEqual(policy.to_api_repr(), EXPECTED)

--- a/gcloud/pubsub/test_iam.py
+++ b/gcloud/pubsub/test_iam.py
@@ -87,7 +87,7 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(list(policy.readers), [])
 
     def test_from_api_repr_complete(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         WRITER1 = 'domain:google.com'
@@ -99,8 +99,8 @@ class TestPolicy(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         klass = self._getTargetClass()
@@ -134,7 +134,7 @@ class TestPolicy(unittest2.TestCase):
         self.assertEqual(policy.to_api_repr(), {'etag': 'DEADBEEF'})
 
     def test_to_api_repr_full(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         WRITER1 = 'domain:google.com'
@@ -146,8 +146,8 @@ class TestPolicy(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         policy = self._makeOne('DEADBEEF', 17)

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -642,12 +642,13 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['data'], {'policy': {}})
 
     def test_check_iam_permissions_w_bound_client(self):
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         PROJECT = 'PROJECT'
         TOPIC_NAME = 'topic_name'
         SUB_NAME = 'sub_name'
         PATH = 'projects/%s/subscriptions/%s:testIamPermissions' % (
             PROJECT, SUB_NAME)
-        ROLES = ['roles/viewer', 'roles/editor', 'roles/owner']
+        ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
         }
@@ -669,12 +670,13 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['data'], REQUESTED)
 
     def test_check_iam_permissions_w_alternate_client(self):
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         PROJECT = 'PROJECT'
         TOPIC_NAME = 'topic_name'
         SUB_NAME = 'sub_name'
         PATH = 'projects/%s/subscriptions/%s:testIamPermissions' % (
             PROJECT, SUB_NAME)
-        ROLES = ['roles/viewer', 'roles/editor', 'roles/owner']
+        ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
         }

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -488,17 +488,17 @@ class TestSubscription(unittest2.TestCase):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         POLICY = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         PROJECT = 'PROJECT'
@@ -517,8 +517,8 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(policy.etag, 'DEADBEEF')
         self.assertEqual(policy.version, 17)
         self.assertEqual(sorted(policy.owners), [OWNER2, OWNER1])
-        self.assertEqual(sorted(policy.writers), [WRITER1, WRITER2])
-        self.assertEqual(sorted(policy.readers), [READER1, READER2])
+        self.assertEqual(sorted(policy.editors), [EDITOR1, EDITOR2])
+        self.assertEqual(sorted(policy.viewers), [VIEWER1, VIEWER2])
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -547,8 +547,8 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(policy.etag, 'ACAB')
         self.assertEqual(policy.version, None)
         self.assertEqual(sorted(policy.owners), [])
-        self.assertEqual(sorted(policy.writers), [])
-        self.assertEqual(sorted(policy.readers), [])
+        self.assertEqual(sorted(policy.editors), [])
+        self.assertEqual(sorted(policy.viewers), [])
 
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
@@ -561,17 +561,17 @@ class TestSubscription(unittest2.TestCase):
         from gcloud.pubsub.iam import Policy
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         POLICY = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         RESPONSE = POLICY.copy()
@@ -590,18 +590,18 @@ class TestSubscription(unittest2.TestCase):
         policy = Policy('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
-        policy.writers.add(WRITER1)
-        policy.writers.add(WRITER2)
-        policy.readers.add(READER1)
-        policy.readers.add(READER2)
+        policy.editors.add(EDITOR1)
+        policy.editors.add(EDITOR2)
+        policy.viewers.add(VIEWER1)
+        policy.viewers.add(VIEWER2)
 
         new_policy = subscription.set_iam_policy(policy)
 
         self.assertEqual(new_policy.etag, 'ABACABAF')
         self.assertEqual(new_policy.version, 18)
         self.assertEqual(sorted(new_policy.owners), [OWNER1, OWNER2])
-        self.assertEqual(sorted(new_policy.writers), [WRITER1, WRITER2])
-        self.assertEqual(sorted(new_policy.readers), [READER1, READER2])
+        self.assertEqual(sorted(new_policy.editors), [EDITOR1, EDITOR2])
+        self.assertEqual(sorted(new_policy.viewers), [VIEWER1, VIEWER2])
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -631,8 +631,8 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(new_policy.etag, 'ACAB')
         self.assertEqual(new_policy.version, None)
         self.assertEqual(sorted(new_policy.owners), [])
-        self.assertEqual(sorted(new_policy.writers), [])
-        self.assertEqual(sorted(new_policy.readers), [])
+        self.assertEqual(sorted(new_policy.editors), [])
+        self.assertEqual(sorted(new_policy.viewers), [])
 
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -485,7 +485,7 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['path'], '/%s' % SUB_PATH)
 
     def test_get_iam_policy_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         WRITER1 = 'domain:google.com'
@@ -497,8 +497,8 @@ class TestSubscription(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         PROJECT = 'PROJECT'
@@ -557,7 +557,7 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_set_iam_policy_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         from gcloud.pubsub.iam import Policy
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
@@ -570,8 +570,8 @@ class TestSubscription(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         RESPONSE = POLICY.copy()
@@ -607,7 +607,7 @@ class TestSubscription(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['data'], POLICY)
+        self.assertEqual(req['data'], {'policy': POLICY})
 
     def test_set_iam_policy_w_alternate_client(self):
         from gcloud.pubsub.iam import Policy
@@ -639,7 +639,7 @@ class TestSubscription(unittest2.TestCase):
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['data'], {})
+        self.assertEqual(req['data'], {'policy': {}})
 
     def test_check_iam_permissions_w_bound_client(self):
         PROJECT = 'PROJECT'
@@ -647,7 +647,7 @@ class TestSubscription(unittest2.TestCase):
         SUB_NAME = 'sub_name'
         PATH = 'projects/%s/subscriptions/%s:testIamPermissions' % (
             PROJECT, SUB_NAME)
-        ROLES = ['roles/reader', 'roles/writer', 'roles/owner']
+        ROLES = ['roles/viewer', 'roles/editor', 'roles/owner']
         REQUESTED = {
             'permissions': ROLES,
         }
@@ -674,7 +674,7 @@ class TestSubscription(unittest2.TestCase):
         SUB_NAME = 'sub_name'
         PATH = 'projects/%s/subscriptions/%s:testIamPermissions' % (
             PROJECT, SUB_NAME)
-        ROLES = ['roles/reader', 'roles/writer', 'roles/owner']
+        ROLES = ['roles/viewer', 'roles/editor', 'roles/owner']
         REQUESTED = {
             'permissions': ROLES,
         }

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -453,7 +453,7 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(req['query_params'], {})
 
     def test_get_iam_policy_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         WRITER1 = 'domain:google.com'
@@ -465,8 +465,8 @@ class TestTopic(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         TOPIC_NAME = 'topic_name'
@@ -522,7 +522,7 @@ class TestTopic(unittest2.TestCase):
 
     def test_set_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import Policy
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         WRITER1 = 'domain:google.com'
@@ -534,8 +534,8 @@ class TestTopic(unittest2.TestCase):
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': WRITER_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': READER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
+                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
             ],
         }
         RESPONSE = POLICY.copy()
@@ -569,7 +569,7 @@ class TestTopic(unittest2.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['data'], POLICY)
+        self.assertEqual(req['data'], {'policy': POLICY})
 
     def test_set_iam_policy_w_alternate_client(self):
         from gcloud.pubsub.iam import Policy
@@ -599,15 +599,15 @@ class TestTopic(unittest2.TestCase):
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['data'], {})
+        self.assertEqual(req['data'], {'policy': {}})
 
     def test_check_iam_permissions_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         TOPIC_NAME = 'topic_name'
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/topics/%s:testIamPermissions' % (
             PROJECT, TOPIC_NAME)
-        ROLES = [READER_ROLE, WRITER_ROLE, OWNER_ROLE]
+        ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
         }
@@ -628,12 +628,12 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(req['data'], REQUESTED)
 
     def test_check_iam_permissions_w_alternate_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, WRITER_ROLE, READER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         TOPIC_NAME = 'topic_name'
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/topics/%s:testIamPermissions' % (
             PROJECT, TOPIC_NAME)
-        ROLES = [READER_ROLE, WRITER_ROLE, OWNER_ROLE]
+        ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
         }

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -456,17 +456,17 @@ class TestTopic(unittest2.TestCase):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         POLICY = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         TOPIC_NAME = 'topic_name'
@@ -483,8 +483,8 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(policy.etag, 'DEADBEEF')
         self.assertEqual(policy.version, 17)
         self.assertEqual(sorted(policy.owners), [OWNER2, OWNER1])
-        self.assertEqual(sorted(policy.writers), [WRITER1, WRITER2])
-        self.assertEqual(sorted(policy.readers), [READER1, READER2])
+        self.assertEqual(sorted(policy.editors), [EDITOR1, EDITOR2])
+        self.assertEqual(sorted(policy.viewers), [VIEWER1, VIEWER2])
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -511,8 +511,8 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(policy.etag, 'ACAB')
         self.assertEqual(policy.version, None)
         self.assertEqual(sorted(policy.owners), [])
-        self.assertEqual(sorted(policy.writers), [])
-        self.assertEqual(sorted(policy.readers), [])
+        self.assertEqual(sorted(policy.editors), [])
+        self.assertEqual(sorted(policy.viewers), [])
 
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
@@ -525,17 +525,17 @@ class TestTopic(unittest2.TestCase):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
-        WRITER1 = 'domain:google.com'
-        WRITER2 = 'user:phred@example.com'
-        READER1 = 'serviceAccount:1234-abcdef@service.example.com'
-        READER2 = 'user:phred@example.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
         POLICY = {
             'etag': 'DEADBEEF',
             'version': 17,
             'bindings': [
                 {'role': OWNER_ROLE, 'members': [OWNER1, OWNER2]},
-                {'role': EDITOR_ROLE, 'members': [WRITER1, WRITER2]},
-                {'role': VIEWER_ROLE, 'members': [READER1, READER2]},
+                {'role': EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+                {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
         RESPONSE = POLICY.copy()
@@ -552,18 +552,18 @@ class TestTopic(unittest2.TestCase):
         policy = Policy('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
-        policy.writers.add(WRITER1)
-        policy.writers.add(WRITER2)
-        policy.readers.add(READER1)
-        policy.readers.add(READER2)
+        policy.editors.add(EDITOR1)
+        policy.editors.add(EDITOR2)
+        policy.viewers.add(VIEWER1)
+        policy.viewers.add(VIEWER2)
 
         new_policy = topic.set_iam_policy(policy)
 
         self.assertEqual(new_policy.etag, 'ABACABAF')
         self.assertEqual(new_policy.version, 18)
         self.assertEqual(sorted(new_policy.owners), [OWNER1, OWNER2])
-        self.assertEqual(sorted(new_policy.writers), [WRITER1, WRITER2])
-        self.assertEqual(sorted(new_policy.readers), [READER1, READER2])
+        self.assertEqual(sorted(new_policy.editors), [EDITOR1, EDITOR2])
+        self.assertEqual(sorted(new_policy.viewers), [VIEWER1, VIEWER2])
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -591,8 +591,8 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(new_policy.etag, 'ACAB')
         self.assertEqual(new_policy.version, None)
         self.assertEqual(sorted(new_policy.owners), [])
-        self.assertEqual(sorted(new_policy.writers), [])
-        self.assertEqual(sorted(new_policy.readers), [])
+        self.assertEqual(sorted(new_policy.editors), [])
+        self.assertEqual(sorted(new_policy.viewers), [])
 
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -299,8 +299,9 @@ class Topic(object):
         client = self._require_client(client)
         path = '%s:setIamPolicy' % (self.path,)
         resource = policy.to_api_repr()
+        wrapped = {'policy': resource}
         resp = client.connection.api_request(
-            method='POST', path=path, data=resource)
+            method='POST', path=path, data=wrapped)
         return Policy.from_api_repr(resp)
 
     def check_iam_permissions(self, permissions, client=None):

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -177,6 +177,7 @@ class TestPubsub(unittest2.TestCase):
         while count > 0 and not topic.exists():
             time.sleep(1)
             count -= 1
+        self.assertTrue(topic.exists())
         self.to_delete.append(topic)
         policy = topic.get_iam_policy()
         policy.readers.add(policy.user('jjg@google.com'))
@@ -200,6 +201,7 @@ class TestPubsub(unittest2.TestCase):
         while count > 0 and not subscription.exists():
             time.sleep(1)
             count -= 1
+        self.assertTrue(subscription.exists())
         self.to_delete.insert(0, subscription)
         policy = subscription.get_iam_policy()
         policy.readers.add(policy.user('jjg@google.com'))

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -89,7 +89,7 @@ class TestPubsub(unittest2.TestCase):
         self.assertFalse(topic.exists())
         topic.create()
         self.to_delete.append(topic)
-        SUBSCRIPTION_NAME = 'subscribing-now'
+        SUBSCRIPTION_NAME = 'subscribing-now-%d' % (1000 * time.time(),)
         subscription = topic.subscription(SUBSCRIPTION_NAME)
         self.assertFalse(subscription.exists())
         subscription.create()
@@ -103,7 +103,7 @@ class TestPubsub(unittest2.TestCase):
         self.assertFalse(topic.exists())
         topic.create()
         self.to_delete.append(topic)
-        SUBSCRIPTION_NAME = 'subscribing-now'
+        SUBSCRIPTION_NAME = 'subscribing-now-%d' % (1000 * time.time(),)
         subscription = topic.subscription(SUBSCRIPTION_NAME, ack_deadline=120)
         self.assertFalse(subscription.exists())
         subscription.create()
@@ -142,7 +142,7 @@ class TestPubsub(unittest2.TestCase):
         self.assertFalse(topic.exists())
         topic.create()
         self.to_delete.append(topic)
-        SUBSCRIPTION_NAME = 'subscribing-now'
+        SUBSCRIPTION_NAME = 'subscribing-now-%d' % (1000 * time.time(),)
         subscription = topic.subscription(SUBSCRIPTION_NAME)
         self.assertFalse(subscription.exists())
         subscription.create()
@@ -168,3 +168,40 @@ class TestPubsub(unittest2.TestCase):
         self.assertEqual(message1.attributes['extra'], EXTRA_1)
         self.assertEqual(message2.data, MESSAGE_2)
         self.assertEqual(message2.attributes['extra'], EXTRA_2)
+
+    def test_topic_iam_policy(self):
+        topic_name = 'test-topic-iam-policy-topic-%d' % (1000 * time.time(),)
+        topic = Config.CLIENT.topic(topic_name)
+        topic.create()
+        count = 5
+        while count > 0 and not topic.exists():
+            time.sleep(1)
+            count -= 1
+        self.to_delete.append(topic)
+        policy = topic.get_iam_policy()
+        policy.readers.add(policy.user('jjg@google.com'))
+        new_policy = topic.set_iam_policy(policy)
+        self.assertEqual(new_policy.readers, policy.readers)
+
+    def test_subscription_iam_policy(self):
+        topic_name = 'test-sub-iam-policy-topic-%d' % (1000 * time.time(),)
+        topic = Config.CLIENT.topic(topic_name)
+        topic.create()
+        count = 5
+        while count > 0 and not topic.exists():
+            time.sleep(1)
+            count -= 1
+        self.assertTrue(topic.exists())
+        self.to_delete.append(topic)
+        SUB_NAME = 'test-sub-iam-policy-sub-%d' % (1000 * time.time(),)
+        subscription = topic.subscription(SUB_NAME)
+        subscription.create()
+        count = 5
+        while count > 0 and not subscription.exists():
+            time.sleep(1)
+            count -= 1
+        self.to_delete.insert(0, subscription)
+        policy = subscription.get_iam_policy()
+        policy.readers.add(policy.user('jjg@google.com'))
+        new_policy = subscription.set_iam_policy(policy)
+        self.assertEqual(new_policy.readers, policy.readers)


### PR DESCRIPTION
The tests uncover a wart in the API:  `setIamPermissions` takes an extra wrapper element (`policy`) around the actual `Policy` resource.  I don't know where to report that issue.

The new system tests fail repeatedly for my system account with 503s:  adding retries (interspersed with `time.sleep(1)`) doesn't seem to help.  @tmatsuo can you comment?  (Note that I have made that account an owner of my project).