### PR TITLE
Add explicit dep on 'sphinx_rtd_theme' for 'tox -e docs'.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands =
     python {toxinidir}/scripts/verify_included_modules.py
 deps =
     Sphinx
+    sphinx_rtd_theme
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD
 
 [testenv:docs-rtd]


### PR DESCRIPTION
Sphinx 1.4 dropped the dependency.