### PR TITLE
Upgrading version to 0.13.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ GRPC_EXTRAS = ['grpcio >= 0.13.1']
 
 setup(
     name='gcloud',
-    version='0.12.1',
+    version='0.13.0',
     description='API Client library for Google Cloud',
     author='Google Cloud Platform',
     author_email='jjg+gcloud-python@google.com',


### PR DESCRIPTION
```
$ git log -1 --pretty=%H
f227fdc96287d92ba7232f005a447b6af06a7525
$ git log 0.12.1..HEAD \
> | grep 'Merge pull request ' \
> | awk -F ' ' '{print $4}' \
> | sort
```

yields

#1700
#1733
#1734
#1736
#1737
#1738

#1691 didn't show up (because I merged it with GitHub's squash commit feature). If we use this feature I'll need to refine my release process to capture all PRs since the last release (maybe something already exists from GitHub that I don't know about).