### PR TITLE
Allow predefined ACL names from either XML or JSON APIs.

### DIFF
--- a/gcloud/storage/acl.py
+++ b/gcloud/storage/acl.py
@@ -168,14 +168,24 @@ class ACL(object):
     _URL_PATH_ELEM = 'acl'
     _PREDEFINED_QUERY_PARAM = 'predefinedAcl'
 
-    _PREDEFINED_ACLS = frozenset([
+    PREDEFINED_XML_ACLS = {
+        # XML API name -> JSON API name
+        'project-private': 'projectPrivate',
+        'public-read': 'publicRead',
+        'public-read-write': 'publicReadWrite',
+        'authenticated-read': 'authenticatedRead',
+        'bucket-owner-read': 'bucketOwnerRead',
+        'bucket-owner-full-control': 'bucketOwnerFullControl',
+    }
+
+    PREDEFINED_JSON_ACLS = frozenset([
         'private',
-        'project-private',
-        'public-read',
-        'public-read-write',
-        'authenticated-read',
-        'bucket-owner-read',
-        'bucket-owner-full-control',
+        'projectPrivate',
+        'publicRead',
+        'publicReadWrite',
+        'authenticatedRead',
+        'bucketOwnerRead',
+        'bucketOwnerFullControl',
     ])
     """See:
     https://cloud.google.com/storage/docs/access-control#predefined-acl
@@ -409,7 +419,7 @@ class ACL(object):
 
         :type predefined: string or None
         :param predefined: An identifier for a predefined ACL.  Must be one
-                           of the keys in :attr:`_PREDEFINED_ACLS`
+                           of the keys in :attr:`PREDEFINED_JSON_ACLS`
                            If passed, `acl` must be None.
 
         :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
@@ -458,14 +468,18 @@ class ACL(object):
 
         :type predefined: string
         :param predefined: An identifier for a predefined ACL.  Must be one
-                           of the keys in :attr:`_PREDEFINED_ACLS`
+                           of the keys in :attr:`PREDEFINED_JSON_ACLS`
+                           or :attr:`PREDEFINED_XML_ACLS` (which will be
+                           aliased to the corresponding JSON name).
                            If passed, `acl` must be None.
 
         :type client: :class:`gcloud.storage.client.Client` or ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the ACL's parent.
         """
-        if predefined not in self._PREDEFINED_ACLS:
+        predefined = self.PREDEFINED_XML_ACLS.get(predefined, predefined)
+
+        if predefined not in self.PREDEFINED_JSON_ACLS:
             raise ValueError("Invalid predefined ACL: %s" % (predefined,))
 
         self._save(None, predefined, client)

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -648,9 +648,29 @@ class Test_ACL(unittest2.TestCase):
         self.assertEqual(kw[0]['query_params'],
                          {'projection': 'full', 'predefinedAcl': PREDEFINED})
 
+    def test_save_predefined_w_XML_alias(self):
+        PREDEFINED_XML = 'project-private'
+        PREDEFINED_JSON = 'projectPrivate'
+        connection = _Connection({'acl': []})
+        client = _Client(connection)
+        acl = self._makeOne()
+        acl.save_path = '/testing'
+        acl.loaded = True
+        acl.save_predefined(PREDEFINED_XML, client=client)
+        entries = list(acl)
+        self.assertEqual(len(entries), 0)
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': []})
+        self.assertEqual(kw[0]['query_params'],
+                         {'projection': 'full',
+                          'predefinedAcl': PREDEFINED_JSON})
+
     def test_save_predefined_valid_w_alternate_query_param(self):
         # Cover case where subclass overrides _PREDEFINED_QUERY_PARAM
-        PREDEFINED = 'private'
+        PREDEFINED = 'publicRead'
         connection = _Connection({'acl': []})
         client = _Client(connection)
         acl = self._makeOne()


### PR DESCRIPTION
Convert names from the XML API to the equivalent JSON names.

Fixes #1659.