### PR TITLE
Removing py26 and pandas from default tox environments.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py34,py35,py27-pandas,cover,docs,lint
+    py27,py34,py35,cover,docs,lint
 
 [testenv]
 commands =


### PR DESCRIPTION
FYI @rimey I'm not sure if you intended to make `py27-pandas` one of the default environments but the install takes quite a bit of time / it isn't strictly necessary.