### PR TITLE
Allow constructing 'ManagedZone' instance w/o 'dns_name'.

### DIFF
--- a/gcloud/dns/client.py
+++ b/gcloud/dns/client.py
@@ -95,14 +95,15 @@ class Client(JSONClient):
                  for resource in resp['managedZones']]
         return zones, resp.get('nextPageToken')
 
-    def zone(self, name, dns_name):
+    def zone(self, name, dns_name=None):
         """Construct a zone bound to this client.
 
         :type name: string
         :param name: Name of the zone.
 
-        :type dns_name: string
-        :param dns_name: DNS name of the zone.
+        :type dns_name: string or :class:`NoneType`
+        :param dns_name: DNS name of the zone.  If not passed, then calls
+                         to :meth:`zone.create` will fail.
 
         :rtype: :class:`gcloud.dns.zone.ManagedZone`
         :returns: a new ``ManagedZone`` instance

--- a/gcloud/dns/test_zone.py
+++ b/gcloud/dns/test_zone.py
@@ -84,7 +84,23 @@ class TestManagedZone(unittest2.TestCase):
         self.assertEqual(zone.zone_id, resource.get('id'))
         self.assertEqual(zone.name_server_set, resource.get('nameServerSet'))
 
-    def test_ctor(self):
+    def test_ctor_defaults(self):
+        zone = self._makeOne(self.ZONE_NAME)
+        self.assertEqual(zone.name, self.ZONE_NAME)
+        self.assertEqual(zone.dns_name, None)
+        self.assertTrue(zone._client is None)
+
+        with self.assertRaises(AttributeError):
+            _ = zone.project
+
+        with self.assertRaises(AttributeError):
+            _ = zone.path
+
+        self.assertEqual(zone.zone_id, None)
+        self.assertEqual(zone.created, None)
+        self.assertEqual(zone.description, None)
+
+    def test_ctor_explicit(self):
         client = _Client(self.PROJECT)
         zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
         self.assertEqual(zone.name, self.ZONE_NAME)
@@ -94,10 +110,8 @@ class TestManagedZone(unittest2.TestCase):
         self.assertEqual(
             zone.path,
             '/projects/%s/managedZones/%s' % (self.PROJECT, self.ZONE_NAME))
-
         self.assertEqual(zone.zone_id, None)
         self.assertEqual(zone.created, None)
-
         self.assertEqual(zone.description, None)
 
     def test_from_api_repr_missing_identity(self):

--- a/gcloud/dns/zone.py
+++ b/gcloud/dns/zone.py
@@ -30,15 +30,16 @@ class ManagedZone(object):
     :type name: string
     :param name: the name of the zone
 
-    :type dns_name: string
-    :param dns_name: the DNS name of the zone
+    :type dns_name: string or :class:`NoneType`
+    :param dns_name: the DNS name of the zone.  If not passed, then calls
+                     to :meth:`create` will fail.
 
     :type client: :class:`gcloud.dns.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the zone (which requires a project).
     """
 
-    def __init__(self, name, dns_name, client):
+    def __init__(self, name, dns_name=None, client=None):
         self.name = name
         self.dns_name = dns_name
         self._client = client


### PR DESCRIPTION
Closes: #1719.