### PR TITLE
#1577:  allow logging protobuf entries

### DIFF
--- a/gcloud/logging/entries.py
+++ b/gcloud/logging/entries.py
@@ -14,6 +14,10 @@
 
 """Log entries within the Google Cloud Logging API."""
 
+import json
+
+from google.protobuf.json_format import Parse
+
 from gcloud._helpers import _rfc3339_nanos_to_datetime
 from gcloud.logging._helpers import logger_name_from_path
 
@@ -100,3 +104,11 @@ class ProtobufEntry(_BaseEntry):
     https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/LogEntry
     """
     _PAYLOAD_KEY = 'protoPayload'
+
+    def parse_message(self, message):
+        """Parse payload into a protobuf message.
+
+        :type message: Protobuf message
+        :param message: the message to be logged
+        """
+        Parse(json.dumps(self.payload), message)

--- a/gcloud/logging/entries.py
+++ b/gcloud/logging/entries.py
@@ -108,6 +108,8 @@ class ProtobufEntry(_BaseEntry):
     def parse_message(self, message):
         """Parse payload into a protobuf message.
 
+        Mutates the passed-in ``message`` in place.
+
         :type message: Protobuf message
         :param message: the message to be logged
         """

--- a/gcloud/logging/test_entries.py
+++ b/gcloud/logging/test_entries.py
@@ -122,6 +122,29 @@ class Test_BaseEntry(unittest2.TestCase):
         self.assertTrue(entry.logger is LOGGER)
 
 
+class TestProtobufEntry(unittest2.TestCase):
+
+    PROJECT = 'PROJECT'
+    LOGGER_NAME = 'LOGGER_NAME'
+
+    def _getTargetClass(self):
+        from gcloud.logging.entries import ProtobufEntry
+        return ProtobufEntry
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_message(self):
+        from google.protobuf.unittest_pb2 import BoolMessage
+        LOGGER = object()
+        PAYLOAD = {'data': True}
+        message = BoolMessage(data=False)
+        self.assertFalse(message.data)
+        entry = self._makeOne(PAYLOAD, LOGGER)
+        entry.parse_message(message)
+        self.assertTrue(message.data)
+
+
 def _datetime_to_rfc3339_w_nanos(value):
     from gcloud._helpers import _RFC3339_NO_FRACTION
     no_fraction = value.strftime(_RFC3339_NO_FRACTION)

--- a/gcloud/logging/test_entries.py
+++ b/gcloud/logging/test_entries.py
@@ -134,15 +134,17 @@ class TestProtobufEntry(unittest2.TestCase):
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
-    def test_message(self):
-        from google.protobuf.unittest_pb2 import BoolMessage
+    def test_parse_message(self):
+        import json
+        from google.protobuf.json_format import MessageToJson
+        from google.protobuf.struct_pb2 import Struct, Value
         LOGGER = object()
-        PAYLOAD = {'data': True}
-        message = BoolMessage(data=False)
-        self.assertFalse(message.data)
+        message = Struct(fields={'foo': Value(bool_value=False)})
+        with_true = Struct(fields={'foo': Value(bool_value=True)})
+        PAYLOAD = json.loads(MessageToJson(with_true))
         entry = self._makeOne(PAYLOAD, LOGGER)
         entry.parse_message(message)
-        self.assertTrue(message.data)
+        self.assertTrue(message.fields['foo'])
 
 
 def _datetime_to_rfc3339_w_nanos(value):

--- a/gcloud/logging/test_logger.py
+++ b/gcloud/logging/test_logger.py
@@ -128,19 +128,21 @@ class TestLogger(unittest2.TestCase):
         self.assertEqual(req['data'], SENT)
 
     def test_log_proto_w_implicit_client(self):
-        from google.protobuf.unittest_pb2 import BoolMessage
-        MESSAGE = BoolMessage(data=True)
+        import json
+        from google.protobuf.json_format import MessageToJson
+        from google.protobuf.struct_pb2 import Struct, Value
+        message = Struct(fields={'foo': Value(bool_value=True)})
         conn = _Connection({})
         client = _Client(self.PROJECT, conn)
         logger = self._makeOne(self.LOGGER_NAME, client=client)
-        logger.log_proto(MESSAGE)
+        logger.log_proto(message)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         SENT = {
             'entries': [{
                 'logName': 'projects/%s/logs/%s' % (
                     self.PROJECT, self.LOGGER_NAME),
-                'protoPayload': {'data': True},
+                'protoPayload': json.loads(MessageToJson(message)),
                 'resource': {
                     'type': 'global',
                 },
@@ -151,20 +153,22 @@ class TestLogger(unittest2.TestCase):
         self.assertEqual(req['data'], SENT)
 
     def test_log_proto_w_explicit_client(self):
-        from google.protobuf.unittest_pb2 import BoolMessage
-        MESSAGE = BoolMessage(data=True)
+        import json
+        from google.protobuf.json_format import MessageToJson
+        from google.protobuf.struct_pb2 import Struct, Value
+        message = Struct(fields={'foo': Value(bool_value=True)})
         conn = _Connection({})
         client1 = _Client(self.PROJECT, object())
         client2 = _Client(self.PROJECT, conn)
         logger = self._makeOne(self.LOGGER_NAME, client=client1)
-        logger.log_proto(MESSAGE, client=client2)
+        logger.log_proto(message, client=client2)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         SENT = {
             'entries': [{
                 'logName': 'projects/%s/logs/%s' % (
                     self.PROJECT, self.LOGGER_NAME),
-                'protoPayload': {'data': True},
+                'protoPayload': json.loads(MessageToJson(message)),
                 'resource': {
                     'type': 'global',
                 },

--- a/gcloud/logging/test_logger.py
+++ b/gcloud/logging/test_logger.py
@@ -127,6 +127,53 @@ class TestLogger(unittest2.TestCase):
         self.assertEqual(req['path'], '/entries:write')
         self.assertEqual(req['data'], SENT)
 
+    def test_log_proto_w_implicit_client(self):
+        from google.protobuf.unittest_pb2 import BoolMessage
+        MESSAGE = BoolMessage(data=True)
+        conn = _Connection({})
+        client = _Client(self.PROJECT, conn)
+        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger.log_proto(MESSAGE)
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        SENT = {
+            'entries': [{
+                'logName': 'projects/%s/logs/%s' % (
+                    self.PROJECT, self.LOGGER_NAME),
+                'protoPayload': {'data': True},
+                'resource': {
+                    'type': 'global',
+                },
+            }],
+        }
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/entries:write')
+        self.assertEqual(req['data'], SENT)
+
+    def test_log_proto_w_explicit_client(self):
+        from google.protobuf.unittest_pb2 import BoolMessage
+        MESSAGE = BoolMessage(data=True)
+        conn = _Connection({})
+        client1 = _Client(self.PROJECT, object())
+        client2 = _Client(self.PROJECT, conn)
+        logger = self._makeOne(self.LOGGER_NAME, client=client1)
+        logger.log_proto(MESSAGE, client=client2)
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        SENT = {
+            'entries': [{
+                'logName': 'projects/%s/logs/%s' % (
+                    self.PROJECT, self.LOGGER_NAME),
+                'protoPayload': {'data': True},
+                'resource': {
+                    'type': 'global',
+                },
+            }],
+        }
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/entries:write')
+        self.assertEqual(req['data'], SENT)
+
     def test_delete_w_bound_client(self):
         PATH = 'projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         conn = _Connection({})


### PR DESCRIPTION
Also, add a helper to parse an entry's payload into a protobuf message object.

Closes #1577