### PR TITLE
Stop requiring pyOpenSSL.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,18 +67,11 @@ repo, from which you can submit a pull request.
 I'm getting weird errors... Can you help?
 -----------------------------------------
 
-Chances are you have some dependency problems...
-If you're on Ubuntu,
-try installing the pre-compiled packages::
+If the error mentions ``Python.h`` not being found,
+install ``python-dev`` and try again.
+On Debian/Ubuntu::
 
-  $ sudo apt-get install python-crypto python-openssl libffi-dev
-
-or try installing the development packages
-(that have the header files included)
-and then ``pip install`` the dependencies again::
-
-  $ sudo apt-get install python-dev libssl-dev libffi-dev
-  $ pip install gcloud
+  $ sudo apt-get install python-dev
 
 Adding Features
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,22 +138,6 @@ The ``gcloud`` library is ``pip`` install-able:
 
     $ pip install gcloud
 
-If you have trouble installing
-``pycrypto`` or ``pyopenssl``
-(and you're on Ubuntu),
-you can try install the precompiled packages:
-
-.. code-block:: console
-
-    $ sudo apt-get install python-crypto python-openssl
-
-If you want to install everything with ``pip``,
-try installing the ``dev`` packages beforehand:
-
-.. code-block:: console
-
-    $ sudo apt-get install python-dev libssl-dev
-
 If you want to install ``gcloud-python`` from source,
 you can clone the repository from GitHub:
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ REQUIREMENTS = [
     'googleapis-common-protos',
     'oauth2client >= 2.0.1',
     'protobuf >= 3.0.0b2, != 3.0.0.b2.post1',
-    'pyOpenSSL',
     'six',
 ]
 GRPC_EXTRAS = ['grpcio >= 0.13.1']


### PR DESCRIPTION
This is no longer needed.