### PR TITLE
Fix docs side-nav background.

### DIFF
--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -1335,7 +1335,6 @@ span.caption-text {
         left: 0;
         width: 240px;
         padding-top: 7.7em;
-        background: none;
         font-size: 0.9em;
     }
 


### PR DESCRIPTION
This allows the side-nav background color to extend
to the bottom of the screen.

**Before:**
![side-nav-before](https://cloud.githubusercontent.com/assets/192456/14728866/c5ee8426-0806-11e6-9553-6b545a599559.png)

**After:**
![side-nav-after](https://cloud.githubusercontent.com/assets/192456/14728870/ca74d2b6-0806-11e6-893f-c82c96608b94.png)
