### PR TITLE
Allow passing 'description' 'ManagedZone.__init__'

### DIFF
--- a/gcloud/dns/client.py
+++ b/gcloud/dns/client.py
@@ -95,7 +95,7 @@ class Client(JSONClient):
                  for resource in resp['managedZones']]
         return zones, resp.get('nextPageToken')
 
-    def zone(self, name, dns_name=None):
+    def zone(self, name, dns_name=None, description=None):
         """Construct a zone bound to this client.
 
         :type name: string
@@ -105,7 +105,12 @@ class Client(JSONClient):
         :param dns_name: DNS name of the zone.  If not passed, then calls
                          to :meth:`zone.create` will fail.
 
+        :type description: string or :class:`NoneType`
+        :param description: the description for the zone.  If not passed,
+                            defaults to the value of 'dns_name'.
+
         :rtype: :class:`gcloud.dns.zone.ManagedZone`
         :returns: a new ``ManagedZone`` instance
         """
-        return ManagedZone(name, dns_name, client=self)
+        return ManagedZone(name, dns_name, client=self,
+                           description=description)

--- a/gcloud/dns/test_client.py
+++ b/gcloud/dns/test_client.py
@@ -190,7 +190,20 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(req['query_params'],
                          {'maxResults': 3, 'pageToken': TOKEN})
 
-    def test_zone_w_explicit_dns_name(self):
+    def test_zone_explicit(self):
+        from gcloud.dns.zone import ManagedZone
+        DESCRIPTION = 'DESCRIPTION'
+        DNS_NAME = 'test.example.com'
+        creds = _Credentials()
+        client = self._makeOne(self.PROJECT, creds)
+        zone = client.zone(self.ZONE_NAME, DNS_NAME, DESCRIPTION)
+        self.assertTrue(isinstance(zone, ManagedZone))
+        self.assertEqual(zone.name, self.ZONE_NAME)
+        self.assertEqual(zone.dns_name, DNS_NAME)
+        self.assertEqual(zone.description, DESCRIPTION)
+        self.assertTrue(zone._client is client)
+
+    def test_zone_w_dns_name_wo_description(self):
         from gcloud.dns.zone import ManagedZone
         DNS_NAME = 'test.example.com'
         creds = _Credentials()
@@ -199,6 +212,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(zone, ManagedZone))
         self.assertEqual(zone.name, self.ZONE_NAME)
         self.assertEqual(zone.dns_name, DNS_NAME)
+        self.assertEqual(zone.description, DNS_NAME)
         self.assertTrue(zone._client is client)
 
     def test_zone_wo_dns_name(self):
@@ -209,6 +223,7 @@ class TestClient(unittest2.TestCase):
         self.assertTrue(isinstance(zone, ManagedZone))
         self.assertEqual(zone.name, self.ZONE_NAME)
         self.assertEqual(zone.dns_name, None)
+        self.assertEqual(zone.description, None)
         self.assertTrue(zone._client is client)
 
 

--- a/gcloud/dns/zone.py
+++ b/gcloud/dns/zone.py
@@ -37,13 +37,20 @@ class ManagedZone(object):
     :type client: :class:`gcloud.dns.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the zone (which requires a project).
+
+    :type description: string or :class:`NoneType`
+    :param description: the description for the zone.  If not passed, defaults
+                        to the value of 'dns_name'.
     """
 
-    def __init__(self, name, dns_name=None, client=None):
+    def __init__(self, name, dns_name=None, client=None, description=None):
         self.name = name
         self.dns_name = dns_name
         self._client = client
         self._properties = {}
+        if description is None:
+            description = dns_name
+        self.description = description
 
     @classmethod
     def from_api_repr(cls, resource, client):
@@ -221,8 +228,10 @@ class ManagedZone(object):
         """Generate a resource for ``create`` or ``update``."""
         resource = {
             'name': self.name,
-            'dnsName': self.dns_name,
         }
+
+        if self.dns_name is not None:
+            resource['dnsName'] = self.dns_name
 
         if self.description is not None:
             resource['description'] = self.description


### PR DESCRIPTION
~~Uses #1728 as a base.~~

Likewise, allow passing 'description' to 'Client.zone'.

Closes: #1721