### PR TITLE
Restore 'grpc' extra for testing on Python 2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIREMENTS = [
     'pyOpenSSL',
     'six',
 ]
-GRPC_EXTRAS = ['grpcio >= 0.13.0']
+GRPC_EXTRAS = ['grpcio >= 0.13.1']
 
 setup(
     name='gcloud',

--- a/tox.ini
+++ b/tox.ini
@@ -21,22 +21,20 @@ covercmd =
       --cover-branches \
       --nocapture
 
-# Until grpcio 0.13.1 ships, this environment is broken on UCS2 builds.
-# See: https://github.com/grpc/grpc/issues/5280 and
-#      https://github.com/grpc/grpc/pull/5319
-#[testenv:py27]
-#basepython =
-#    python2.7
-#deps =
-#    {[testenv]deps}
-#    grpcio >= 0.13.0
-#setenv =
-#    PYTHONPATH =
+[testenv:py27]
+basepython =
+    python2.7
+commands =
+    pip install gcloud[grpc]
+    nosetests
+setenv =
+    PYTHONPATH =
 
 [testenv:cover]
 basepython =
     python2.7
 commands =
+    pip install gcloud[grpc]
     {[testenv]covercmd} --cover-min-percentage=100
 deps =
     {[testenv]deps}
@@ -98,12 +96,10 @@ passenv = {[testenv:system-tests]passenv}
 basepython =
     python2.7
 commands =
+    pip install gcloud[grpc]
     python {toxinidir}/system_tests/attempt_system_tests.py
 setenv =
     PYTHONPATH =
-deps =
-    {[testenv]deps}
-    grpcio >= 0.13.0
 passenv = GOOGLE_* GCLOUD_* TRAVIS* encrypted_*
 
 [testenv:system-tests3]


### PR DESCRIPTION
Bump minimum required 'grpc' version to 0.13.1, which supports UCS-4 and UCS-2 builds on Linux.

Closes #1572.