### PR TITLE
Add methods to connection mapping API requests

### DIFF
--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -65,20 +65,12 @@ class Client(JSONClient):
                   more topics can be retrieved with another call (pass that
                   value as ``page_token``).
         """
-        params = {}
-
-        if page_size is not None:
-            params['pageSize'] = page_size
-
-        if page_token is not None:
-            params['pageToken'] = page_token
-
-        path = '/projects/%s/topics' % (self.project,)
-        resp = self.connection.api_request(method='GET', path=path,
-                                           query_params=params)
+        conn = self.connection
+        resources, next_token = conn.list_topics(
+            self.project, page_size, page_token)
         topics = [Topic.from_api_repr(resource, self)
-                  for resource in resp.get('topics', ())]
-        return topics, resp.get('nextPageToken')
+                  for resource in resources]
+        return topics, next_token
 
     def list_subscriptions(self, page_size=None, page_token=None):
         """List subscriptions for the project associated with this client.

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -96,23 +96,14 @@ class Client(JSONClient):
                   more topics can be retrieved with another call (pass that
                   value as ``page_token``).
         """
-        params = {}
-
-        if page_size is not None:
-            params['pageSize'] = page_size
-
-        if page_token is not None:
-            params['pageToken'] = page_token
-
-        path = '/projects/%s/subscriptions' % (self.project,)
-
-        resp = self.connection.api_request(method='GET', path=path,
-                                           query_params=params)
+        conn = self.connection
+        resources, next_token = conn.list_subscriptions(
+            self.project, page_size, page_token)
         topics = {}
         subscriptions = [Subscription.from_api_repr(resource, self,
                                                     topics=topics)
-                         for resource in resp.get('subscriptions', ())]
-        return subscriptions, resp.get('nextPageToken')
+                         for resource in resources]
+        return subscriptions, next_token
 
     def topic(self, name, timestamp_messages=False):
         """Creates a topic bound to the current client.

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -160,3 +160,15 @@ class Connection(base_connection.JSONConnection):
         path = '/projects/%s/subscriptions' % (project,)
         resp = self.api_request(method='GET', path=path, query_params=params)
         return resp.get('subscriptions', ()), resp.get('nextPageToken')
+
+    def topic_create(self, topic_path):
+        """API call:  create a topic via a PUT request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the new topic, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        """
+        return self.api_request(method='PUT', path='/%s' % (topic_path,))

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -387,3 +387,35 @@ class Connection(base_connection.JSONConnection):
         path = '/%s:modifyPushConfig' % (subscription_path,)
         resource = {'pushConfig': {'pushEndpoint': push_endpoint}}
         return self.api_request(method='POST', path=path, data=resource)
+
+    def subscription_pull(self, subscription_path, return_immediately=False,
+                          max_messages=1):
+        """API call:  update push config of a subscription via a POST request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the new
+                                  subscription, in format
+                                  ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+
+        :type return_immediately: boolean
+        :param return_immediately: if True, the back-end returns even if no
+                                   messages are available;  if False, the API
+                                   call blocks until one or more messages are
+                                   available.
+
+        :type max_messages: int
+        :param max_messages: the maximum number of messages to return.
+
+        :rtype: list of dict
+        :returns:  the ``receivedMessages`` element of the response.
+        """
+        path = '/%s:pull' % (subscription_path,)
+        data = {
+            'returnImmediately': return_immediately,
+            'maxMessages': max_messages,
+        }
+        response = self.api_request(method='POST', path=path, data=data)
+        return response['receivedMessages']

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -419,3 +419,49 @@ class Connection(base_connection.JSONConnection):
         }
         response = self.api_request(method='POST', path=path, data=data)
         return response['receivedMessages']
+
+    def subscription_acknowledge(self, subscription_path, ack_ids):
+        """API call:  acknowledge retrieved messages for the subscription.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the new
+                                  subscription, in format
+                                  ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+
+        :type ack_ids: list of string
+        :param ack_ids: ack IDs of messages being acknowledged
+        """
+        path = '/%s:acknowledge' % (subscription_path,)
+        data = {
+            'ackIds': ack_ids,
+        }
+        self.api_request(method='POST', path=path, data=data)
+
+    def subscription_modify_ack_deadline(self, subscription_path, ack_ids,
+                                         ack_deadline):
+        """API call:  acknowledge retrieved messages for the subscription.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the new
+                                  subscription, in format
+                                  ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+
+        :type ack_ids: list of string
+        :param ack_ids: ack IDs of messages being acknowledged
+
+        :type ack_deadline: int
+        :param ack_deadline: the deadline (in seconds) by which messages pulled
+                            from the back-end must be acknowledged.
+        """
+        path = '/%s:modifyAckDeadline' % (subscription_path,)
+        data = {
+            'ackIds': ack_ids,
+            'ackDeadlineSeconds': ack_deadline,
+        }
+        self.api_request(method='POST', path=path, data=data)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -124,3 +124,39 @@ class Connection(base_connection.JSONConnection):
         path = '/projects/%s/topics' % (project,)
         resp = self.api_request(method='GET', path=path, query_params=params)
         return resp.get('topics', ()), resp.get('nextPageToken')
+
+    def list_subscriptions(self, project, page_size=None, page_token=None):
+        """List subscriptions for the project associated with this client.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/list
+
+        :type project: string
+        :param project: project ID
+
+        :type page_size: int
+        :param page_size: maximum number of subscriptions to return, If not
+                          passed, defaults to a value set by the API.
+
+        :type page_token: string
+        :param page_token: opaque marker for the next "page" of subscriptions.
+                           If not passed, the API will return the first page
+                           of subscriptions.
+
+        :rtype: tuple, (list, str)
+        :returns: list of ``Subscription`` resource dicts, plus a
+                  "next page token" string:  if not None, indicates that
+                  more subscriptions can be retrieved with another call (pass
+                  that value as ``page_token``).
+        """
+        params = {}
+
+        if page_size is not None:
+            params['pageSize'] = page_size
+
+        if page_token is not None:
+            params['pageToken'] = page_token
+
+        path = '/projects/%s/subscriptions' % (project,)
+        resp = self.api_request(method='GET', path=path, query_params=params)
+        return resp.get('subscriptions', ()), resp.get('nextPageToken')

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -216,14 +216,13 @@ class Connection(base_connection.JSONConnection):
         :type messages: list of dict
         :param messages: messages to be published.
 
-        :rtype: dict
-        :returns: resource returned from the API:  a mapping with key,
-                  ``messageIds``, whose values is a list of opaque IDs for
-                  published messages.
+        :rtype: list of string
+        :returns: list of opaque IDs for published messages.
         """
         data = {'messages': messages}
-        return self.api_request(
+        response = self.api_request(
             method='POST', path='/%s:publish' % (topic_path,), data=data)
+        return response['messageIds']
 
     def topic_list_subscriptions(self, topic_path, page_size=None,
                                  page_token=None):
@@ -467,7 +466,7 @@ class Connection(base_connection.JSONConnection):
         """API call:  acknowledge retrieved messages for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
         :param subscription_path: the fully-qualfied path of the new

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -339,3 +339,17 @@ class Connection(base_connection.JSONConnection):
             resource['pushConfig'] = {'pushEndpoint': push_endpoint}
 
         return self.api_request(method='PUT', path=path, data=resource)
+
+    def subscription_get(self, subscription_path):
+        """API call:  retrieve a subscription via a GET request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the subscription,
+                                  in format
+                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        """
+        path = '/%s' % (subscription_path,)
+        return self.api_request(method='GET', path=path)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -172,3 +172,15 @@ class Connection(base_connection.JSONConnection):
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
         return self.api_request(method='PUT', path='/%s' % (topic_path,))
+
+    def topic_get(self, topic_path):
+        """API call:  retrieve a topic via a GET request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the new topic, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        """
+        return self.api_request(method='GET', path='/%s' % (topic_path,))

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -196,3 +196,20 @@ class Connection(base_connection.JSONConnection):
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
         return self.api_request(method='DELETE', path='/%s' % (topic_path,))
+
+    def topic_publish(self, topic_path, messages):
+        """API call:  publish a message to a topic via a POST request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the topic, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :type messages: list of dict
+        :param messages: messages to be published.
+        """
+        data = {'messages': messages}
+        return self.api_request(
+            method='POST', path='/%s:publish' % (topic_path,), data=data)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -281,3 +281,24 @@ class Connection(base_connection.JSONConnection):
         wrapped = {'policy': policy}
         return self.api_request(method='POST', path='/%s:setIamPolicy' % (
             target_path,), data=wrapped)
+
+    def test_iam_permissions(self, target_path, permissions):
+        """Update the IAM policy for the target.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/testIamPermissions
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/testIamPermissions
+
+        :type target_path: string
+        :param target_path: the path of the target object.
+
+        :type permissions: list of string
+        :param permissions: the permissions to check
+
+        :rtype: dict
+        :returns: the resource returned by the ``getIamPolicy`` API request.
+        """
+        wrapped = {'permissions': permissions}
+        path = '/%s:testIamPermissions' % (target_path,)
+        resp = self.api_request(method='POST', path=path, data=wrapped)
+        return resp.get('permissions', [])

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -180,7 +180,19 @@ class Connection(base_connection.JSONConnection):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the new topic, in format
+        :param topic_path: the fully-qualfied path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
         return self.api_request(method='GET', path='/%s' % (topic_path,))
+
+    def topic_delete(self, topic_path):
+        """API call:  delete a topic via a DELETE request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the topic, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        """
+        return self.api_request(method='DELETE', path='/%s' % (topic_path,))

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -170,6 +170,9 @@ class Connection(base_connection.JSONConnection):
         :type topic_path: string
         :param topic_path: the fully-qualfied path of the new topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :rtype: dict
+        :returns: ``Topic`` resource returned from the API.
         """
         return self.api_request(method='PUT', path='/%s' % (topic_path,))
 
@@ -182,6 +185,9 @@ class Connection(base_connection.JSONConnection):
         :type topic_path: string
         :param topic_path: the fully-qualfied path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :rtype: dict
+        :returns: ``Topic`` resource returned from the API.
         """
         return self.api_request(method='GET', path='/%s' % (topic_path,))
 
@@ -195,7 +201,7 @@ class Connection(base_connection.JSONConnection):
         :param topic_path: the fully-qualfied path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
-        return self.api_request(method='DELETE', path='/%s' % (topic_path,))
+        self.api_request(method='DELETE', path='/%s' % (topic_path,))
 
     def topic_publish(self, topic_path, messages):
         """API call:  publish a message to a topic via a POST request
@@ -209,6 +215,11 @@ class Connection(base_connection.JSONConnection):
 
         :type messages: list of dict
         :param messages: messages to be published.
+
+        :rtype: dict
+        :returns: resource returned from the API:  a mapping with key,
+                  ``messageIds``, whose values is a list of opaque IDs for
+                  published messages.
         """
         data = {'messages': messages}
         return self.api_request(
@@ -233,6 +244,10 @@ class Connection(base_connection.JSONConnection):
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
+
+        :rtype: list of strings
+        :returns: fully-qualified names of subscriptions for the supplied
+                  topic.
         """
         params = {}
 
@@ -276,7 +291,7 @@ class Connection(base_connection.JSONConnection):
         :param policy: the new policy resource.
 
         :rtype: dict
-        :returns: the resource returned by the ``getIamPolicy`` API request.
+        :returns: the resource returned by the ``setIamPolicy`` API request.
         """
         wrapped = {'policy': policy}
         path = '/%s:setIamPolicy' % (target_path,)
@@ -328,6 +343,9 @@ class Connection(base_connection.JSONConnection):
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
+
+        :rtype: dict
+        :returns: ``Subscription`` resource returned from the API.
         """
         path = '/%s' % (subscription_path,)
         resource = {'topic': topic_path}
@@ -350,6 +368,9 @@ class Connection(base_connection.JSONConnection):
         :param subscription_path: the fully-qualfied path of the subscription,
                                   in format
                                   ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+
+        :rtype: dict
+        :returns: ``Subscription`` resource returned from the API.
         """
         path = '/%s' % (subscription_path,)
         return self.api_request(method='GET', path=path)
@@ -366,7 +387,7 @@ class Connection(base_connection.JSONConnection):
                                   ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
         """
         path = '/%s' % (subscription_path,)
-        return self.api_request(method='DELETE', path=path)
+        self.api_request(method='DELETE', path=path)
 
     def subscription_modify_push_config(self, subscription_path,
                                         push_endpoint):
@@ -379,6 +400,7 @@ class Connection(base_connection.JSONConnection):
         :param subscription_path: the fully-qualfied path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+
         :type push_endpoint: string, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
@@ -386,7 +408,7 @@ class Connection(base_connection.JSONConnection):
         """
         path = '/%s:modifyPushConfig' % (subscription_path,)
         resource = {'pushConfig': {'pushEndpoint': push_endpoint}}
-        return self.api_request(method='POST', path=path, data=resource)
+        self.api_request(method='POST', path=path, data=resource)
 
     def subscription_pull(self, subscription_path, return_immediately=False,
                           max_messages=1):

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -245,3 +245,19 @@ class Connection(base_connection.JSONConnection):
         path = '/%s/subscriptions' % (topic_path,)
         resp = self.api_request(method='GET', path=path, query_params=params)
         return resp.get('subscriptions', ()), resp.get('nextPageToken')
+
+    def get_iam_policy(self, target_path):
+        """Fetch the IAM policy for the target.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/getIamPolicy
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/getIamPolicy
+
+        :type target_path: string
+        :param target_path: the path of the target object.
+
+        :rtype: dict
+        :returns: the resource returned by the ``getIamPolicy`` API request.
+        """
+        return self.api_request(method='GET', path='/%s:getIamPolicy' % (
+            target_path,))

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -261,3 +261,23 @@ class Connection(base_connection.JSONConnection):
         """
         return self.api_request(method='GET', path='/%s:getIamPolicy' % (
             target_path,))
+
+    def set_iam_policy(self, target_path, policy):
+        """Update the IAM policy for the target.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/setIamPolicy
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/setIamPolicy
+
+        :type target_path: string
+        :param target_path: the path of the target object.
+
+        :type policy: dict
+        :param policy: the new policy resource.
+
+        :rtype: dict
+        :returns: the resource returned by the ``getIamPolicy`` API request.
+        """
+        wrapped = {'policy': policy}
+        return self.api_request(method='POST', path='/%s:setIamPolicy' % (
+            target_path,), data=wrapped)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -302,3 +302,40 @@ class Connection(base_connection.JSONConnection):
         path = '/%s:testIamPermissions' % (target_path,)
         resp = self.api_request(method='POST', path=path, data=wrapped)
         return resp.get('permissions', [])
+
+    def subscription_create(self, subscription_path, topic_path,
+                            ack_deadline=None, push_endpoint=None):
+        """API call:  create a subscription via a PUT request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the new
+                                  subscription, in format
+                                  ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the topic being
+                           subscribed, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :type ack_deadline: int, or ``NoneType``
+        :param ack_deadline: the deadline (in seconds) by which messages pulled
+                            from the back-end must be acknowledged.
+
+        :type push_endpoint: string, or ``NoneType``
+        :param push_endpoint: URL to which messages will be pushed by the
+                              back-end.  If not set, the application must pull
+                              messages.
+        """
+        path = '/%s' % (subscription_path,)
+        resource = {'topic': topic_path}
+
+        if ack_deadline is not None:
+            resource['ackDeadlineSeconds'] = ack_deadline
+
+        if push_endpoint is not None:
+            resource['pushConfig'] = {'pushEndpoint': push_endpoint}
+
+        return self.api_request(method='PUT', path=path, data=resource)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -367,3 +367,23 @@ class Connection(base_connection.JSONConnection):
         """
         path = '/%s' % (subscription_path,)
         return self.api_request(method='DELETE', path=path)
+
+    def subscription_modify_push_config(self, subscription_path,
+                                        push_endpoint):
+        """API call:  update push config of a subscription via a POST request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the new
+                                  subscription, in format
+                                  ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
+        :type push_endpoint: string, or ``NoneType``
+        :param push_endpoint: URL to which messages will be pushed by the
+                              back-end.  If not set, the application must pull
+                              messages.
+        """
+        path = '/%s:modifyPushConfig' % (subscription_path,)
+        resource = {'pushConfig': {'pushEndpoint': push_endpoint}}
+        return self.api_request(method='POST', path=path, data=resource)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -88,3 +88,39 @@ class Connection(base_connection.JSONConnection):
         return super(Connection, self.__class__).build_api_url(
             path, query_params=query_params,
             api_base_url=api_base_url, api_version=api_version)
+
+    def list_topics(self, project, page_size=None, page_token=None):
+        """List topics for the project associated with this client.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+
+        :type project: string
+        :param project: project ID
+
+        :type page_size: int
+        :param page_size: maximum number of topics to return, If not passed,
+                          defaults to a value set by the API.
+
+        :type page_token: string
+        :param page_token: opaque marker for the next "page" of topics. If not
+                           passed, the API will return the first page of
+                           topics.
+
+        :rtype: tuple, (list, str)
+        :returns: list of ``Topic`` resource dicts, plus a
+                  "next page token" string:  if not None, indicates that
+                  more topics can be retrieved with another call (pass that
+                  value as ``page_token``).
+        """
+        params = {}
+
+        if page_size is not None:
+            params['pageSize'] = page_size
+
+        if page_token is not None:
+            params['pageToken'] = page_token
+
+        path = '/projects/%s/topics' % (project,)
+        resp = self.api_request(method='GET', path=path, query_params=params)
+        return resp.get('topics', ()), resp.get('nextPageToken')

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -213,3 +213,35 @@ class Connection(base_connection.JSONConnection):
         data = {'messages': messages}
         return self.api_request(
             method='POST', path='/%s:publish' % (topic_path,), data=data)
+
+    def topic_list_subscriptions(self, topic_path, page_size=None,
+                                 page_token=None):
+        """API call:  list subscriptions bound to a topic via a GET request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+
+        :type topic_path: string
+        :param topic_path: the fully-qualfied path of the topic, in format
+                           ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :type page_size: int
+        :param page_size: maximum number of topics to return, If not passed,
+                          defaults to a value set by the API.
+
+        :type page_token: string
+        :param page_token: opaque marker for the next "page" of topics. If not
+                           passed, the API will return the first page of
+                           topics.
+        """
+        params = {}
+
+        if page_size is not None:
+            params['pageSize'] = page_size
+
+        if page_token is not None:
+            params['pageToken'] = page_token
+
+        path = '/%s/subscriptions' % (topic_path,)
+        resp = self.api_request(method='GET', path=path, query_params=params)
+        return resp.get('subscriptions', ()), resp.get('nextPageToken')

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -353,3 +353,17 @@ class Connection(base_connection.JSONConnection):
         """
         path = '/%s' % (subscription_path,)
         return self.api_request(method='GET', path=path)
+
+    def subscription_delete(self, subscription_path):
+        """API call:  delete a subscription via a DELETE request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+
+        :type subscription_path: string
+        :param subscription_path: the fully-qualfied path of the subscription,
+                                  in format
+                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        """
+        path = '/%s' % (subscription_path,)
+        return self.api_request(method='DELETE', path=path)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -259,8 +259,8 @@ class Connection(base_connection.JSONConnection):
         :rtype: dict
         :returns: the resource returned by the ``getIamPolicy`` API request.
         """
-        return self.api_request(method='GET', path='/%s:getIamPolicy' % (
-            target_path,))
+        path = '/%s:getIamPolicy' % (target_path,)
+        return self.api_request(method='GET', path=path)
 
     def set_iam_policy(self, target_path, policy):
         """Update the IAM policy for the target.
@@ -279,8 +279,8 @@ class Connection(base_connection.JSONConnection):
         :returns: the resource returned by the ``getIamPolicy`` API request.
         """
         wrapped = {'policy': policy}
-        return self.api_request(method='POST', path='/%s:setIamPolicy' % (
-            target_path,), data=wrapped)
+        path = '/%s:setIamPolicy' % (target_path,)
+        return self.api_request(method='POST', path=path, data=wrapped)
 
     def test_iam_permissions(self, target_path, permissions):
         """Update the IAM policy for the target.

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -216,13 +216,8 @@ class Subscription(object):
                        ``client`` stored on the current subscription's topic.
         """
         client = self._require_client(client)
-        data = {}
-        config = data['pushConfig'] = {}
-        if push_endpoint is not None:
-            config['pushEndpoint'] = push_endpoint
-        client.connection.api_request(
-            method='POST', path='%s:modifyPushConfig' % (self.path,),
-            data=data)
+        client.connection.subscription_modify_push_config(
+            self.full_name, push_endpoint)
         self.push_endpoint = push_endpoint
 
     def pull(self, return_immediately=False, max_messages=1, client=None):

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -182,7 +182,7 @@ class Subscription(object):
                        ``client`` stored on the current subscription's topic.
         """
         client = self._require_client(client)
-        data = client.connection.api_request(method='GET', path=self.path)
+        data = client.connection.subscription_get(self.full_name)
         self.ack_deadline = data.get('ackDeadlineSeconds')
         push_config = data.get('pushConfig', {})
         self.push_endpoint = push_config.get('pushEndpoint')

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -114,9 +114,14 @@ class Subscription(object):
         return self._client.project
 
     @property
+    def full_name(self):
+        """URL path for the subscription's APIs"""
+        return 'projects/%s/subscriptions/%s' % (self.project, self.name)
+
+    @property
     def path(self):
         """URL path for the subscription's APIs"""
-        return '/projects/%s/subscriptions/%s' % (self.project, self.name)
+        return '/%s' % (self.full_name,)
 
     def _require_client(self, client):
         """Check client or verify over-ride.
@@ -143,16 +148,10 @@ class Subscription(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current subscription's topic.
         """
-        data = {'topic': self.topic.full_name}
-
-        if self.ack_deadline is not None:
-            data['ackDeadlineSeconds'] = self.ack_deadline
-
-        if self.push_endpoint is not None:
-            data['pushConfig'] = {'pushEndpoint': self.push_endpoint}
-
         client = self._require_client(client)
-        client.connection.api_request(method='PUT', path=self.path, data=data)
+        client.connection.subscription_create(
+            self.full_name, self.topic.full_name, self.ack_deadline,
+            self.push_endpoint)
 
     def exists(self, client=None):
         """API call:  test existence of the subscription via a GET request

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -323,11 +323,8 @@ class Subscription(object):
                   ``setIamPolicy`` API request.
         """
         client = self._require_client(client)
-        path = '%s:setIamPolicy' % (self.path,)
         resource = policy.to_api_repr()
-        wrapped = {'policy': resource}
-        resp = client.connection.api_request(
-            method='POST', path=path, data=wrapped)
+        resp = client.connection.set_iam_policy(self.full_name, resource)
         return Policy.from_api_repr(resp)
 
     def check_iam_permissions(self, permissions, client=None):

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -118,11 +118,6 @@ class Subscription(object):
         """URL path for the subscription's APIs"""
         return 'projects/%s/subscriptions/%s' % (self.project, self.name)
 
-    @property
-    def path(self):
-        """URL path for the subscription's APIs"""
-        return '/%s' % (self.full_name,)
-
     def _require_client(self, client):
         """Check client or verify over-ride.
 
@@ -344,10 +339,5 @@ class Subscription(object):
         :returns: subset of ``permissions`` allowed by current IAM policy.
         """
         client = self._require_client(client)
-        path = '%s:testIamPermissions' % (self.path,)
-        data = {
-            'permissions': list(permissions),
-        }
-        resp = client.connection.api_request(
-            method='POST', path=path, data=data)
-        return resp.get('permissions', ())
+        return client.connection.test_iam_permissions(
+            self.full_name, list(permissions))

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -301,8 +301,7 @@ class Subscription(object):
                   ``getIamPolicy`` API request.
         """
         client = self._require_client(client)
-        path = '%s:getIamPolicy' % (self.path,)
-        resp = client.connection.api_request(method='GET', path=path)
+        resp = client.connection.get_iam_policy(self.full_name)
         return Policy.from_api_repr(resp)
 
     def set_iam_policy(self, policy, client=None):

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -165,7 +165,7 @@ class Subscription(object):
         """
         client = self._require_client(client)
         try:
-            client.connection.api_request(method='GET', path=self.path)
+            client.connection.subscription_get(self.full_name)
         except NotFound:
             return False
         else:

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -264,18 +264,16 @@ class Subscription(object):
                        ``client`` stored on the current subscription's topic.
         """
         client = self._require_client(client)
-        data = {'ackIds': ack_ids}
-        client.connection.api_request(
-            method='POST', path='%s:acknowledge' % (self.path,), data=data)
+        client.connection.subscription_acknowledge(self.full_name, ack_ids)
 
-    def modify_ack_deadline(self, ack_id, ack_deadline, client=None):
+    def modify_ack_deadline(self, ack_ids, ack_deadline, client=None):
         """API call:  update acknowledgement deadline for a retrieved message.
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
-        :type ack_id: string
-        :param ack_id: ack ID of message being updated
+        :type ack_ids: list of string
+        :param ack_ids: ack IDs of messages being updated
 
         :type ack_deadline: int
         :param ack_deadline: new deadline for the message, in seconds
@@ -285,10 +283,8 @@ class Subscription(object):
                        ``client`` stored on the current subscription's topic.
         """
         client = self._require_client(client)
-        data = {'ackIds': [ack_id], 'ackDeadlineSeconds': ack_deadline}
-        client.connection.api_request(
-            method='POST', path='%s:modifyAckDeadline' % (self.path,),
-            data=data)
+        client.connection.subscription_modify_ack_deadline(
+            self.full_name, ack_ids, ack_deadline)
 
     def get_iam_policy(self, client=None):
         """Fetch the IAM policy for the subscription.

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -245,12 +245,10 @@ class Subscription(object):
                   is an instance of :class:`gcloud.pubsub.message.Message`.
         """
         client = self._require_client(client)
-        data = {'returnImmediately': return_immediately,
-                'maxMessages': max_messages}
-        response = client.connection.api_request(
-            method='POST', path='%s:pull' % (self.path,), data=data)
+        response = client.connection.subscription_pull(
+            self.full_name, return_immediately, max_messages)
         return [(info['ackId'], Message.from_api_repr(info['message']))
-                for info in response.get('receivedMessages', ())]
+                for info in response]
 
     def acknowledge(self, ack_ids, client=None):
         """API call:  acknowledge retrieved messages for the subscription.

--- a/gcloud/pubsub/subscription.py
+++ b/gcloud/pubsub/subscription.py
@@ -187,6 +187,19 @@ class Subscription(object):
         push_config = data.get('pushConfig', {})
         self.push_endpoint = push_config.get('pushEndpoint')
 
+    def delete(self, client=None):
+        """API call:  delete the subscription via a DELETE request.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+
+        :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
+        :param client: the client to use.  If not passed, falls back to the
+                       ``client`` stored on the current subscription's topic.
+        """
+        client = self._require_client(client)
+        client.connection.subscription_delete(self.full_name)
+
     def modify_push_configuration(self, push_endpoint, client=None):
         """API call:  update the push endpoint for the subscription.
 
@@ -283,19 +296,6 @@ class Subscription(object):
         client.connection.api_request(
             method='POST', path='%s:modifyAckDeadline' % (self.path,),
             data=data)
-
-    def delete(self, client=None):
-        """API call:  delete the subscription via a DELETE request.
-
-        See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
-
-        :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current subscription's topic.
-        """
-        client = self._require_client(client)
-        client.connection.api_request(method='DELETE', path=self.path)
 
     def get_iam_policy(self, client=None):
         """Fetch the IAM policy for the subscription.

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -19,6 +19,8 @@ class TestClient(unittest2.TestCase):
     PROJECT = 'PROJECT'
     TOPIC_NAME = 'topic_name'
     TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+    SUB_NAME = 'subscription_name'
+    SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
 
     def _getTargetClass(self):
         from gcloud.pubsub.client import Client
@@ -42,7 +44,7 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(next_page_token, None)
 
         self.assertEqual(len(conn._requested), 0)
-        self.assertEqual(conn._listed, (self.PROJECT, None, None))
+        self.assertEqual(conn._listed_topics, (self.PROJECT, None, None))
 
     def test_list_topics_with_paging(self):
         from gcloud.pubsub.topic import Topic
@@ -62,7 +64,7 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(next_page_token, TOKEN2)
 
         self.assertEqual(len(conn._requested), 0)
-        self.assertEqual(conn._listed, (self.PROJECT, 1, TOKEN1))
+        self.assertEqual(conn._listed_topics, (self.PROJECT, 1, TOKEN1))
 
     def test_list_topics_missing_key(self):
         creds = _Credentials()
@@ -76,100 +78,76 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(next_page_token, None)
 
         self.assertEqual(len(conn._requested), 0)
-        self.assertEqual(conn._listed, (self.PROJECT, None, None))
+        self.assertEqual(conn._listed_topics, (self.PROJECT, None, None))
 
     def test_list_subscriptions_no_paging(self):
         from gcloud.pubsub.subscription import Subscription
-        PROJECT = 'PROJECT'
+        SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
+        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        conn = client.connection = _Connection()
+        conn._list_subscriptions_response = [SUB_INFO], None
 
-        client = self._makeOne(project=PROJECT, credentials=creds)
-
-        SUB_NAME = 'subscription_name'
-        SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
-        TOPIC_NAME = 'topic_name'
-        TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        SUB_INFO = [{'name': SUB_PATH, 'topic': TOPIC_PATH}]
-        RETURNED = {'subscriptions': SUB_INFO}
-        # Replace the connection on the client with one of our own.
-        client.connection = _Connection(RETURNED)
-
-        # Execute request.
         subscriptions, next_page_token = client.list_subscriptions()
-        # Test values are correct.
+
         self.assertEqual(len(subscriptions), 1)
         self.assertTrue(isinstance(subscriptions[0], Subscription))
-        self.assertEqual(subscriptions[0].name, SUB_NAME)
-        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
+        self.assertEqual(subscriptions[0].name, self.SUB_NAME)
+        self.assertEqual(subscriptions[0].topic.name, self.TOPIC_NAME)
         self.assertEqual(next_page_token, None)
-        self.assertEqual(len(client.connection._requested), 1)
-        req = client.connection._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/projects/%s/subscriptions' % PROJECT)
-        self.assertEqual(req['query_params'], {})
+
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._listed_subscriptions,
+                         (self.PROJECT, None, None))
 
     def test_list_subscriptions_with_paging(self):
         from gcloud.pubsub.subscription import Subscription
-        PROJECT = 'PROJECT'
+        SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
-
-        client = self._makeOne(project=PROJECT, credentials=creds)
-
-        SUB_NAME = 'subscription_name'
-        SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
-        TOPIC_NAME = 'topic_name'
-        TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        client = self._makeOne(project=self.PROJECT, credentials=creds)
         ACK_DEADLINE = 42
         PUSH_ENDPOINT = 'https://push.example.com/endpoint'
+        SUB_INFO = {'name': self.SUB_PATH,
+                    'topic': self.TOPIC_PATH,
+                    'ackDeadlineSeconds': ACK_DEADLINE,
+                    'pushConfig': {'pushEndpoint': PUSH_ENDPOINT}}
         TOKEN1 = 'TOKEN1'
         TOKEN2 = 'TOKEN2'
         SIZE = 1
-        SUB_INFO = [{'name': SUB_PATH,
-                     'topic': TOPIC_PATH,
-                     'ackDeadlineSeconds': ACK_DEADLINE,
-                     'pushConfig': {'pushEndpoint': PUSH_ENDPOINT}}]
-        RETURNED = {'subscriptions': SUB_INFO, 'nextPageToken': TOKEN2}
-        # Replace the connection on the client with one of our own.
-        client.connection = _Connection(RETURNED)
+        conn = client.connection = _Connection()
+        conn._list_subscriptions_response = [SUB_INFO], TOKEN2
 
-        # Execute request.
         subscriptions, next_page_token = client.list_subscriptions(
             SIZE, TOKEN1)
-        # Test values are correct.
+
         self.assertEqual(len(subscriptions), 1)
         self.assertTrue(isinstance(subscriptions[0], Subscription))
-        self.assertEqual(subscriptions[0].name, SUB_NAME)
-        self.assertEqual(subscriptions[0].topic.name, TOPIC_NAME)
+        self.assertEqual(subscriptions[0].name, self.SUB_NAME)
+        self.assertEqual(subscriptions[0].topic.name, self.TOPIC_NAME)
         self.assertEqual(subscriptions[0].ack_deadline, ACK_DEADLINE)
         self.assertEqual(subscriptions[0].push_endpoint, PUSH_ENDPOINT)
         self.assertEqual(next_page_token, TOKEN2)
-        self.assertEqual(len(client.connection._requested), 1)
-        req = client.connection._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/projects/%s/subscriptions' % PROJECT)
-        self.assertEqual(req['query_params'],
-                         {'pageSize': SIZE, 'pageToken': TOKEN1})
+
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._listed_subscriptions,
+                         (self.PROJECT, SIZE, TOKEN1))
 
     def test_list_subscriptions_w_missing_key(self):
         PROJECT = 'PROJECT'
         creds = _Credentials()
 
         client = self._makeOne(project=PROJECT, credentials=creds)
+        conn = client.connection = _Connection()
+        conn._list_subscriptions_response = (), None
 
-        RETURNED = {}
-        # Replace the connection on the client with one of our own.
-        client.connection = _Connection(RETURNED)
-
-        # Execute request.
         subscriptions, next_page_token = client.list_subscriptions()
-        # Test values are correct.
+
         self.assertEqual(len(subscriptions), 0)
         self.assertEqual(next_page_token, None)
-        self.assertEqual(len(client.connection._requested), 1)
-        req = client.connection._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/projects/%s/subscriptions' % PROJECT)
-        self.assertEqual(req['query_params'], {})
+
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._listed_subscriptions,
+                         (self.PROJECT, None, None))
 
     def test_topic(self):
         PROJECT = 'PROJECT'
@@ -205,11 +183,10 @@ class _Connection(object):
         self._responses = responses
         self._requested = []
 
-    def api_request(self, **kw):
-        self._requested.append(kw)
-        response, self._responses = self._responses[0], self._responses[1:]
-        return response
-
     def list_topics(self, project, page_size, page_token):
-        self._listed = (project, page_size, page_token)
+        self._listed_topics = (project, page_size, page_token)
         return self._list_topics_response
+
+    def list_subscriptions(self, project, page_size, page_token):
+        self._listed_subscriptions = (project, page_size, page_token)
+        return self._list_subscriptions_response

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -705,6 +705,53 @@ class TestConnection(unittest2.TestCase):
                          '%s:pull' % (self.SUB_PATH,))
         self.assertEqual(http._called_with['body'], json.dumps(BODY))
 
+    def test_subscription_acknowledge(self):
+        import json
+        ACK_ID1 = 'DEADBEEF'
+        ACK_ID2 = 'BEADCAFE'
+        BODY = {
+            'ackIds': [ACK_ID1, ACK_ID2],
+        }
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        conn.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
+
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'],
+                         '%s:acknowledge' % (self.SUB_PATH,))
+        self.assertEqual(http._called_with['body'], json.dumps(BODY))
+
+    def test_subscription_modify_ack_deadline(self):
+        import json
+        ACK_ID1 = 'DEADBEEF'
+        ACK_ID2 = 'BEADCAFE'
+        NEW_DEADLINE = 90
+        BODY = {
+            'ackIds': [ACK_ID1, ACK_ID2],
+            'ackDeadlineSeconds': NEW_DEADLINE,
+        }
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        conn.subscription_modify_ack_deadline(
+            self.SUB_PATH, [ACK_ID1, ACK_ID2], NEW_DEADLINE)
+
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'],
+                         '%s:modifyAckDeadline' % (self.SUB_PATH,))
+        self.assertEqual(http._called_with['body'], json.dumps(BODY))
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -267,6 +267,22 @@ class TestConnection(unittest2.TestCase):
                          self.LIST_SUBSCRIPTIONS_PATH)
         self.assertEqual(http._called_with['body'], None)
 
+    def test_topic_create(self):
+        import json
+        RETURNED = {'name': self.TOPIC_PATH}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.topic_create(self.TOPIC_PATH)
+
+        self.assertEqual(http._called_with['method'], 'PUT')
+        self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
+        self.assertEqual(http._called_with['body'], None)
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -318,6 +318,30 @@ class TestConnection(unittest2.TestCase):
         self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
         self.assertEqual(http._called_with['body'], None)
 
+    def test_topic_publish(self):
+        import base64
+        import json
+        PAYLOAD = b'This is the message text'
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        MSGID = 'DEADBEEF'
+        MESSAGE = {'data': B64, 'attributes': {}}
+        RETURNED = {'messageIds': [MSGID]}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.topic_publish(self.TOPIC_PATH, [MESSAGE])
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'],
+                         '%s:publish' % (self.TOPIC_PATH,))
+        self.assertEqual(http._called_with['body'],
+                         json.dumps({'messages': [MESSAGE]}))
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -582,6 +582,30 @@ class TestConnection(unittest2.TestCase):
         self._verify_uri(http._called_with['uri'], self.SUB_PATH)
         self.assertEqual(http._called_with['body'], json.dumps(RESOURCE))
 
+    def test_subscription_get(self):
+        import json
+        ACK_DEADLINE = 90
+        PUSH_ENDPOINT = 'https://api.example.com/push'
+        RETURNED = {
+            'topic': self.TOPIC_PATH,
+            'name': self.SUB_PATH,
+            'ackDeadlineSeconds': ACK_DEADLINE,
+            'pushConfig': {'pushEndpoint': PUSH_ENDPOINT},
+        }
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.subscription_get(self.SUB_PATH)
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'GET')
+        self._verify_uri(http._called_with['uri'], self.SUB_PATH)
+        self.assertEqual(http._called_with['body'], None)
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -491,6 +491,49 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'],
                          json.dumps({'policy': POLICY}))
 
+    def test_test_iam_permissions(self):
+        import json
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        PATH = '%s:testIamPermissions' % (self.TOPIC_PATH,)
+        ALL_ROLES = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
+        ALLOWED = ALL_ROLES[1:]
+        RETURNED = {'permissions': ALLOWED}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        allowed = conn.test_iam_permissions(self.TOPIC_PATH, ALL_ROLES)
+
+        self.assertEqual(allowed, ALLOWED)
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'], PATH)
+        self.assertEqual(http._called_with['body'],
+                         json.dumps({'permissions': ALL_ROLES}))
+
+    def test_test_iam_permissions_missing_key(self):
+        import json
+        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        PATH = '%s:testIamPermissions' % (self.TOPIC_PATH,)
+        ALL_ROLES = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        allowed = conn.test_iam_permissions(self.TOPIC_PATH, ALL_ROLES)
+
+        self.assertEqual(allowed, [])
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'], PATH)
+        self.assertEqual(http._called_with['body'],
+                         json.dumps({'permissions': ALL_ROLES}))
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -301,6 +301,23 @@ class TestConnection(unittest2.TestCase):
         self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
         self.assertEqual(http._called_with['body'], None)
 
+    def test_topic_delete(self):
+        import json
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.topic_delete(self.TOPIC_PATH)
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'DELETE')
+        self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
+        self.assertEqual(http._called_with['body'], None)
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -622,6 +622,27 @@ class TestConnection(unittest2.TestCase):
         self._verify_uri(http._called_with['uri'], self.SUB_PATH)
         self.assertEqual(http._called_with['body'], None)
 
+    def test_subscription_modify_push_config(self):
+        import json
+        PUSH_ENDPOINT = 'https://api.example.com/push'
+        BODY = {
+            'pushConfig': {'pushEndpoint': PUSH_ENDPOINT},
+        }
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        conn.subscription_modify_push_config(self.SUB_PATH, PUSH_ENDPOINT)
+
+        self.assertEqual(http._called_with['method'], 'POST')
+        self._verify_uri(http._called_with['uri'],
+                         '%s:modifyPushConfig' % (self.SUB_PATH,))
+        self.assertEqual(http._called_with['body'], json.dumps(BODY))
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -606,6 +606,22 @@ class TestConnection(unittest2.TestCase):
         self._verify_uri(http._called_with['uri'], self.SUB_PATH)
         self.assertEqual(http._called_with['body'], None)
 
+    def test_subscription_delete(self):
+        import json
+        RETURNED = {}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        conn.subscription_delete(self.SUB_PATH)
+
+        self.assertEqual(http._called_with['method'], 'DELETE')
+        self._verify_uri(http._called_with['uri'], self.SUB_PATH)
+        self.assertEqual(http._called_with['body'], None)
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -304,17 +304,15 @@ class TestConnection(unittest2.TestCase):
 
     def test_topic_delete(self):
         import json
-        RETURNED = {}
         HEADERS = {
             'status': '200',
             'content-type': 'application/json',
         }
-        http = _Http(HEADERS, json.dumps(RETURNED))
+        http = _Http(HEADERS, json.dumps({}))
         conn = self._makeOne(http=http)
 
-        resource = conn.topic_delete(self.TOPIC_PATH)
+        conn.topic_delete(self.TOPIC_PATH)
 
-        self.assertEqual(resource, RETURNED)
         self.assertEqual(http._called_with['method'], 'DELETE')
         self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
         self.assertEqual(http._called_with['body'], None)

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -534,6 +534,54 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(http._called_with['body'],
                          json.dumps({'permissions': ALL_ROLES}))
 
+    def test_subscription_create_defaults(self):
+        import json
+        RESOURCE = {'topic': self.TOPIC_PATH}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        RETURNED = RESOURCE.copy()
+        RETURNED['name'] = self.SUB_PATH
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.subscription_create(self.SUB_PATH, self.TOPIC_PATH)
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'PUT')
+        self._verify_uri(http._called_with['uri'], self.SUB_PATH)
+        self.assertEqual(http._called_with['body'], json.dumps(RESOURCE))
+
+    def test_subscription_create_explicit(self):
+        import json
+        ACK_DEADLINE = 90
+        PUSH_ENDPOINT = 'https://api.example.com/push'
+        RESOURCE = {
+            'topic': self.TOPIC_PATH,
+            'ackDeadlineSeconds': ACK_DEADLINE,
+            'pushConfig': {
+                'pushEndpoint': PUSH_ENDPOINT,
+            },
+        }
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        RETURNED = RESOURCE.copy()
+        RETURNED['name'] = self.SUB_PATH
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.subscription_create(
+            self.SUB_PATH, self.TOPIC_PATH,
+            ack_deadline=ACK_DEADLINE, push_endpoint=PUSH_ENDPOINT)
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'PUT')
+        self._verify_uri(http._called_with['uri'], self.SUB_PATH)
+        self.assertEqual(http._called_with['body'], json.dumps(RESOURCE))
+
 
 class _Http(object):
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -647,7 +647,7 @@ class TestConnection(unittest2.TestCase):
         import base64
         import json
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         MESSAGE = {'messageId': MSG_ID, 'data': B64, 'attributes': {'a': 'b'}}
@@ -677,7 +677,7 @@ class TestConnection(unittest2.TestCase):
         import base64
         import json
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         MESSAGE = {'messageId': MSG_ID, 'data': B64, 'attributes': {'a': 'b'}}

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -279,7 +279,25 @@ class TestConnection(unittest2.TestCase):
 
         resource = conn.topic_create(self.TOPIC_PATH)
 
+        self.assertEqual(resource, RETURNED)
         self.assertEqual(http._called_with['method'], 'PUT')
+        self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
+        self.assertEqual(http._called_with['body'], None)
+
+    def test_topic_get(self):
+        import json
+        RETURNED = {'name': self.TOPIC_PATH}
+        HEADERS = {
+            'status': '200',
+            'content-type': 'application/json',
+        }
+        http = _Http(HEADERS, json.dumps(RETURNED))
+        conn = self._makeOne(http=http)
+
+        resource = conn.topic_get(self.TOPIC_PATH)
+
+        self.assertEqual(resource, RETURNED)
+        self.assertEqual(http._called_with['method'], 'GET')
         self._verify_uri(http._called_with['uri'], self.TOPIC_PATH)
         self.assertEqual(http._called_with['body'], None)
 

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -334,7 +334,7 @@ class TestConnection(unittest2.TestCase):
 
         resource = conn.topic_publish(self.TOPIC_PATH, [MESSAGE])
 
-        self.assertEqual(resource, RETURNED)
+        self.assertEqual(resource, [MSGID])
         self.assertEqual(http._called_with['method'], 'POST')
         self._verify_uri(http._called_with['uri'],
                          '%s:publish' % (self.TOPIC_PATH,))

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -275,38 +275,37 @@ class TestSubscription(unittest2.TestCase):
         self.assertEqual(conn2._subscription_deleted, self.SUB_PATH)
 
     def test_modify_push_config_w_endpoint_w_bound_client(self):
-        PATH = '/%s:modifyPushConfig' % (self.SUB_PATH,)
-        conn = _Connection({})
+        conn = _Connection()
+        conn._subscription_modify_push_config_response = {}
         client = _Client(project=self.PROJECT, connection=conn)
         topic = _Topic(self.TOPIC_NAME, client=client)
         subscription = self._makeOne(self.SUB_NAME, topic)
+
         subscription.modify_push_configuration(push_endpoint=self.ENDPOINT)
+
         self.assertEqual(subscription.push_endpoint, self.ENDPOINT)
-        self.assertEqual(len(conn._requested), 1)
-        req = conn._requested[0]
-        self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], PATH)
-        self.assertEqual(req['data'],
-                         {'pushConfig': {'pushEndpoint': self.ENDPOINT}})
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._subscription_modified_push_config,
+                         (self.SUB_PATH, self.ENDPOINT))
 
     def test_modify_push_config_wo_endpoint_w_alternate_client(self):
-        PATH = '/%s:modifyPushConfig' % (self.SUB_PATH,)
-        conn1 = _Connection({})
+        conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
-        conn2 = _Connection({})
+        conn2 = _Connection()
+        conn2._subscription_modify_push_config_response = {}
         client2 = _Client(project=self.PROJECT, connection=conn2)
         topic = _Topic(self.TOPIC_NAME, client=client1)
         subscription = self._makeOne(self.SUB_NAME, topic,
                                      push_endpoint=self.ENDPOINT)
+
         subscription.modify_push_configuration(push_endpoint=None,
                                                client=client2)
+
         self.assertEqual(subscription.push_endpoint, None)
         self.assertEqual(len(conn1._requested), 0)
-        self.assertEqual(len(conn2._requested), 1)
-        req = conn2._requested[0]
-        self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], PATH)
-        self.assertEqual(req['data'], {'pushConfig': {}})
+        self.assertEqual(len(conn2._requested), 0)
+        self.assertEqual(conn2._subscription_modified_push_config,
+                         (self.SUB_PATH, None))
 
     def test_pull_wo_return_immediately_max_messages_w_bound_client(self):
         import base64
@@ -671,6 +670,12 @@ class _Connection(object):
     def subscription_delete(self, subscription_path):
         self._subscription_deleted = subscription_path
         return self._subscription_delete_response
+
+    def subscription_modify_push_config(
+            self, subscription_path, push_endpoint):
+        self._subscription_modified_push_config = (
+            subscription_path, push_endpoint)
+        return self._subscription_modify_push_config_response
 
 
 class _Topic(object):

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -58,29 +58,29 @@ class TestTopic(unittest2.TestCase):
                           resource, client=client)
 
     def test_create_w_bound_client(self):
-        PATH = '/%s' % (self.TOPIC_PATH,)
-        conn = _Connection({'name': self.TOPIC_PATH})
+        conn = _Connection()
+        conn._topic_create_response = {'name': self.TOPIC_PATH}
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client)
+
         topic.create()
-        self.assertEqual(len(conn._requested), 1)
-        req = conn._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], PATH)
+
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._topic_created, self.TOPIC_PATH)
 
     def test_create_w_alternate_client(self):
-        PATH = '/%s' % (self.TOPIC_PATH,)
         conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
-        conn2 = _Connection({'name': self.TOPIC_PATH})
+        conn2 = _Connection()
+        conn2._topic_create_response = {'name': self.TOPIC_PATH}
         client2 = _Client(project=self.PROJECT, connection=conn2)
         topic = self._makeOne(self.TOPIC_NAME, client=client1)
+
         topic.create(client=client2)
+
         self.assertEqual(len(conn1._requested), 0)
-        self.assertEqual(len(conn2._requested), 1)
-        req = conn2._requested[0]
-        self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], PATH)
+        self.assertEqual(len(conn2._requested), 0)
+        self.assertEqual(conn2._topic_created, self.TOPIC_PATH)
 
     def test_exists_miss_w_bound_client(self):
         PATH = '/%s' % (self.TOPIC_PATH,)
@@ -792,6 +792,10 @@ class _Connection(object):
             raise NotFound('miss')
         else:
             return response
+
+    def topic_create(self, topic_path):
+        self._topic_created = topic_path
+        return self._topic_create_response
 
 
 class _Topic(object):

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -138,7 +138,7 @@ class TestTopic(unittest2.TestCase):
         MSGID = 'DEADBEEF'
         MESSAGE = {'data': B64, 'attributes': {}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID]}
+        conn._topic_publish_response = [MSGID]
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client)
 
@@ -169,7 +169,7 @@ class TestTopic(unittest2.TestCase):
         conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection()
-        conn2._topic_publish_response = {'messageIds': [MSGID]}
+        conn2._topic_publish_response = [MSGID]
         client2 = _Client(project=self.PROJECT, connection=conn2)
 
         topic = self._makeOne(self.TOPIC_NAME, client=client1,
@@ -191,7 +191,7 @@ class TestTopic(unittest2.TestCase):
         MESSAGE = {'data': B64,
                    'attributes': {'timestamp': OVERRIDE}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID]}
+        conn._topic_publish_response = [MSGID]
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client,
                               timestamp_messages=True)
@@ -210,7 +210,7 @@ class TestTopic(unittest2.TestCase):
         MESSAGE = {'data': B64,
                    'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID]}
+        conn._topic_publish_response = [MSGID]
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client)
 
@@ -233,7 +233,7 @@ class TestTopic(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID1, MSGID2]}
+        conn._topic_publish_response = [MSGID1, MSGID2]
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client)
 
@@ -263,7 +263,7 @@ class TestTopic(unittest2.TestCase):
         conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection()
-        conn2._topic_publish_response = {'messageIds': [MSGID1, MSGID2]}
+        conn2._topic_publish_response = [MSGID1, MSGID2]
         client2 = _Client(project=self.PROJECT, connection=conn2)
         topic = self._makeOne(self.TOPIC_NAME, client=client1)
 
@@ -627,7 +627,7 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID1, MSGID2]}
+        conn._topic_publish_response = [MSGID1, MSGID2]
         client = _Client(project='PROJECT', connection=conn)
         topic = _Topic()
         batch = self._makeOne(topic, client=client)
@@ -657,7 +657,7 @@ class TestBatch(unittest2.TestCase):
         conn1 = _Connection()
         client1 = _Client(project='PROJECT', connection=conn1)
         conn2 = _Connection()
-        conn2._topic_publish_response = {'messageIds': [MSGID1, MSGID2]}
+        conn2._topic_publish_response = [MSGID1, MSGID2]
         client2 = _Client(project='PROJECT', connection=conn2)
         topic = _Topic()
         batch = self._makeOne(topic, client=client1)
@@ -686,7 +686,7 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection()
-        conn._topic_publish_response = {'messageIds': [MSGID1, MSGID2]}
+        conn._topic_publish_response = [MSGID1, MSGID2]
         client = _Client(project='PROJECT', connection=conn)
         topic = _Topic()
         batch = self._makeOne(topic, client=client)

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -397,7 +397,6 @@ class TestTopic(unittest2.TestCase):
 
     def test_get_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
-        PATH = '/%s:getIamPolicy' % (self.TOPIC_PATH,)
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -414,7 +413,8 @@ class TestTopic(unittest2.TestCase):
             ],
         }
 
-        conn = _Connection(POLICY)
+        conn = _Connection()
+        conn._get_iam_policy_response = POLICY
         client = _Client(project=self.PROJECT, connection=conn)
         topic = self._makeOne(self.TOPIC_NAME, client=client)
 
@@ -425,20 +425,17 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(sorted(policy.owners), [OWNER2, OWNER1])
         self.assertEqual(sorted(policy.editors), [EDITOR1, EDITOR2])
         self.assertEqual(sorted(policy.viewers), [VIEWER1, VIEWER2])
-
-        self.assertEqual(len(conn._requested), 1)
-        req = conn._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], PATH)
+        self.assertEqual(len(conn._requested), 0)
+        self.assertEqual(conn._got_iam_policy, self.TOPIC_PATH)
 
     def test_get_iam_policy_w_alternate_client(self):
-        PATH = '/%s:getIamPolicy' % (self.TOPIC_PATH,)
         POLICY = {
             'etag': 'ACAB',
         }
 
         conn1 = _Connection()
-        conn2 = _Connection(POLICY)
+        conn2 = _Connection()
+        conn2._get_iam_policy_response = POLICY
         client1 = _Client(project=self.PROJECT, connection=conn1)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         topic = self._makeOne(self.TOPIC_NAME, client=client1)
@@ -452,10 +449,8 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(sorted(policy.viewers), [])
 
         self.assertEqual(len(conn1._requested), 0)
-        self.assertEqual(len(conn2._requested), 1)
-        req = conn2._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], PATH)
+        self.assertEqual(len(conn2._requested), 0)
+        self.assertEqual(conn2._got_iam_policy, self.TOPIC_PATH)
 
     def test_set_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import Policy
@@ -801,6 +796,10 @@ class _Connection(object):
                                  page_token=None):
         self._topic_listed = topic_path, page_size, page_token
         return self._topic_list_subscriptions_response
+
+    def get_iam_policy(self, target_path):
+        self._got_iam_policy = target_path
+        return self._get_iam_policy_response
 
 
 class _Topic(object):

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -16,6 +16,9 @@ import unittest2
 
 
 class TestTopic(unittest2.TestCase):
+    PROJECT = 'PROJECT'
+    TOPIC_NAME = 'topic_name'
+    TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
 
     def _getTargetClass(self):
         from gcloud.pubsub.topic import Topic
@@ -25,119 +28,101 @@ class TestTopic(unittest2.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_ctor_w_explicit_timestamp(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        CLIENT = _Client(project=PROJECT)
-        topic = self._makeOne(TOPIC_NAME,
-                              client=CLIENT,
+        client = _Client(project=self.PROJECT)
+        topic = self._makeOne(self.TOPIC_NAME,
+                              client=client,
                               timestamp_messages=True)
-        self.assertEqual(topic.name, TOPIC_NAME)
-        self.assertEqual(topic.project, PROJECT)
-        self.assertEqual(topic.full_name,
-                         'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME))
+        self.assertEqual(topic.name, self.TOPIC_NAME)
+        self.assertEqual(topic.project, self.PROJECT)
+        self.assertEqual(topic.full_name, self.TOPIC_PATH)
         self.assertTrue(topic.timestamp_messages)
 
     def test_from_api_repr(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        CLIENT = _Client(project=PROJECT)
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        resource = {'name': PATH}
+        client = _Client(project=self.PROJECT)
+        resource = {'name': self.TOPIC_PATH}
         klass = self._getTargetClass()
-        topic = klass.from_api_repr(resource, client=CLIENT)
-        self.assertEqual(topic.name, TOPIC_NAME)
-        self.assertTrue(topic._client is CLIENT)
-        self.assertEqual(topic.project, PROJECT)
-        self.assertEqual(topic.full_name, PATH)
+        topic = klass.from_api_repr(resource, client=client)
+        self.assertEqual(topic.name, self.TOPIC_NAME)
+        self.assertTrue(topic._client is client)
+        self.assertEqual(topic.project, self.PROJECT)
+        self.assertEqual(topic.full_name, self.TOPIC_PATH)
 
     def test_from_api_repr_with_bad_client(self):
-        TOPIC_NAME = 'topic_name'
         PROJECT1 = 'PROJECT1'
         PROJECT2 = 'PROJECT2'
-        CLIENT = _Client(project=PROJECT1)
-        PATH = 'projects/%s/topics/%s' % (PROJECT2, TOPIC_NAME)
+        client = _Client(project=PROJECT1)
+        PATH = 'projects/%s/topics/%s' % (PROJECT2, self.TOPIC_NAME)
         resource = {'name': PATH}
         klass = self._getTargetClass()
         self.assertRaises(ValueError, klass.from_api_repr,
-                          resource, client=CLIENT)
+                          resource, client=client)
 
     def test_create_w_bound_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn = _Connection({'name': PATH})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        PATH = '/%s' % (self.TOPIC_PATH,)
+        conn = _Connection({'name': self.TOPIC_PATH})
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         topic.create()
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_create_w_alternate_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn1 = _Connection({'name': PATH})
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
-        conn2 = _Connection({'name': PATH})
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
-        topic.create(client=CLIENT2)
+        PATH = '/%s' % (self.TOPIC_PATH,)
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        conn2 = _Connection({'name': self.TOPIC_PATH})
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic.create(client=client2)
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'PUT')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_exists_miss_w_bound_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        PATH = '/%s' % (self.TOPIC_PATH,)
         conn = _Connection()
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         self.assertFalse(topic.exists())
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_exists_hit_w_alternate_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn1 = _Connection({'name': PATH})
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
-        conn2 = _Connection({'name': PATH})
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
-        self.assertTrue(topic.exists(client=CLIENT2))
+        PATH = '/%s' % (self.TOPIC_PATH,)
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        conn2 = _Connection({'name': self.TOPIC_PATH})
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        self.assertTrue(topic.exists(client=client2))
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_publish_single_bytes_wo_attrs_w_bound_client(self):
         import base64
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
-        MESSAGE = {'data': B64,
-                   'attributes': {}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        MESSAGE = {'data': B64, 'attributes': {}}
         conn = _Connection({'messageIds': [MSGID]})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         msgid = topic.publish(PAYLOAD)
         self.assertEqual(msgid, MSGID)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE]})
 
     def test_publish_single_bytes_wo_attrs_w_add_timestamp_alt_client(self):
@@ -146,85 +131,80 @@ class TestTopic(unittest2.TestCase):
         from gcloud.pubsub import topic as MUT
         from gcloud._helpers import _RFC3339_MICROS
         from gcloud._testing import _Monkey
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         NOW = datetime.datetime.utcnow()
 
         def _utcnow():
             return NOW
 
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
-        MESSAGE = {'data': B64,
-                   'attributes': {'timestamp': NOW.strftime(_RFC3339_MICROS)}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn1 = _Connection({'messageIds': [MSGID]})
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
+        MESSAGE = {
+            'data': B64,
+            'attributes': {'timestamp': NOW.strftime(_RFC3339_MICROS)},
+        }
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({'messageIds': [MSGID]})
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
 
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1,
+        topic = self._makeOne(self.TOPIC_NAME, client=client1,
                               timestamp_messages=True)
         with _Monkey(MUT, _NOW=_utcnow):
-            msgid = topic.publish(PAYLOAD, client=CLIENT2)
+            msgid = topic.publish(PAYLOAD, client=client2)
 
         self.assertEqual(msgid, MSGID)
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE]})
 
     def test_publish_single_bytes_w_add_timestamp_w_ts_in_attrs(self):
         import base64
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
         OVERRIDE = '2015-04-10T16:46:22.868399Z'
         MESSAGE = {'data': B64,
                    'attributes': {'timestamp': OVERRIDE}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
         conn = _Connection({'messageIds': [MSGID]})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT,
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client,
                               timestamp_messages=True)
         msgid = topic.publish(PAYLOAD, timestamp=OVERRIDE)
         self.assertEqual(msgid, MSGID)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE]})
 
     def test_publish_single_w_attrs(self):
         import base64
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
         MESSAGE = {'data': B64,
                    'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
         conn = _Connection({'messageIds': [MSGID]})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         msgid = topic.publish(PAYLOAD, attr1='value1', attr2='value2')
         self.assertEqual(msgid, MSGID)
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE]})
 
     def test_publish_multiple_w_bound_client(self):
         import base64
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD1 = b'This is the first message text'
         PAYLOAD2 = b'This is the second message text'
         B64_1 = base64.b64encode(PAYLOAD1)
@@ -235,10 +215,9 @@ class TestTopic(unittest2.TestCase):
                     'attributes': {}}
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
         conn = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         with topic.batch() as batch:
             batch.publish(PAYLOAD1)
             batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
@@ -247,30 +226,29 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE1, MESSAGE2]})
 
     def test_publish_multiple_w_alternate_client(self):
         import base64
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD1 = b'This is the first message text'
         PAYLOAD2 = b'This is the second message text'
         B64_1 = base64.b64encode(PAYLOAD1)
         B64_2 = base64.b64encode(PAYLOAD2)
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
-                    'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
-                    'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn1 = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
+        MESSAGE1 = {'data': B64_1.decode('ascii'), 'attributes': {}}
+        MESSAGE2 = {
+            'data': B64_2.decode('ascii'),
+            'attributes': {'attr1': 'value1', 'attr2': 'value2'},
+        }
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
-        with topic.batch(client=CLIENT2) as batch:
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        with topic.batch(client=client2) as batch:
             batch.publish(PAYLOAD1)
             batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
         self.assertEqual(list(batch), [MSGID1, MSGID2])
@@ -279,19 +257,18 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s:publish' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'messages': [MESSAGE1, MESSAGE2]})
 
     def test_publish_multiple_error(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
+        PATH = '/%s:publish' % (self.TOPIC_PATH,)
         PAYLOAD1 = b'This is the first message text'
         PAYLOAD2 = b'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
         conn = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT = _Client(project=PROJECT)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         try:
             with topic.batch() as batch:
                 batch.publish(PAYLOAD1)
@@ -303,40 +280,34 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 0)
 
     def test_delete_w_bound_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+        PATH = '/%s' % (self.TOPIC_PATH,)
         conn = _Connection({})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         topic.delete()
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'DELETE')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_delete_w_alternate_client(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        conn1 = _Connection({})
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
+        PATH = '/%s' % (self.TOPIC_PATH,)
+        conn1 = _Connection()
+        client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
-        topic.delete(client=CLIENT2)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic.delete(client=client2)
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'DELETE')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_subscription(self):
         from gcloud.pubsub.subscription import Subscription
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        CLIENT = _Client(project=PROJECT)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         SUBSCRIPTION_NAME = 'subscription_name'
         subscription = topic.subscription(SUBSCRIPTION_NAME)
@@ -345,21 +316,21 @@ class TestTopic(unittest2.TestCase):
         self.assertTrue(subscription.topic is topic)
 
     def test_list_subscriptions_no_paging(self):
+        PATH = '/%s/subscriptions' % (self.TOPIC_PATH,)
         from gcloud.pubsub.subscription import Subscription
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
         SUB_NAME_1 = 'subscription_1'
-        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_1)
+        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (
+            self.PROJECT, SUB_NAME_1)
         SUB_NAME_2 = 'subscription_2'
-        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_2)
-        TOPIC_NAME = 'topic_name'
+        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (
+            self.PROJECT, SUB_NAME_2)
         SUBS_LIST = [SUB_PATH_1, SUB_PATH_2]
         TOKEN = 'TOKEN'
         RETURNED = {'subscriptions': SUBS_LIST, 'nextPageToken': TOKEN}
 
         conn = _Connection(RETURNED)
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         # Execute request.
         subscriptions, next_page_token = topic.list_subscriptions()
@@ -380,28 +351,26 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'],
-                         '/projects/%s/topics/%s/subscriptions'
-                         % (PROJECT, TOPIC_NAME))
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['query_params'], {})
 
     def test_list_subscriptions_with_paging(self):
+        PATH = '/%s/subscriptions' % (self.TOPIC_PATH,)
         from gcloud.pubsub.subscription import Subscription
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
         SUB_NAME_1 = 'subscription_1'
-        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_1)
+        SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (
+            self.PROJECT, SUB_NAME_1)
         SUB_NAME_2 = 'subscription_2'
-        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME_2)
-        TOPIC_NAME = 'topic_name'
+        SUB_PATH_2 = 'projects/%s/subscriptions/%s' % (
+            self.PROJECT, SUB_NAME_2)
         SUBS_LIST = [SUB_PATH_1, SUB_PATH_2]
         PAGE_SIZE = 10
         TOKEN = 'TOKEN'
         RETURNED = {'subscriptions': SUBS_LIST}
 
         conn = _Connection(RETURNED)
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         # Execute request.
         subscriptions, next_page_token = topic.list_subscriptions(
@@ -423,20 +392,15 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'],
-                         '/projects/%s/topics/%s/subscriptions'
-                         % (PROJECT, TOPIC_NAME))
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['query_params'],
                          {'pageSize': PAGE_SIZE, 'pageToken': TOKEN})
 
     def test_list_subscriptions_missing_key(self):
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        TOPIC_NAME = 'topic_name'
-
+        PATH = '/%s/subscriptions' % (self.TOPIC_PATH,)
         conn = _Connection({})
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         # Execute request.
         subscriptions, next_page_token = topic.list_subscriptions()
@@ -447,13 +411,12 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'],
-                         '/projects/%s/topics/%s/subscriptions'
-                         % (PROJECT, TOPIC_NAME))
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['query_params'], {})
 
     def test_get_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        PATH = '/%s:getIamPolicy' % (self.TOPIC_PATH,)
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -469,14 +432,10 @@ class TestTopic(unittest2.TestCase):
                 {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        TOPIC_NAME = 'topic_name'
-        PATH = 'projects/%s/topics/%s:getIamPolicy' % (PROJECT, TOPIC_NAME)
 
         conn = _Connection(POLICY)
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         policy = topic.get_iam_policy()
 
@@ -489,24 +448,21 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_get_iam_policy_w_alternate_client(self):
+        PATH = '/%s:getIamPolicy' % (self.TOPIC_PATH,)
         POLICY = {
             'etag': 'ACAB',
         }
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        TOPIC_NAME = 'topic_name'
-        PATH = 'projects/%s/topics/%s:getIamPolicy' % (PROJECT, TOPIC_NAME)
 
         conn1 = _Connection()
         conn2 = _Connection(POLICY)
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
 
-        policy = topic.get_iam_policy(client=CLIENT2)
+        policy = topic.get_iam_policy(client=client2)
 
         self.assertEqual(policy.etag, 'ACAB')
         self.assertEqual(policy.version, None)
@@ -518,11 +474,12 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
 
     def test_set_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import Policy
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        PATH = '/%s:setIamPolicy' % (self.TOPIC_PATH,)
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'
@@ -541,14 +498,10 @@ class TestTopic(unittest2.TestCase):
         RESPONSE = POLICY.copy()
         RESPONSE['etag'] = 'ABACABAF'
         RESPONSE['version'] = 18
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        TOPIC_NAME = 'topic_name'
-        PATH = 'projects/%s/topics/%s:setIamPolicy' % (PROJECT, TOPIC_NAME)
 
         conn = _Connection(RESPONSE)
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
         policy = Policy('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
@@ -568,25 +521,22 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'policy': POLICY})
 
     def test_set_iam_policy_w_alternate_client(self):
         from gcloud.pubsub.iam import Policy
+        PATH = '/%s:setIamPolicy' % (self.TOPIC_PATH,)
         RESPONSE = {'etag': 'ACAB'}
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        TOPIC_NAME = 'topic_name'
-        PATH = 'projects/%s/topics/%s:setIamPolicy' % (PROJECT, TOPIC_NAME)
 
         conn1 = _Connection()
         conn2 = _Connection(RESPONSE)
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
+        client1 = _Client(project=self.PROJECT, connection=conn1)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
 
         policy = Policy()
-        new_policy = topic.set_iam_policy(policy, client=CLIENT2)
+        new_policy = topic.set_iam_policy(policy, client=client2)
 
         self.assertEqual(new_policy.etag, 'ACAB')
         self.assertEqual(new_policy.version, None)
@@ -598,15 +548,12 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], {'policy': {}})
 
     def test_check_iam_permissions_w_bound_client(self):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s:testIamPermissions' % (
-            PROJECT, TOPIC_NAME)
+        PATH = '/%s:testIamPermissions' % (self.TOPIC_PATH,)
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
@@ -615,8 +562,8 @@ class TestTopic(unittest2.TestCase):
             'permissions': ROLES[:-1],
         }
         conn = _Connection(RESPONSE)
-        CLIENT = _Client(project=PROJECT, connection=conn)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT)
+        client = _Client(project=self.PROJECT, connection=conn)
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
 
         allowed = topic.check_iam_permissions(ROLES)
 
@@ -624,34 +571,31 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], REQUESTED)
 
     def test_check_iam_permissions_w_alternate_client(self):
         from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
-        TOPIC_NAME = 'topic_name'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/topics/%s:testIamPermissions' % (
-            PROJECT, TOPIC_NAME)
+        PATH = '/%s:testIamPermissions' % (self.TOPIC_PATH,)
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         REQUESTED = {
             'permissions': ROLES,
         }
         RESPONSE = {}
         conn1 = _Connection()
-        CLIENT1 = _Client(project=PROJECT, connection=conn1)
+        client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESPONSE)
-        CLIENT2 = _Client(project=PROJECT, connection=conn2)
-        topic = self._makeOne(TOPIC_NAME, client=CLIENT1)
+        client2 = _Client(project=self.PROJECT, connection=conn2)
+        topic = self._makeOne(self.TOPIC_NAME, client=client1)
 
-        allowed = topic.check_iam_permissions(ROLES, client=CLIENT2)
+        allowed = topic.check_iam_permissions(ROLES, client=client2)
 
         self.assertEqual(len(allowed), 0)
         self.assertEqual(len(conn1._requested), 0)
         self.assertEqual(len(conn2._requested), 1)
         req = conn2._requested[0]
         self.assertEqual(req['method'], 'POST')
-        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(req['path'], PATH)
         self.assertEqual(req['data'], REQUESTED)
 
 
@@ -666,10 +610,10 @@ class TestBatch(unittest2.TestCase):
 
     def test_ctor_defaults(self):
         topic = _Topic()
-        CLIENT = _Client(project='PROJECT')
-        batch = self._makeOne(topic, CLIENT)
+        client = _Client(project='PROJECT')
+        batch = self._makeOne(topic, client)
         self.assertTrue(batch.topic is topic)
-        self.assertTrue(batch.client is CLIENT)
+        self.assertTrue(batch.client is client)
         self.assertEqual(len(batch.messages), 0)
         self.assertEqual(len(batch.message_ids), 0)
 
@@ -693,9 +637,9 @@ class TestBatch(unittest2.TestCase):
         MESSAGE = {'data': B64,
                    'attributes': {}}
         connection = _Connection()
-        CLIENT = _Client(project='PROJECT', connection=connection)
+        client = _Client(project='PROJECT', connection=connection)
         topic = _Topic()
-        batch = self._makeOne(topic, client=CLIENT)
+        batch = self._makeOne(topic, client=client)
         batch.publish(PAYLOAD)
         self.assertEqual(len(connection._requested), 0)
         self.assertEqual(batch.messages, [MESSAGE])
@@ -707,9 +651,9 @@ class TestBatch(unittest2.TestCase):
         MESSAGE = {'data': B64,
                    'attributes': {'timestamp': 'TIMESTAMP'}}
         connection = _Connection()
-        CLIENT = _Client(project='PROJECT', connection=connection)
+        client = _Client(project='PROJECT', connection=connection)
         topic = _Topic(timestamp_messages=True)
-        batch = self._makeOne(topic, client=CLIENT)
+        batch = self._makeOne(topic, client=client)
         batch.publish(PAYLOAD)
         self.assertEqual(len(connection._requested), 0)
         self.assertEqual(batch.messages, [MESSAGE])
@@ -727,9 +671,9 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT = _Client(project='PROJECT', connection=conn)
+        client = _Client(project='PROJECT', connection=conn)
         topic = _Topic()
-        batch = self._makeOne(topic, client=CLIENT)
+        batch = self._makeOne(topic, client=client)
         batch.publish(PAYLOAD1)
         batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
         batch.commit()
@@ -754,14 +698,14 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn1 = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT1 = _Client(project='PROJECT', connection=conn1)
+        client1 = _Client(project='PROJECT', connection=conn1)
         conn2 = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT2 = _Client(project='PROJECT', connection=conn2)
+        client2 = _Client(project='PROJECT', connection=conn2)
         topic = _Topic()
-        batch = self._makeOne(topic, client=CLIENT1)
+        batch = self._makeOne(topic, client=client1)
         batch.publish(PAYLOAD1)
         batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
-        batch.commit(client=CLIENT2)
+        batch.commit(client=client2)
         self.assertEqual(list(batch), [MSGID1, MSGID2])
         self.assertEqual(list(batch.messages), [])
         self.assertEqual(len(conn1._requested), 0)
@@ -784,9 +728,9 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT = _Client(project='PROJECT', connection=conn)
+        client = _Client(project='PROJECT', connection=conn)
         topic = _Topic()
-        batch = self._makeOne(topic, client=CLIENT)
+        batch = self._makeOne(topic, client=client)
 
         with batch as other:
             batch.publish(PAYLOAD1)
@@ -814,9 +758,9 @@ class TestBatch(unittest2.TestCase):
         MESSAGE2 = {'data': B64_2.decode('ascii'),
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         conn = _Connection({'messageIds': [MSGID1, MSGID2]})
-        CLIENT = _Client(project='PROJECT', connection=conn)
+        client = _Client(project='PROJECT', connection=conn)
         topic = _Topic()
-        batch = self._makeOne(topic, client=CLIENT)
+        batch = self._makeOne(topic, client=client)
 
         try:
             with batch as other:

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -196,9 +196,8 @@ class Topic(object):
         self._timestamp_message(attrs)
         message_b = base64.b64encode(message).decode('ascii')
         message_data = {'data': message_b, 'attributes': attrs}
-        data = {'messages': [message_data]}
-        response = client.connection.api_request(
-            method='POST', path='%s:publish' % (self.path,), data=data)
+        response = client.connection.topic_publish(
+            self.full_name, [message_data])
         return response['messageIds'][0]
 
     def batch(self, client=None):
@@ -380,8 +379,7 @@ class Batch(object):
         """
         if client is None:
             client = self.client
-        response = client.connection.api_request(
-            method='POST', path='%s:publish' % self.topic.path,
-            data={'messages': self.messages[:]})
+        response = client.connection.topic_publish(
+            self.topic.full_name, self.messages[:])
         self.message_ids.extend(response['messageIds'])
         del self.messages[:]

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -143,7 +143,7 @@ class Topic(object):
         client = self._require_client(client)
 
         try:
-            client.connection.api_request(method='GET', path=self.path)
+            client.connection.topic_get(topic_path=self.full_name)
         except NotFound:
             return False
         else:

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -239,24 +239,14 @@ class Topic(object):
                   value as ``page_token``).
         """
         client = self._require_client(client)
-        params = {}
-
-        if page_size is not None:
-            params['pageSize'] = page_size
-
-        if page_token is not None:
-            params['pageToken'] = page_token
-
-        path = '/projects/%s/topics/%s/subscriptions' % (
-            self.project, self.name)
-
-        resp = client.connection.api_request(method='GET', path=path,
-                                             query_params=params)
+        conn = client.connection
+        sub_paths, next_token = conn.topic_list_subscriptions(
+            self.full_name, page_size, page_token)
         subscriptions = []
-        for sub_path in resp.get('subscriptions', ()):
+        for sub_path in sub_paths:
             sub_name = subscription_name_from_path(sub_path, self.project)
             subscriptions.append(Subscription(sub_name, self))
-        return subscriptions, resp.get('nextPageToken')
+        return subscriptions, next_token
 
     def get_iam_policy(self, client=None):
         """Fetch the IAM policy for the topic.

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -128,7 +128,7 @@ class Topic(object):
                        ``client`` stored on the current topic.
         """
         client = self._require_client(client)
-        client.connection.api_request(method='PUT', path=self.path)
+        client.connection.topic_create(topic_path=self.full_name)
 
     def exists(self, client=None):
         """API call:  test for the existence of the topic via a GET request

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -149,6 +149,19 @@ class Topic(object):
         else:
             return True
 
+    def delete(self, client=None):
+        """API call:  delete the topic via a DELETE request
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+
+        :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
+        :param client: the client to use.  If not passed, falls back to the
+                       ``client`` stored on the current topic.
+        """
+        client = self._require_client(client)
+        client.connection.topic_delete(topic_path=self.full_name)
+
     def _timestamp_message(self, attrs):
         """Add a timestamp to ``attrs``, if the topic is so configured.
 
@@ -200,19 +213,6 @@ class Topic(object):
         """
         client = self._require_client(client)
         return Batch(self, client)
-
-    def delete(self, client=None):
-        """API call:  delete the topic via a DELETE request
-
-        See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
-
-        :type client: :class:`gcloud.pubsub.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current topic.
-        """
-        client = self._require_client(client)
-        client.connection.api_request(method='DELETE', path=self.path)
 
     def list_subscriptions(self, page_size=None, page_token=None, client=None):
         """List subscriptions for the project associated with this client.

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -263,8 +263,7 @@ class Topic(object):
                   ``getIamPolicy`` API request.
         """
         client = self._require_client(client)
-        path = '%s:getIamPolicy' % (self.path,)
-        resp = client.connection.api_request(method='GET', path=path)
+        resp = client.connection.get_iam_policy(self.full_name)
         return Policy.from_api_repr(resp)
 
     def set_iam_policy(self, policy, client=None):

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -98,11 +98,6 @@ class Topic(object):
         """Fully-qualified name used in topic / subscription APIs"""
         return 'projects/%s/topics/%s' % (self.project, self.name)
 
-    @property
-    def path(self):
-        """URL path for the topic's APIs"""
-        return '/%s' % (self.full_name)
-
     def _require_client(self, client):
         """Check client or verify over-ride.
 
@@ -306,13 +301,8 @@ class Topic(object):
         :returns: subset of ``permissions`` allowed by current IAM policy.
         """
         client = self._require_client(client)
-        path = '%s:testIamPermissions' % (self.path,)
-        data = {
-            'permissions': list(permissions),
-        }
-        resp = client.connection.api_request(
-            method='POST', path=path, data=data)
-        return resp.get('permissions', ())
+        return client.connection.test_iam_permissions(
+            self.full_name, list(permissions))
 
 
 class Batch(object):

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -191,9 +191,9 @@ class Topic(object):
         self._timestamp_message(attrs)
         message_b = base64.b64encode(message).decode('ascii')
         message_data = {'data': message_b, 'attributes': attrs}
-        response = client.connection.topic_publish(
+        message_ids = client.connection.topic_publish(
             self.full_name, [message_data])
-        return response['messageIds'][0]
+        return message_ids[0]
 
     def batch(self, client=None):
         """Return a batch to use as a context manager.
@@ -355,7 +355,7 @@ class Batch(object):
         """
         if client is None:
             client = self.client
-        response = client.connection.topic_publish(
+        message_ids = client.connection.topic_publish(
             self.topic.full_name, self.messages[:])
-        self.message_ids.extend(response['messageIds'])
+        self.message_ids.extend(message_ids)
         del self.messages[:]

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -285,11 +285,8 @@ class Topic(object):
                   ``setIamPolicy`` API request.
         """
         client = self._require_client(client)
-        path = '%s:setIamPolicy' % (self.path,)
         resource = policy.to_api_repr()
-        wrapped = {'policy': resource}
-        resp = client.connection.api_request(
-            method='POST', path=path, data=wrapped)
+        resp = client.connection.set_iam_policy(self.full_name, resource)
         return Policy.from_api_repr(resp)
 
     def check_iam_permissions(self, permissions, client=None):

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -290,6 +290,8 @@ good-names = i, j, k, ex, Run, _,
 
 # Regular expression matching correct method names
 # DEFAULT:  method-rgx=[a-z_][a-z0-9_]{2,30}$
+# RATIONALE:  mapping long API names onto connection methods
+method-rgx=[a-z_][a-z0-9_]{2,35}$
 
 # Naming hint for method names
 # DEFAULT:  method-name-hint=[a-z_][a-z0-9_]{2,30}$


### PR DESCRIPTION
Encapsulate JSON/REST-specific knowledge inside the connection, allowing later use of a gRPC-based connection.

Toward #851 and #1696.