### PR TITLE
Update 'zone.dns_name' during 'zone.reload'. 

### DIFF
--- a/gcloud/dns/test_zone.py
+++ b/gcloud/dns/test_zone.py
@@ -349,9 +349,11 @@ class TestManagedZone(unittest2.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._makeOne(self.ZONE_NAME, client=client)
 
         zone.reload()
+
+        self.assertEqual(zone.dns_name, self.DNS_NAME)
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]

--- a/gcloud/dns/zone.py
+++ b/gcloud/dns/zone.py
@@ -219,6 +219,7 @@ class ManagedZone(object):
         """
         self._properties.clear()
         cleaned = api_response.copy()
+        self.dns_name = cleaned.pop('dnsName', None)
         if 'creationTime' in cleaned:
             cleaned['creationTime'] = _rfc3339_to_datetime(
                 cleaned['creationTime'])


### PR DESCRIPTION
~~Uses #1729 as a base.~~

Closes #1720.