### PR TITLE
Define __all__ in gcloud/monitoring/__init__.py.

### DIFF
--- a/gcloud/monitoring/__init__.py
+++ b/gcloud/monitoring/__init__.py
@@ -30,5 +30,16 @@ from gcloud.monitoring.resource import ResourceDescriptor
 from gcloud.monitoring.timeseries import Point
 from gcloud.monitoring.timeseries import TimeSeries
 
+__all__ = (
+    'Client',
+    'Connection',
+    'LabelDescriptor', 'LabelValueType',
+    'Metric', 'MetricDescriptor', 'MetricKind', 'ValueType',
+    'Aligner', 'Query', 'Reducer',
+    'Resource', 'ResourceDescriptor',
+    'Point', 'TimeSeries',
+    'SCOPE',
+)
+
 
 SCOPE = Connection.SCOPE


### PR DESCRIPTION
This is so that "from gcloud.monitoring import *" doesn't import
the package's module names.