### PR TITLE
Allow unit tests to pass if pytz is installed.

### DIFF
--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -54,9 +54,13 @@ class Test__UTC(unittest2.TestCase):
 
     def test_module_property(self):
         from gcloud import _helpers as MUT
-
         klass = self._getTargetClass()
-        self.assertTrue(isinstance(MUT.UTC, klass))
+        try:
+            import pytz
+        except ImportError:  # pragma: NO COVER
+            self.assertTrue(isinstance(MUT.UTC, klass))
+        else:
+            self.assertIs(MUT.UTC, pytz.UTC)  # pragma: NO COVER
 
     def test_dst(self):
         import datetime


### PR DESCRIPTION
I'm assuming the intent of test_module_property() is
to check that gcloud._helpers.UTC is defined and has
the right sort of value. It was failing if pytz
happened to be installed.

Note that the current test environment does _not_
install pytz. The gcloud package uses pytz if it is
available but does not depend on it.