### PR TITLE
Make pubsub example snippets testable.

### DIFF
--- a/docs/pubsub-subscription.rst
+++ b/docs/pubsub-subscription.rst
@@ -3,5 +3,6 @@ Subscriptions
 
 .. automodule:: gcloud.pubsub.subscription
   :members:
+  :member-order: bysource
   :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-topic.rst
+++ b/docs/pubsub-topic.rst
@@ -3,5 +3,6 @@ Topics
 
 .. automodule:: gcloud.pubsub.topic
   :members:
+  :member-order: bysource
   :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -28,84 +28,47 @@ Authentication / Configuration
 Manage topics for a project
 ---------------------------
 
+List topics for the default project:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START client_list_topics]
+   :end-before: [END client_list_topics]
+
 Create a new topic for the default project:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> topic.create()  # API request
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_create]
+   :end-before: [END topic_create]
 
 Check for the existence of a topic:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> topic.exists()  # API request
-   True
-
-List topics for the default project:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topics, next_page_token = client.list_topics()  # API request
-   >>> [topic.name for topic in topics]
-   ['topic_name']
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_exists]
+   :end-before: [END topic_exists]
 
 Delete a topic:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> topic.delete()  # API request
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_delete]
+   :end-before: [END topic_delete]
 
 Fetch the IAM policy for a topic:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> policy = topic.get_iam_policy()  # API request
-   >>> policy.etag
-   'DEADBEEF'
-   >>> policy.owners
-   ['user:phred@example.com']
-   >>> policy.writers
-   ['systemAccount:abc-1234@systemaccounts.example.com']
-   >>> policy.readers
-   ['domain:example.com']
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_get_iam_policy]
+   :end-before: [END topic_get_iam_policy]
 
 Update the IAM policy for a topic:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> policy = topic.get_iam_policy()  # API request
-   >>> policy.writers.add(policy.group('editors-list@example.com'))
-   >>> topic.set_iam_policy(policy)  # API request
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_set_iam_policy]
+   :end-before: [END topic_set_iam_policy]
 
 Test permissions allowed by the current IAM policy on a topic:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> allowed = topic.check_iam_permissions(
-   ...     [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE])  # API request
-   >>> allowed == [VIEWER_ROLE, EDITOR_ROLE]
-   True
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_check_iam_permissions]
+   :end-before: [END topic_check_iam_permissions]
 
 
 Publish messages to a topic
@@ -113,144 +76,93 @@ Publish messages to a topic
 
 Publish a single message to a topic, without attributes:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> topic.publish('this is the message_payload')  # API request
-   <message_id>
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_publish_simple_message]
+   :end-before: [END topic_publish_simple_message]
 
 Publish a single message to a topic, with attributes:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> topic.publish('this is another message_payload',
-   ...               attr1='value1', attr2='value2')  # API request
-   <message_id>
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_publish_message_with_attrs]
+   :end-before: [END topic_publish_message_with_attrs]
 
 Publish a set of messages to a topic (as a single request):
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> with topic.batch() as batch:
-   ...     batch.publish('this is the first message_payload')
-   ...     batch.publish('this is the second message_payload',
-   ...                   attr1='value1', attr2='value2')
-   >>> list(batch)
-   [<message_id1>, <message_id2>]
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_batch]
+   :end-before: [END topic_batch]
 
 .. note::
 
    The only API request happens during the ``__exit__()`` of the topic
-   used as a context manager.
+   used as a context manager, and only if the block exits without raising
+   an exception.
 
 
 Manage subscriptions to topics
 ------------------------------
 
-Create a new pull subscription for a topic:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> subscription.create()  # API request
-
-Create a new pull subscription for a topic with a non-default ACK deadline:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name', ack_deadline=90)
-   >>> subscription.create()  # API request
-
-Create a new push subscription for a topic:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> ENDPOINT = 'https://example.com/hook'
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name',
-   ...                                   push_endpoint=ENDPOINT)
-   >>> subscription.create()  # API request
-
-Check for the existence of a subscription:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> subscription.exists()  # API request
-   True
-
-Convert a pull subscription to push:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> ENDPOINT = 'https://example.com/hook'
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> subscription.modify_push_configuration(push_endpoint=ENDPOINT)  # API request
-
-Convert a push subscription to pull:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> ENDPOINT = 'https://example.com/hook'
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name',
-   ...                                   push_endpoint=ENDPOINT)
-   >>> subscription.modify_push_configuration(push_endpoint=None)  # API request
-
-List subscriptions for a topic:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscriptions, next_page_token = topic.list_subscriptions()  # API request
-   >>> [subscription.name for subscription in subscriptions]
-   ['subscription_name']
-
 List all subscriptions for the default project:
 
 .. doctest::
 
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> subscription, next_page_tokens = client.list_subscriptions()  # API request
-   >>> [subscription.name for subscription in subscriptions]
-   ['subscription_name']
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START client_list_subscriptions]
+   :end-before: [END client_list_subscriptions]
+
+List subscriptions for a topic:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_list_subscriptions]
+   :end-before: [END topic_list_subscriptions]
+
+Create a new pull subscription for a topic, with defaults:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_subscription_defaults]
+   :end-before: [END topic_subscription_defaults]
+
+Create a new pull subscription for a topic with a non-default ACK deadline:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_subscription_ack90]
+   :end-before: [END topic_subscription_ack90]
+
+Create a new push subscription for a topic:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START topic_subscription_push]
+   :end-before: [END topic_subscription_push]
+
+Check for the existence of a subscription:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_exists]
+   :end-before: [END subscription_exists]
+
+Convert a pull subscription to push:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_pull_push]
+   :end-before: [END subscription_pull_push]
+
+Convert a push subscription to pull:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_push_pull]
+   :end-before: [END subscription_push_pull]
+
+Re-synchronize a subscription with the back-end:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_reload]
+   :end-before: [END subscription_reload]
 
 Delete a subscription:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> subscription.delete()  # API request
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_delete]
+   :end-before: [END subscription_delete]
 
 
 Pull messages from a subscription

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -170,61 +170,28 @@ Pull messages from a subscription
 
 Fetch pending messages for a pull subscription:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> with topic.batch() as batch:
-   ...     batch.publish('this is the first message_payload')
-   ...     batch.publish('this is the second message_payload',
-   ...                   attr1='value1', attr2='value2')
-   >>> received = subscription.pull()  # API request
-   >>> messages = [recv[1] for recv in received]
-   >>> [message.message_id for message in messages]
-   [<message_id1>, <message_id2>]
-   >>> [message.data for message in messages]
-   ['this is the first message_payload', 'this is the second message_payload']
-   >>> [message.attributes for message in messages]
-   [{}, {'attr1': 'value1', 'attr2': 'value2'}]
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_pull]
+   :end-before: [END subscription_pull]
 
 Note that received messages must be acknowledged, or else the back-end
 will re-send them later:
 
-.. doctest::
-
-   >>> ack_ids = [recv[0] for recv in received]
-   >>> subscription.acknowledge(ack_ids)
-
-Fetch a limited number of pending messages for a pull subscription:
-
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> with topic.batch() as batch:
-   ...     batch.publish('this is the first message_payload')
-   ...     batch.publish('this is the second message_payload',
-   ...                   attr1='value1', attr2='value2')
-   >>> received = subscription.pull(max_messages=1)  # API request
-   >>> messages = [recv[1] for recv in received]
-   >>> [message.message_id for message in messages]
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_acknowledge]
+   :end-before: [END subscription_acknowledge]
 
 Fetch messages for a pull subscription without blocking (none pending):
 
-.. doctest::
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_pull_return_immediately]
+   :end-before: [END subscription_pull_return_immediately]
 
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> received = subscription.pull(return_immediately=True)  # API request
-   >>> messages = [recv[1] for recv in received]
-   >>> [message.message_id for message in messages]
-   []
+Update the acknowlegement deadline for pulled messages:
+
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_modify_ack_deadline]
+   :end-before: [END subscription_modify_ack_deadline]
 
 Fetch the IAM policy for a subscription
 

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -195,44 +195,18 @@ Update the acknowlegement deadline for pulled messages:
 
 Fetch the IAM policy for a subscription
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> policy = subscription.get_iam_policy()  # API request
-   >>> policy.etag
-   'DEADBEEF'
-   >>> policy.owners
-   ['user:phred@example.com']
-   >>> policy.writers
-   ['systemAccount:abc-1234@systemaccounts.example.com']
-   >>> policy.readers
-   ['domain:example.com']
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_get_iam_policy]
+   :end-before: [END subscription_get_iam_policy]
 
 Update the IAM policy for a subscription:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> policy = subscription.get_iam_policy()  # API request
-   >>> policy.writers.add(policy.group('editors-list@example.com'))
-   >>> subscription.set_iam_policy(policy)  # API request
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_set_iam_policy]
+   :end-before: [END subscription_set_iam_policy]
 
 Test permissions allowed by the current IAM policy on a subscription:
 
-.. doctest::
-
-   >>> from gcloud import pubsub
-   >>> from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
-   >>> client = pubsub.Client()
-   >>> topic = client.topic('topic_name')
-   >>> subscription = topic.subscription('subscription_name')
-   >>> allowed = subscription.check_iam_permissions(
-   ...     [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE])  # API request
-   >>> allowed == [VIEWER_ROLE, EDITOR_ROLE]
-   True
+.. literalinclude:: pubsub_snippets.py
+   :start-after: [START subscription_check_iam_permissions]
+   :end-before: [END subscription_check_iam_permissions]

--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -1,0 +1,319 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testable usage examples for Google Cloud Pubsub API wrapper
+
+Each example function takes a ``client`` argument (which must be an instance
+of :class:`gcloud.pubsub.client.Client`) and uses it to perform a task with
+the API.
+
+To facility running the examples as system tests, each example is also passed
+a ``to_delete`` list;  the function adds to the list any objects created which
+need to be deleted during teardown.
+"""
+
+import time
+
+from gcloud.pubsub.client import Client
+
+
+def snippet(func):
+    """Mark ``func`` as a snippet example function."""
+    func._snippet = True
+    return func
+
+
+def _millis():
+    return time.time() * 1000
+
+
+@snippet
+def client_list_topics(client, to_delete):  # pylint: disable=unused-argument
+    """List topics for a project."""
+
+    def do_something_with(sub):  # pylint: disable=unused-argument
+        pass
+
+    # [START client_list_topics]
+    topics, token = client.list_topics()   # API request
+    while True:
+        for topic in topics:
+            do_something_with(topic)
+        if token is None:
+            break
+        topics, token = client.list_topics(page_token=token)  # API request
+    # [END client_list_topics]
+
+
+@snippet
+def client_list_subscriptions(client,
+                              to_delete):  # pylint: disable=unused-argument
+    """List all subscriptions for a project."""
+
+    def do_something_with(sub):  # pylint: disable=unused-argument
+        pass
+
+    # [START client_list_subscriptions]
+    subscriptions, token = client.list_subscriptions()   # API request
+    while True:
+        for subscription in subscriptions:
+            do_something_with(subscription)
+        if token is None:
+            break
+        subscriptions, token = client.list_subscriptions(
+            page_token=token)                           # API request
+    # [END client_list_subscriptions]
+
+
+@snippet
+def topic_create(client, to_delete):
+    """Create a topic."""
+    TOPIC_NAME = 'topic_create-%d' % (_millis(),)
+
+    # [START topic_create]
+    topic = client.topic(TOPIC_NAME)
+    topic.create()              # API request
+    # [END topic_create]
+
+    to_delete.append(topic)
+
+
+@snippet
+def topic_exists(client, to_delete):
+    """Test existence of a topic."""
+    TOPIC_NAME = 'topic_exists-%d' % (_millis(),)
+
+    # [START client_topic]
+    topic = client.topic(TOPIC_NAME)
+    # [END client_topic]
+
+    to_delete.append(topic)
+
+    # [START topic_exists]
+    assert not topic.exists()   # API request
+    topic.create()              # API request
+    assert topic.exists()       # API request
+    # [END topic_exists]
+
+
+@snippet
+def topic_delete(client, to_delete):  # pylint: disable=unused-argument
+    """Delete a topic."""
+    TOPIC_NAME = 'topic_delete-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()              # API request
+
+    # [START topic_delete]
+    assert topic.exists()       # API request
+    topic.delete()
+    assert not topic.exists()   # API request
+    # [END topic_delete]
+
+
+@snippet
+def topic_iam_policy(client, to_delete):
+    """Fetch / set a topic's IAM policy."""
+    TOPIC_NAME = 'topic_iam_policy-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_get_iam_policy]
+    policy = topic.get_iam_policy()             # API request
+    assert len(policy.viewers) == 0
+    assert len(policy.editors) == 0
+    assert len(policy.owners) == 0
+    # [END topic_get_iam_policy]
+
+    # [START topic_set_iam_policy]
+    ALL_USERS = policy.all_users()
+    policy.viewers.add(ALL_USERS)
+    LOGS_GROUP = policy.group('cloud-logs@google.com')
+    policy.editors.add(LOGS_GROUP)
+    new_policy = topic.set_iam_policy(policy)   # API request
+    assert ALL_USERS in new_policy.viewers
+    assert LOGS_GROUP in new_policy.editors
+    # [END topic_set_iam_policy]
+
+
+# @snippet   # Disabled due to #1687
+def topic_check_iam_permissions(client, to_delete):
+    """Check topic IAM permissions."""
+    TOPIC_NAME = 'topic_check_iam_permissions-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_check_iam_permissions]
+    from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+    TO_CHECK = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
+    ALLOWED = topic.check_iam_permissions(TO_CHECK)
+    assert set(ALLOWED) == set(TO_CHECK)
+    # [END topic_check_iam_permissions]
+
+
+@snippet
+def topic_publish_messages(client, to_delete):
+    """Publish messages to a topic."""
+    TOPIC_NAME = 'topic_publish_messages-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_publish_simple_message]
+    topic.publish(b'This is the message payload')               # API request
+    # [END topic_publish_simple_message]
+
+    # [START topic_publish_message_with_attrs]
+    topic.publish(b'Another message payload', extra='EXTRA')    # API request
+    # [END topic_publish_message_with_attrs]
+
+
+@snippet
+def topic_batch(client, to_delete):
+    """Publish multiple messages in a single request."""
+    TOPIC_NAME = 'topic_batch-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_batch]
+    with topic.batch() as batch:
+        batch.publish(b'This is the message payload')
+        batch.publish(b'Another message payload', extra='EXTRA')
+    # [END topic_batch]  API request on block exit
+
+
+@snippet
+def topic_subscription(client, to_delete):
+    """Create subscriptions to a topic."""
+    TOPIC_NAME = 'topic_subscription-%d' % (_millis(),)
+    SUB_DEFAULTS = 'topic_subscription-defaults-%d' % (_millis(),)
+    SUB_ACK90 = 'topic_subscription-ack90-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_subscription_defaults]
+    sub_defaults = topic.subscription(SUB_DEFAULTS)
+    # [END topic_subscription_defaults]
+
+    sub_defaults.create()                               # API request
+    to_delete.append(sub_defaults)
+    expected_names = set()
+    expected_names.add(sub_defaults.full_name)
+
+    # [START topic_subscription_ack90]
+    sub_ack90 = topic.subscription(SUB_ACK90, ack_deadline=90)
+    # [END topic_subscription_ack90]
+
+    sub_ack90.create()                                  # API request
+    to_delete.append(sub_ack90)
+    expected_names.add(sub_ack90.full_name)
+
+    sub_names = set()
+
+    def do_something_with(sub):
+        sub_names.add(sub.full_name)
+
+    # [START topic_list_subscriptions]
+    subscriptions, token = topic.list_subscriptions()   # API request
+    while True:
+        for subscription in subscriptions:
+            do_something_with(subscription)
+        if token is None:
+            break
+        subscriptions, token = topic.list_subscriptions(
+            page_token=token)                           # API request
+    # [END topic_list_subscriptions]
+
+    assert sub_names.issuperset(expected_names)
+
+
+# @snippet:  disabled, because push-mode requires a validated endpoint URL
+def topic_subscription_push(client, to_delete):
+    """Create subscriptions to a topic."""
+    TOPIC_NAME = 'topic_subscription_push-%d' % (_millis(),)
+    SUB_PUSH = 'topic_subscription_push-sub-%d' % (_millis(),)
+    PUSH_URL = 'https://api.example.com/push-endpoint'
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START topic_subscription_push]
+    subscription = topic.subscription(SUB_PUSH, push_endpoint=PUSH_URL)
+    subscription.create()               # API request
+    # [END topic_subscription_push]
+
+    # [START subscription_push_pull]
+    subscription.modify_push_configuration(push_endpoint=None)  # API request
+    # [END subscription_push_pull]
+
+    # [START subscription_pull_push]
+    subscription.modify_push_configuration(
+        push_endpoint=PUSH_URL)                                 # API request
+    # [END subscription_pull_push]
+
+
+@snippet
+def subscription_lifecycle(client, to_delete):
+    """Test lifecycle of a subscription."""
+    TOPIC_NAME = 'subscription_lifecycle-%d' % (_millis(),)
+    SUB_NAME = 'subscription_lifecycle-defaults-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    # [START subscription_create]
+    subscription = topic.subscription(SUB_NAME)
+    subscription.create()                               # API request
+    # [END subscription_create]
+
+    # [START subscription_exists]
+    assert subscription.exists()                        # API request
+    # [END subscription_exists]
+
+    # [START subscription_reload]
+    subscription.reload()                               # API request
+    # [END subscription_reload]
+
+    # [START subscription_delete]
+    subscription.delete()                               # API request
+    # [END subscription_delete]
+
+
+def _find_examples():
+    funcs = [obj for obj in globals().values()
+             if getattr(obj, '_snippet', False)]
+    for func in sorted(funcs, key=lambda f: f.func_code.co_firstlineno):
+        yield func
+
+
+def main():
+    client = Client()
+    for example in _find_examples():
+        to_delete = []
+        print('%-25s: %s' % (
+            example.func_name, example.func_doc))
+        try:
+            example(client, to_delete)
+        except AssertionError as e:
+            print('   FAIL: %s' % (e,))
+        except Exception as e:  # pylint: disable=broad-except
+            print('  ERROR: %r' % (e,))
+        for item in to_delete:
+            item.delete()
+
+if __name__ == '__main__':
+    main()

--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -131,10 +131,11 @@ def topic_iam_policy(client, to_delete):
 
     # [START topic_get_iam_policy]
     policy = topic.get_iam_policy()             # API request
+    # [END topic_get_iam_policy]
+
     assert len(policy.viewers) == 0
     assert len(policy.editors) == 0
     assert len(policy.owners) == 0
-    # [END topic_get_iam_policy]
 
     # [START topic_set_iam_policy]
     ALL_USERS = policy.all_users()
@@ -142,9 +143,10 @@ def topic_iam_policy(client, to_delete):
     LOGS_GROUP = policy.group('cloud-logs@google.com')
     policy.editors.add(LOGS_GROUP)
     new_policy = topic.set_iam_policy(policy)   # API request
+    # [END topic_set_iam_policy]
+
     assert ALL_USERS in new_policy.viewers
     assert LOGS_GROUP in new_policy.editors
-    # [END topic_set_iam_policy]
 
 
 # @snippet   # Disabled due to #1687
@@ -361,6 +363,60 @@ def subscription_pull(client, to_delete):
         (payloads,))
     assert extras == [{'extra': EXTRA}], 'extras: %s' % (
         (extras,))
+
+
+@snippet
+def subscription_iam_policy(client, to_delete):
+    """Fetch / set a subscription's IAM policy."""
+    TOPIC_NAME = 'subscription_iam_policy-%d' % (_millis(),)
+    SUB_NAME = 'subscription_iam_policy-defaults-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    subscription = topic.subscription(SUB_NAME)
+    subscription.create()
+    to_delete.append(subscription)
+
+    # [START subscription_get_iam_policy]
+    policy = subscription.get_iam_policy()             # API request
+    # [END subscription_get_iam_policy]
+
+    assert len(policy.viewers) == 0
+    assert len(policy.editors) == 0
+    assert len(policy.owners) == 0
+
+    # [START subscription_set_iam_policy]
+    ALL_USERS = policy.all_users()
+    policy.viewers.add(ALL_USERS)
+    LOGS_GROUP = policy.group('cloud-logs@google.com')
+    policy.editors.add(LOGS_GROUP)
+    new_policy = subscription.set_iam_policy(policy)   # API request
+    # [END subscription_set_iam_policy]
+
+    assert ALL_USERS in new_policy.viewers
+    assert LOGS_GROUP in new_policy.editors
+
+
+# @snippet   # Disabled due to #1687
+def subscription_check_iam_permissions(client, to_delete):
+    """Check subscription IAM permissions."""
+    TOPIC_NAME = 'subscription_check_iam_permissions-%d' % (_millis(),)
+    SUB_NAME = 'subscription_check_iam_permissions-defaults-%d' % (_millis(),)
+    topic = client.topic(TOPIC_NAME)
+    topic.create()
+    to_delete.append(topic)
+
+    subscription = topic.subscription(SUB_NAME)
+    subscription.create()
+    to_delete.append(subscription)
+
+    # [START subscription_check_iam_permissions]
+    from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+    TO_CHECK = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
+    ALLOWED = subscription.check_iam_permissions(TO_CHECK)
+    assert set(ALLOWED) == set(TO_CHECK)
+    # [END subscription_check_iam_permissions]
 
 
 def _find_examples():

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -75,6 +75,12 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START client_list_topics]
+           :end-before: [END client_list_topics]
+
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
@@ -103,8 +109,11 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
 
-        and (where ``topic_name`` is passed):
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START client_list_subscriptions]
+           :end-before: [END client_list_subscriptions]
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
@@ -132,6 +141,12 @@ class Client(JSONClient):
 
     def topic(self, name, timestamp_messages=False):
         """Creates a topic bound to the current client.
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START client_topic]
+           :end-before: [END client_topic]
 
         :type name: string
         :param name: the name of the topic to be constructed.

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -267,8 +267,8 @@ class Subscription(object):
         Example:
 
         .. literalinclude:: pubsub_snippets.py
-           :start-after: [START subscription_push_pull]
-           :end-before: [END subscription_push_pull]
+           :start-after: [START subscription_pull]
+           :end-before: [END subscription_pull]
 
         :type return_immediately: boolean
         :param return_immediately: if True, the back-end returns even if no
@@ -300,6 +300,12 @@ class Subscription(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_acknowledge]
+           :end-before: [END subscription_acknowledge]
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -345,6 +345,12 @@ class Subscription(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/getIamPolicy
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_get_iam_policy]
+           :end-before: [END subscription_get_iam_policy]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current subscription's topic.
@@ -363,6 +369,12 @@ class Subscription(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/setIamPolicy
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_set_iam_policy]
+           :end-before: [END subscription_set_iam_policy]
 
         :type policy: :class:`gcloud.pubsub.iam.Policy`
         :param policy: the new policy, typically fetched via
@@ -387,6 +399,12 @@ class Subscription(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/testIamPermissions
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_check_iam_permissions]
+           :end-before: [END subscription_check_iam_permissions]
 
         :type permissions: list of string
         :param permissions: list of permissions to be tested

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -115,8 +115,13 @@ class Subscription(object):
 
     @property
     def full_name(self):
-        """URL path for the subscription's APIs"""
+        """Fully-qualified name used in subscription APIs"""
         return 'projects/%s/subscriptions/%s' % (self.project, self.name)
+
+    @property
+    def path(self):
+        """URL path for the subscription's APIs"""
+        return '/%s' % (self.full_name,)
 
     def _require_client(self, client):
         """Check client or verify over-ride.
@@ -139,6 +144,12 @@ class Subscription(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_create]
+           :end-before: [END subscription_create]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current subscription's topic.
@@ -154,6 +165,12 @@ class Subscription(object):
 
         See
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_exists]
+           :end-before: [END subscription_exists]
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -174,6 +191,12 @@ class Subscription(object):
         See
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_reload]
+           :end-before: [END subscription_reload]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current subscription's topic.
@@ -191,6 +214,12 @@ class Subscription(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_delete]
+           :end-before: [END subscription_delete]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current subscription's topic.
@@ -204,6 +233,16 @@ class Subscription(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_push_pull]
+           :end-before: [END subscription_push_pull]
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_pull_push]
+           :end-before: [END subscription_pull_push]
 
         :type push_endpoint: string
         :param push_endpoint: URL to which messages will be pushed by the
@@ -224,6 +263,12 @@ class Subscription(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START subscription_push_pull]
+           :end-before: [END subscription_push_pull]
 
         :type return_immediately: boolean
         :param return_immediately: if True, the back-end returns even if no

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -132,6 +132,18 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(subscription.ack_deadline, self.DEADLINE)
         self.assertEqual(subscription.push_endpoint, self.ENDPOINT)
 
+    def test_full_name_and_path(self):
+        PROJECT = 'PROJECT'
+        SUB_NAME = 'sub_name'
+        SUB_FULL = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
+        SUB_PATH = '/%s' % (SUB_FULL,)
+        TOPIC_NAME = 'topic_name'
+        CLIENT = _Client(project=PROJECT, connection=None)
+        topic = _Topic(TOPIC_NAME, client=CLIENT)
+        subscription = self._makeOne(SUB_NAME, topic)
+        self.assertEqual(subscription.full_name, SUB_FULL)
+        self.assertEqual(subscription.path, SUB_PATH)
+
     def test_create_pull_wo_ack_deadline_w_bound_client(self):
         RESPONSE = {
             'topic': self.TOPIC_PATH,

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -138,7 +138,7 @@ class TestSubscription(unittest2.TestCase):
         SUB_FULL = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
         SUB_PATH = '/%s' % (SUB_FULL,)
         TOPIC_NAME = 'topic_name'
-        CLIENT = _Client(project=PROJECT, connection=None)
+        CLIENT = _Client(project=PROJECT)
         topic = _Topic(TOPIC_NAME, client=CLIENT)
         subscription = self._makeOne(SUB_NAME, topic)
         self.assertEqual(subscription.full_name, SUB_FULL)

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -53,6 +53,24 @@ class Topic(object):
     def subscription(self, name, ack_deadline=None, push_endpoint=None):
         """Creates a subscription bound to the current topic.
 
+        Example:  pull-mode subcription, default paramter values
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_subscription_defaults]
+           :end-before: [END topic_subscription_defaults]
+
+        Example:  pull-mode subcription, override ``ack_deadline`` default
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_subscription_ack90]
+           :end-before: [END topic_subscription_ack90]
+
+        Example:  push-mode subcription
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_subscription_push]
+           :end-before: [END topic_subscription_push]
+
         :type name: string
         :param name: the name of the subscription
 
@@ -118,6 +136,12 @@ class Topic(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_create]
+           :end-before: [END topic_create]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current topic.
@@ -131,6 +155,12 @@ class Topic(object):
 
         See
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_exists]
+           :end-before: [END topic_exists]
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -151,6 +181,12 @@ class Topic(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_delete]
+           :end-before: [END topic_delete]
 
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -175,6 +211,18 @@ class Topic(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+
+        Example without message attributes:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_publish_simple_message]
+           :end-before: [END topic_publish_simple_message]
+
+        With message attributes:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_publish_message_with_attrs]
+           :end-before: [END topic_publish_message_with_attrs]
 
         :type message: bytes
         :param message: the message payload
@@ -201,6 +249,18 @@ class Topic(object):
     def batch(self, client=None):
         """Return a batch to use as a context manager.
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_batch]
+           :end-before: [END topic_batch]
+
+        .. note::
+
+           The only API request happens during the ``__exit__()`` of the topic
+           used as a context manager, and only if the block exits without
+           raising an exception.
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current topic.
@@ -216,6 +276,12 @@ class Topic(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_list_subscriptions]
+           :end-before: [END topic_list_subscriptions]
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
@@ -252,6 +318,12 @@ class Topic(object):
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/getIamPolicy
 
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_get_iam_policy]
+           :end-before: [END topic_get_iam_policy]
+
         :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current batch.
@@ -270,6 +342,12 @@ class Topic(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/setIamPolicy
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_set_iam_policy]
+           :end-before: [END topic_set_iam_policy]
 
         :type policy: :class:`gcloud.pubsub.iam.Policy`
         :param policy: the new policy, typically fetched via
@@ -294,6 +372,12 @@ class Topic(object):
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/testIamPermissions
+
+        Example:
+
+        .. literalinclude:: pubsub_snippets.py
+           :start-after: [START topic_check_iam_permissions]
+           :end-before: [END topic_check_iam_permissions]
 
         :type permissions: list of string
         :param permissions: list of permissions to be tested

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -125,7 +125,7 @@ def is_production_filename(filename):
     :rtype: bool
     :returns: Boolean indicating production status.
     """
-    return 'test' not in filename
+    return 'test' not in filename and 'docs' not in filename
 
 
 def get_files_for_linting(allow_limited=True):


### PR DESCRIPTION
Toward #212, #1141, etc.

@dhermes, @jgeewax Not-yet-complete transformation, but worth discussing.

I'm basically ripping off the [snippet format](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/edcff8082a2c62b4e1866b28795f3dac92f8baaf/datastore/api/snippets.py) from @pcostell.

The snippets can be tested by running the file as a script, under an appropriately configured environment:

```bash
$ .tox/system-tests/bin/python docs/pubsub_snippets.py 
client_list_topics       : List topics for a project.
client_list_subscriptions: List all subscriptions for a project.
topic_create             : Create a topic.
topic_exists             : Test existence of a topic.
topic_delete             : Delete a topic.
topic_iam_policy         : Fetch / set a topic's IAM policy.
topic_publish_messages   : Publish messages to a topic.
topic_batch              : Publish multiple messages in a single request.
topic_subscription       : Create subscriptions to a topic.
subscription_lifecycle   : Test lifecycle of a subscription.
```