### PR TITLE
 Implement a GAX version of '_PublisherAPI'.

### DIFF
--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -27,6 +27,7 @@ else:
 
     from gcloud.exceptions import Conflict
     from gcloud.exceptions import NotFound
+    from gcloud._helpers import _to_bytes
 
     class _PublisherAPI(object):
         """Helper mapping publisher-related APIs.
@@ -172,7 +173,6 @@ else:
 
 
 def _message_pb_from_dict(message):
-    data = message['data']
-    if not isinstance(data, str):
-        data = data.encode('ascii')
-    return PubsubMessage(data=data, attributes=message['attributes'])
+    """Helper for :meth:`_PublisherAPI.topic_publish`."""
+    return PubsubMessage(data=_to_bytes(message['data']),
+                         attributes=message['attributes'])

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -1,0 +1,178 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GAX wrapper for Pubsub API requests."""
+
+try:
+    # pylint: disable=no-name-in-module
+    from google.gax import CallOptions
+    from google.gax.errors import GaxError
+    from google.pubsub.v1.pubsub_pb2 import PubsubMessage
+    # pylint: enable=no-name-in-module
+except ImportError:  # pragma: NO COVER
+    _HAVE_GAX = False
+else:
+    _HAVE_GAX = True
+
+    from gcloud.exceptions import Conflict
+    from gcloud.exceptions import NotFound
+
+    class _PublisherAPI(object):
+        """Helper mapping publisher-related APIs.
+
+        :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
+        :param gax_api: API object used to make GAX requests.
+        """
+        def __init__(self, gax_api):
+            self._gax_api = gax_api
+
+        def list_topics(self, project):
+            """List topics for the project associated with this API.
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+
+            :type project: string
+            :param project: project ID
+
+            :rtype: tuple, (list, str)
+            :returns: list of ``Topic`` resource dicts, plus a
+                    "next page token" string:  if not None, indicates that
+                    more topics can be retrieved with another call (pass that
+                    value as ``page_token``).
+            """
+            options = CallOptions(is_page_streaming=False)
+            path = 'projects/%s' % (project,)
+            response = self._gax_api.list_topics(path, options)
+            topics = [{'name': topic_pb.name} for topic_pb in response.topics]
+            return topics, response.next_page_token
+
+        def topic_create(self, topic_path):
+            """API call:  create a topic
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+
+            :type topic_path: string
+            :param topic_path: fully-qualfied path of the new topic, in format
+                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+            :rtype: dict
+            :returns: ``Topic`` resource returned from the API.
+            :raises: :exc:`gcloud.exceptions.Conflict` if the topic already
+                     exists
+            """
+            try:
+                topic_pb = self._gax_api.create_topic(topic_path)
+            except GaxError:
+                raise Conflict(topic_path)
+            return {'name': topic_pb.name}
+
+        def topic_get(self, topic_path):
+            """API call:  retrieve a topic
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+
+            :type topic_path: string
+            :param topic_path: fully-qualfied path of the topic, in format
+                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+            :rtype: dict
+            :returns: ``Topic`` resource returned from the API.
+            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                     exist
+            """
+            try:
+                topic_pb = self._gax_api.get_topic(topic_path)
+            except GaxError:
+                raise NotFound(topic_path)
+            return {'name': topic_pb.name}
+
+        def topic_delete(self, topic_path):
+            """API call:  delete a topic
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+
+            :type topic_path: string
+            :param topic_path: fully-qualfied path of the new topic, in format
+                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+            :rtype: dict
+            :returns: ``Topic`` resource returned from the API.
+            """
+            try:
+                self._gax_api.delete_topic(topic_path)
+            except GaxError:
+                pass
+
+        def topic_publish(self, topic_path, messages):
+            """API call:  publish one or more messages to a topic
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+
+            :type topic_path: string
+            :param topic_path: fully-qualfied path of the topic, in format
+                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+            :type messages: list of dict
+            :param messages: messages to be published.
+
+            :rtype: list of string
+            :returns: list of opaque IDs for published messages.
+            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                     exist
+            """
+            message_pbs = [_message_pb_from_dict(message)
+                           for message in messages]
+            try:
+                response = self._gax_api.publish(topic_path, message_pbs)
+            except GaxError:
+                raise NotFound(topic_path)
+            return response.message_ids
+
+        def topic_list_subscriptions(self, topic_path):
+            """API call:  list subscriptions bound to a topic
+
+            See:
+            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+
+            :type topic_path: string
+            :param topic_path: fully-qualfied path of the topic, in format
+                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+            :rtype: list of strings
+            :returns: fully-qualified names of subscriptions for the supplied
+                    topic.
+            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                     exist
+            """
+            options = CallOptions(is_page_streaming=False)
+            try:
+                response = self._gax_api.list_topic_subscriptions(
+                    topic_path, options)
+            except GaxError:
+                raise NotFound(topic_path)
+            subs = [{'topic': topic_path, 'name': subscription}
+                    for subscription in response.subscriptions]
+            return subs, response.next_page_token
+
+
+def _message_pb_from_dict(message):
+    data = message['data']
+    if not isinstance(data, str):
+        data = data.encode('ascii')
+    return PubsubMessage(data=data, attributes=message['attributes'])

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -77,7 +77,7 @@ class _PublisherAPI(object):
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.FAILED_PRECONDITION:
                 raise Conflict(topic_path)
-            raise  # pragma: NO COVER
+            raise
         return {'name': topic_pb.name}
 
     def topic_get(self, topic_path):
@@ -100,7 +100,7 @@ class _PublisherAPI(object):
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
-            raise  # pragma: NO COVER
+            raise
         return {'name': topic_pb.name}
 
     def topic_delete(self, topic_path):
@@ -121,7 +121,7 @@ class _PublisherAPI(object):
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
-            raise  # pragma: NO COVER
+            raise
 
     def topic_publish(self, topic_path, messages):
         """API call:  publish one or more messages to a topic
@@ -148,7 +148,7 @@ class _PublisherAPI(object):
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
-            raise  # pragma: NO COVER
+            raise
         return response.message_ids
 
     def topic_list_subscriptions(self, topic_path):
@@ -174,7 +174,7 @@ class _PublisherAPI(object):
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
-            raise  # pragma: NO COVER
+            raise
         subs = [{'topic': topic_path, 'name': subscription}
                 for subscription in response.subscriptions]
         return subs, response.next_page_token

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -65,7 +65,7 @@ else:
             https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
             :type topic_path: string
-            :param topic_path: fully-qualfied path of the new topic, in format
+            :param topic_path: fully-qualified path of the new topic, in format
                                ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
             :rtype: dict
@@ -86,7 +86,7 @@ else:
             https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
 
             :type topic_path: string
-            :param topic_path: fully-qualfied path of the topic, in format
+            :param topic_path: fully-qualified path of the topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
             :rtype: dict
@@ -107,7 +107,7 @@ else:
             https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
             :type topic_path: string
-            :param topic_path: fully-qualfied path of the new topic, in format
+            :param topic_path: fully-qualified path of the new topic, in format
                                ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
             :rtype: dict
@@ -125,7 +125,7 @@ else:
             https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
 
             :type topic_path: string
-            :param topic_path: fully-qualfied path of the topic, in format
+            :param topic_path: fully-qualified path of the topic, in format
                                ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
             :type messages: list of dict
@@ -151,7 +151,7 @@ else:
             https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
 
             :type topic_path: string
-            :param topic_path: fully-qualfied path of the topic, in format
+            :param topic_path: fully-qualified path of the topic, in format
                                ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
             :rtype: list of strings

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -13,175 +13,171 @@
 # limitations under the License.
 
 """GAX wrapper for Pubsub API requests."""
-try:
-    # pylint: disable=no-name-in-module
-    from google.gax import CallOptions
-    from google.gax.errors import GaxError
-    from google.gax.grpc import exc_to_code
-    # pylint: enable=no-name-in-module
-except ImportError:  # pragma: NO COVER
-    _HAVE_GAX = False
-else:
-    _HAVE_GAX = True
 
-    from google.pubsub.v1.pubsub_pb2 import PubsubMessage
-    from grpc.beta.interfaces import StatusCode
+# pylint: disable=import-error
+from google.gax import CallOptions
+from google.gax.errors import GaxError
+from google.gax.grpc import exc_to_code
+from google.pubsub.v1.pubsub_pb2 import PubsubMessage
+from grpc.beta.interfaces import StatusCode
+# pylint: enable=import-error
 
-    from gcloud.exceptions import Conflict
-    from gcloud.exceptions import NotFound
-    from gcloud._helpers import _to_bytes
+from gcloud.exceptions import Conflict
+from gcloud.exceptions import NotFound
+from gcloud._helpers import _to_bytes
 
-    class _PublisherAPI(object):
-        """Helper mapping publisher-related APIs.
 
-        :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
-        :param gax_api: API object used to make GAX requests.
+class _PublisherAPI(object):
+    """Helper mapping publisher-related APIs.
+
+    :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
+    :param gax_api: API object used to make GAX requests.
+    """
+    def __init__(self, gax_api):
+        self._gax_api = gax_api
+
+    def list_topics(self, project):
+        """List topics for the project associated with this API.
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+
+        :type project: string
+        :param project: project ID
+
+        :rtype: tuple, (list, str)
+        :returns: list of ``Topic`` resource dicts, plus a
+                "next page token" string:  if not None, indicates that
+                more topics can be retrieved with another call (pass that
+                value as ``page_token``).
         """
-        def __init__(self, gax_api):
-            self._gax_api = gax_api
+        options = CallOptions(is_page_streaming=False)
+        path = 'projects/%s' % (project,)
+        response = self._gax_api.list_topics(path, options)
+        topics = [{'name': topic_pb.name} for topic_pb in response.topics]
+        return topics, response.next_page_token
 
-        def list_topics(self, project):
-            """List topics for the project associated with this API.
+    def topic_create(self, topic_path):
+        """API call:  create a topic
 
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
-            :type project: string
-            :param project: project ID
-
-            :rtype: tuple, (list, str)
-            :returns: list of ``Topic`` resource dicts, plus a
-                    "next page token" string:  if not None, indicates that
-                    more topics can be retrieved with another call (pass that
-                    value as ``page_token``).
-            """
-            options = CallOptions(is_page_streaming=False)
-            path = 'projects/%s' % (project,)
-            response = self._gax_api.list_topics(path, options)
-            topics = [{'name': topic_pb.name} for topic_pb in response.topics]
-            return topics, response.next_page_token
-
-        def topic_create(self, topic_path):
-            """API call:  create a topic
-
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
-
-            :type topic_path: string
-            :param topic_path: fully-qualified path of the new topic, in format
-                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
-
-            :rtype: dict
-            :returns: ``Topic`` resource returned from the API.
-            :raises: :exc:`gcloud.exceptions.Conflict` if the topic already
-                     exists
-            """
-            try:
-                topic_pb = self._gax_api.create_topic(topic_path)
-            except GaxError as exc:
-                if exc_to_code(exc.cause) == StatusCode.FAILED_PRECONDITION:
-                    raise Conflict(topic_path)
-                raise  # pragma: NO COVER
-            return {'name': topic_pb.name}
-
-        def topic_get(self, topic_path):
-            """API call:  retrieve a topic
-
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
-
-            :type topic_path: string
-            :param topic_path: fully-qualified path of the topic, in format
+        :type topic_path: string
+        :param topic_path: fully-qualified path of the new topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-            :rtype: dict
-            :returns: ``Topic`` resource returned from the API.
-            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
-                     exist
-            """
-            try:
-                topic_pb = self._gax_api.get_topic(topic_path)
-            except GaxError as exc:
-                if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
-                    raise NotFound(topic_path)
-                raise  # pragma: NO COVER
-            return {'name': topic_pb.name}
+        :rtype: dict
+        :returns: ``Topic`` resource returned from the API.
+        :raises: :exc:`gcloud.exceptions.Conflict` if the topic already
+                    exists
+        """
+        try:
+            topic_pb = self._gax_api.create_topic(topic_path)
+        except GaxError as exc:
+            if exc_to_code(exc.cause) == StatusCode.FAILED_PRECONDITION:
+                raise Conflict(topic_path)
+            raise  # pragma: NO COVER
+        return {'name': topic_pb.name}
 
-        def topic_delete(self, topic_path):
-            """API call:  delete a topic
+    def topic_get(self, topic_path):
+        """API call:  retrieve a topic
 
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
 
-            :type topic_path: string
-            :param topic_path: fully-qualified path of the new topic, in format
-                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        :type topic_path: string
+        :param topic_path: fully-qualified path of the topic, in format
+                        ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-            :rtype: dict
-            :returns: ``Topic`` resource returned from the API.
-            """
-            try:
-                self._gax_api.delete_topic(topic_path)
-            except GaxError as exc:
-                if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
-                    raise NotFound(topic_path)
-                raise  # pragma: NO COVER
+        :rtype: dict
+        :returns: ``Topic`` resource returned from the API.
+        :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                    exist
+        """
+        try:
+            topic_pb = self._gax_api.get_topic(topic_path)
+        except GaxError as exc:
+            if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
+                raise NotFound(topic_path)
+            raise  # pragma: NO COVER
+        return {'name': topic_pb.name}
 
-        def topic_publish(self, topic_path, messages):
-            """API call:  publish one or more messages to a topic
+    def topic_delete(self, topic_path):
+        """API call:  delete a topic
 
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
-            :type topic_path: string
-            :param topic_path: fully-qualified path of the topic, in format
-                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        :type topic_path: string
+        :param topic_path: fully-qualified path of the new topic, in format
+                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-            :type messages: list of dict
-            :param messages: messages to be published.
+        :rtype: dict
+        :returns: ``Topic`` resource returned from the API.
+        """
+        try:
+            self._gax_api.delete_topic(topic_path)
+        except GaxError as exc:
+            if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
+                raise NotFound(topic_path)
+            raise  # pragma: NO COVER
 
-            :rtype: list of string
-            :returns: list of opaque IDs for published messages.
-            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
-                     exist
-            """
-            message_pbs = [_message_pb_from_dict(message)
-                           for message in messages]
-            try:
-                response = self._gax_api.publish(topic_path, message_pbs)
-            except GaxError as exc:
-                if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
-                    raise NotFound(topic_path)
-                raise  # pragma: NO COVER
-            return response.message_ids
+    def topic_publish(self, topic_path, messages):
+        """API call:  publish one or more messages to a topic
 
-        def topic_list_subscriptions(self, topic_path):
-            """API call:  list subscriptions bound to a topic
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
 
-            See:
-            https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+        :type topic_path: string
+        :param topic_path: fully-qualified path of the topic, in format
+                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-            :type topic_path: string
-            :param topic_path: fully-qualified path of the topic, in format
-                               ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        :type messages: list of dict
+        :param messages: messages to be published.
 
-            :rtype: list of strings
-            :returns: fully-qualified names of subscriptions for the supplied
-                    topic.
-            :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
-                     exist
-            """
-            options = CallOptions(is_page_streaming=False)
-            try:
-                response = self._gax_api.list_topic_subscriptions(
-                    topic_path, options)
-            except GaxError as exc:
-                if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
-                    raise NotFound(topic_path)
-                raise  # pragma: NO COVER
-            subs = [{'topic': topic_path, 'name': subscription}
-                    for subscription in response.subscriptions]
-            return subs, response.next_page_token
+        :rtype: list of string
+        :returns: list of opaque IDs for published messages.
+        :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                    exist
+        """
+        message_pbs = [_message_pb_from_dict(message)
+                       for message in messages]
+        try:
+            response = self._gax_api.publish(topic_path, message_pbs)
+        except GaxError as exc:
+            if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
+                raise NotFound(topic_path)
+            raise  # pragma: NO COVER
+        return response.message_ids
+
+    def topic_list_subscriptions(self, topic_path):
+        """API call:  list subscriptions bound to a topic
+
+        See:
+        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+
+        :type topic_path: string
+        :param topic_path: fully-qualified path of the topic, in format
+                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+
+        :rtype: list of strings
+        :returns: fully-qualified names of subscriptions for the supplied
+                topic.
+        :raises: :exc:`gcloud.exceptions.NotFound` if the topic does not
+                    exist
+        """
+        options = CallOptions(is_page_streaming=False)
+        try:
+            response = self._gax_api.list_topic_subscriptions(
+                topic_path, options)
+        except GaxError as exc:
+            if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
+                raise NotFound(topic_path)
+            raise  # pragma: NO COVER
+        subs = [{'topic': topic_path, 'name': subscription}
+                for subscription in response.subscriptions]
+        return subs, response.next_page_token
 
 
 def _message_pb_from_dict(message):

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -117,7 +117,7 @@ else:
             try:
                 self._gax_api.delete_topic(topic_path)
             except GaxError:
-                pass
+                raise NotFound(topic_path)
 
         def topic_publish(self, topic_path, messages):
             """API call:  publish one or more messages to a topic

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -101,7 +101,7 @@ class _PublisherAPI(object):
         self._connection = connection
 
     def list_topics(self, project, page_size=None, page_token=None):
-        """List topics for the project associated with this API.
+        """API call:  list topics for a given project
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
@@ -138,7 +138,7 @@ class _PublisherAPI(object):
         return resp.get('topics', ()), resp.get('nextPageToken')
 
     def topic_create(self, topic_path):
-        """API call:  create a topic via a PUT request
+        """API call:  create a topic
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
@@ -154,7 +154,7 @@ class _PublisherAPI(object):
         return conn.api_request(method='PUT', path='/%s' % (topic_path,))
 
     def topic_get(self, topic_path):
-        """API call:  retrieve a topic via a GET request
+        """API call:  retrieve a topic
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
@@ -170,7 +170,7 @@ class _PublisherAPI(object):
         return conn.api_request(method='GET', path='/%s' % (topic_path,))
 
     def topic_delete(self, topic_path):
-        """API call:  delete a topic via a DELETE request
+        """API call:  delete a topic
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
@@ -183,7 +183,7 @@ class _PublisherAPI(object):
         conn.api_request(method='DELETE', path='/%s' % (topic_path,))
 
     def topic_publish(self, topic_path, messages):
-        """API call:  publish a message to a topic via a POST request
+        """API call:  publish one or more messages to a topic
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
@@ -206,7 +206,7 @@ class _PublisherAPI(object):
 
     def topic_list_subscriptions(self, topic_path, page_size=None,
                                  page_token=None):
-        """API call:  list subscriptions bound to a topic via a GET request
+        """API call:  list subscriptions bound to a topic
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
@@ -253,7 +253,7 @@ class _SubscriberAPI(object):
         self._connection = connection
 
     def list_subscriptions(self, project, page_size=None, page_token=None):
-        """List subscriptions for the project associated with this API.
+        """API call:  list subscriptions for a given project
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/list
@@ -291,7 +291,7 @@ class _SubscriberAPI(object):
 
     def subscription_create(self, subscription_path, topic_path,
                             ack_deadline=None, push_endpoint=None):
-        """API call:  create a subscription via a PUT request
+        """API call:  create a subscription
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
@@ -331,7 +331,7 @@ class _SubscriberAPI(object):
         return conn.api_request(method='PUT', path=path, data=resource)
 
     def subscription_get(self, subscription_path):
-        """API call:  retrieve a subscription via a GET request
+        """API call:  retrieve a subscription
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
@@ -349,7 +349,7 @@ class _SubscriberAPI(object):
         return conn.api_request(method='GET', path=path)
 
     def subscription_delete(self, subscription_path):
-        """API call:  delete a subscription via a DELETE request
+        """API call:  delete a subscription
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
@@ -365,7 +365,7 @@ class _SubscriberAPI(object):
 
     def subscription_modify_push_config(self, subscription_path,
                                         push_endpoint):
-        """API call:  update push config of a subscription via a POST request
+        """API call:  update push config of a subscription
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
@@ -387,7 +387,7 @@ class _SubscriberAPI(object):
 
     def subscription_pull(self, subscription_path, return_immediately=False,
                           max_messages=1):
-        """API call:  update push config of a subscription via a POST request
+        """API call:  retrieve messages for a subscription
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
@@ -419,7 +419,7 @@ class _SubscriberAPI(object):
         return response.get('receivedMessages', ())
 
     def subscription_acknowledge(self, subscription_path, ack_ids):
-        """API call:  acknowledge retrieved messages for the subscription.
+        """API call:  acknowledge retrieved messages
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
@@ -441,7 +441,7 @@ class _SubscriberAPI(object):
 
     def subscription_modify_ack_deadline(self, subscription_path, ack_ids,
                                          ack_deadline):
-        """API call:  acknowledge retrieved messages for the subscription.
+        """API call:  update ack deadline for retrieved messages
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
@@ -478,7 +478,7 @@ class _IAMPolicyAPI(object):
         self._connection = connection
 
     def get_iam_policy(self, target_path):
-        """Fetch the IAM policy for the target.
+        """API call:  fetch the IAM policy for the target
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/getIamPolicy
@@ -495,7 +495,7 @@ class _IAMPolicyAPI(object):
         return conn.api_request(method='GET', path=path)
 
     def set_iam_policy(self, target_path, policy):
-        """Update the IAM policy for the target.
+        """API call:  update the IAM policy for the target
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/setIamPolicy
@@ -516,7 +516,7 @@ class _IAMPolicyAPI(object):
         return conn.api_request(method='POST', path=path, data=wrapped)
 
     def test_iam_permissions(self, target_path, permissions):
-        """Update the IAM policy for the target.
+        """API call:  test permissions
 
         See:
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/testIamPermissions

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -144,7 +144,7 @@ class _PublisherAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the new topic, in format
+        :param topic_path: the fully-qualified path of the new topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :rtype: dict
@@ -160,7 +160,7 @@ class _PublisherAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the topic, in format
+        :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :rtype: dict
@@ -176,7 +176,7 @@ class _PublisherAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the topic, in format
+        :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
         conn = self._connection
@@ -189,7 +189,7 @@ class _PublisherAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the topic, in format
+        :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :type messages: list of dict
@@ -212,7 +212,7 @@ class _PublisherAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the topic, in format
+        :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :type page_size: int
@@ -297,12 +297,12 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the new
+        :param subscription_path: the fully-qualified path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
 
         :type topic_path: string
-        :param topic_path: the fully-qualfied path of the topic being
+        :param topic_path: the fully-qualified path of the topic being
                            subscribed, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -337,7 +337,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the subscription,
+        :param subscription_path: the fully-qualified path of the subscription,
                                   in format
                                   ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
@@ -355,7 +355,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the subscription,
+        :param subscription_path: the fully-qualified path of the subscription,
                                   in format
                                   ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
         """
@@ -371,7 +371,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the new
+        :param subscription_path: the fully-qualified path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
 
@@ -393,7 +393,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the new
+        :param subscription_path: the fully-qualified path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
 
@@ -425,7 +425,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the new
+        :param subscription_path: the fully-qualified path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
 
@@ -447,7 +447,7 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualfied path of the new
+        :param subscription_path: the fully-qualified path of the new
                                   subscription, in format
                                   ``projects/<PROJECT>/subscriptions/<TOPIC_NAME>``.
 

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -122,10 +122,12 @@ class Test_PublisherAPI(unittest2.TestCase):
         self.assertEqual(options, None)
 
     def test_topic_delete_miss(self):
+        from gcloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI(_delete_topic_ok=False)
         api = self._makeOne(gax_api)
 
-        api.topic_delete(self.TOPIC_PATH)
+        with self.assertRaises(NotFound):
+            api.topic_delete(self.TOPIC_PATH)
 
         topic_path, options = gax_api._delete_topic_called_with
         self.assertEqual(topic_path, self.TOPIC_PATH)

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -1,0 +1,282 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+
+try:
+    # pylint: disable=no-name-in-module
+    from gcloud.pubsub._gax import _HAVE_GAX
+    # pylint: enable=no-name-in-module
+except ImportError:  # pragma: NO COVER
+    _HAVE_GAX = False
+
+
+@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_PublisherAPI(unittest2.TestCase):
+    PROJECT = 'PROJECT'
+    PROJECT_PATH = 'projects/%s' % (PROJECT,)
+    LIST_TOPICS_PATH = '%s/topics' % (PROJECT_PATH,)
+    TOPIC_NAME = 'topic_name'
+    TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
+    LIST_TOPIC_SUBSCRIPTIONS_PATH = '%s/subscriptions' % (TOPIC_PATH,)
+    SUB_NAME = 'sub_name'
+    SUB_PATH = '%s/subscriptions/%s' % (TOPIC_PATH, SUB_NAME)
+
+    def _getTargetClass(self):
+        from gcloud.pubsub._gax import _PublisherAPI
+        return _PublisherAPI
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_ctor(self):
+        gax_api = _GAXPublisherAPI()
+        api = self._makeOne(gax_api)
+        self.assertTrue(api._gax_api is gax_api)
+
+    def test_list_topics_no_paging(self):
+        response = _ListTopicsResponsePB([_TopicPB(self.TOPIC_PATH)])
+        gax_api = _GAXPublisherAPI(_list_topics_response=response)
+        api = self._makeOne(gax_api)
+
+        topics, next_token = api.list_topics(self.PROJECT)
+
+        self.assertEqual(len(topics), 1)
+        topic = topics[0]
+        self.assertIsInstance(topic, dict)
+        self.assertEqual(topic['name'], self.TOPIC_PATH)
+        self.assertEqual(next_token, None)
+
+        name, options = gax_api._list_topics_called_with
+        self.assertEqual(name, self.PROJECT_PATH)
+        self.assertFalse(options.is_page_streaming)
+
+    def test_topic_create(self):
+        topic_pb = _TopicPB(self.TOPIC_PATH)
+        gax_api = _GAXPublisherAPI(_create_topic_response=topic_pb)
+        api = self._makeOne(gax_api)
+
+        resource = api.topic_create(self.TOPIC_PATH)
+
+        self.assertEqual(resource, {'name': self.TOPIC_PATH})
+        topic_path, options = gax_api._create_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_create_already_exists(self):
+        from gcloud.exceptions import Conflict
+        gax_api = _GAXPublisherAPI(_create_topic_conflict=True)
+        api = self._makeOne(gax_api)
+
+        with self.assertRaises(Conflict):
+            api.topic_create(self.TOPIC_PATH)
+
+        topic_path, options = gax_api._create_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_get_hit(self):
+        topic_pb = _TopicPB(self.TOPIC_PATH)
+        gax_api = _GAXPublisherAPI(_get_topic_response=topic_pb)
+        api = self._makeOne(gax_api)
+
+        resource = api.topic_get(self.TOPIC_PATH)
+
+        self.assertEqual(resource, {'name': self.TOPIC_PATH})
+        topic_path, options = gax_api._get_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_get_miss(self):
+        from gcloud.exceptions import NotFound
+        gax_api = _GAXPublisherAPI()
+        api = self._makeOne(gax_api)
+
+        with self.assertRaises(NotFound):
+            api.topic_get(self.TOPIC_PATH)
+
+        topic_path, options = gax_api._get_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_delete_hit(self):
+        gax_api = _GAXPublisherAPI(_delete_topic_ok=True)
+        api = self._makeOne(gax_api)
+
+        api.topic_delete(self.TOPIC_PATH)
+
+        topic_path, options = gax_api._delete_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_delete_miss(self):
+        gax_api = _GAXPublisherAPI(_delete_topic_ok=False)
+        api = self._makeOne(gax_api)
+
+        api.topic_delete(self.TOPIC_PATH)
+
+        topic_path, options = gax_api._delete_topic_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertEqual(options, None)
+
+    def test_topic_publish_hit(self):
+        import base64
+        PAYLOAD = b'This is the message text'
+        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        MSGID = 'DEADBEEF'
+        MESSAGE = {'data': B64, 'attributes': {}}
+        response = _PublishResponsePB([MSGID])
+        gax_api = _GAXPublisherAPI(_publish_response=response)
+        api = self._makeOne(gax_api)
+
+        resource = api.topic_publish(self.TOPIC_PATH, [MESSAGE])
+
+        self.assertEqual(resource, [MSGID])
+        topic_path, message_pbs, options = gax_api._publish_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        message_pb, = message_pbs
+        self.assertEqual(message_pb.data, B64)
+        self.assertEqual(message_pb.attributes, {})
+        self.assertEqual(options, None)
+
+    def test_topic_publish_miss_w_attrs_w_bytes_payload(self):
+        import base64
+        from gcloud.exceptions import NotFound
+        PAYLOAD = u'This is the message text'
+        B64 = base64.b64encode(PAYLOAD)
+        MESSAGE = {'data': B64, 'attributes': {'foo': 'bar'}}
+        gax_api = _GAXPublisherAPI()
+        api = self._makeOne(gax_api)
+
+        with self.assertRaises(NotFound):
+            api.topic_publish(self.TOPIC_PATH, [MESSAGE])
+
+        topic_path, message_pbs, options = gax_api._publish_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        message_pb, = message_pbs
+        self.assertEqual(message_pb.data, B64)
+        self.assertEqual(message_pb.attributes, {'foo': 'bar'})
+        self.assertEqual(options, None)
+
+    def test_topic_list_subscriptions_no_paging(self):
+        response = _ListTopicSubscriptionsResponsePB([self.SUB_PATH])
+        gax_api = _GAXPublisherAPI(_list_topic_subscriptions_response=response)
+        api = self._makeOne(gax_api)
+
+        subscriptions, next_token = api.topic_list_subscriptions(
+            self.TOPIC_PATH)
+
+        self.assertEqual(len(subscriptions), 1)
+        subscription = subscriptions[0]
+        self.assertIsInstance(subscription, dict)
+        self.assertEqual(subscription['name'], self.SUB_PATH)
+        self.assertEqual(subscription['topic'], self.TOPIC_PATH)
+        self.assertEqual(next_token, None)
+
+        topic_path, options = gax_api._list_topic_subscriptions_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertFalse(options.is_page_streaming)
+
+    def test_topic_list_subscriptions_miss(self):
+        from gcloud.exceptions import NotFound
+        gax_api = _GAXPublisherAPI()
+        api = self._makeOne(gax_api)
+
+        with self.assertRaises(NotFound):
+            api.topic_list_subscriptions(self.TOPIC_PATH)
+
+        topic_path, options = gax_api._list_topic_subscriptions_called_with
+        self.assertEqual(topic_path, self.TOPIC_PATH)
+        self.assertFalse(options.is_page_streaming)
+
+
+class _GAXPublisherAPI(object):
+
+    _create_topic_conflict = False
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+    def list_topics(self, name, options):
+        self._list_topics_called_with = name, options
+        return self._list_topics_response
+
+    def create_topic(self, name, options=None):
+        # pylint: disable=no-name-in-module
+        from google.gax.errors import GaxError
+        self._create_topic_called_with = name, options
+        if self._create_topic_conflict:
+            raise GaxError('conflict')
+        return self._create_topic_response
+
+    def get_topic(self, name, options=None):
+        # pylint: disable=no-name-in-module
+        from google.gax.errors import GaxError
+        self._get_topic_called_with = name, options
+        try:
+            return self._get_topic_response
+        except AttributeError:
+            raise GaxError('miss')
+
+    def delete_topic(self, name, options=None):
+        # pylint: disable=no-name-in-module
+        from google.gax.errors import GaxError
+        self._delete_topic_called_with = name, options
+        if not self._delete_topic_ok:
+            raise GaxError('miss')
+
+    def publish(self, topic, messages, options=None):
+        # pylint: disable=no-name-in-module
+        from google.gax.errors import GaxError
+        self._publish_called_with = topic, messages, options
+        try:
+            return self._publish_response
+        except AttributeError:
+            raise GaxError('miss')
+
+    def list_topic_subscriptions(self, topic, options=None):
+        # pylint: disable=no-name-in-module
+        from google.gax.errors import GaxError
+        self._list_topic_subscriptions_called_with = topic, options
+        try:
+            return self._list_topic_subscriptions_response
+        except AttributeError:
+            raise GaxError('miss')
+
+
+class _TopicPB(object):
+
+    def __init__(self, name):
+        self.name = name
+
+
+class _PublishResponsePB(object):
+
+    def __init__(self, message_ids):
+        self.message_ids = message_ids
+
+
+class _ListTopicsResponsePB(object):
+
+    def __init__(self, topic_pbs, next_page_token=None):
+        self.topics = topic_pbs
+        self.next_page_token = next_page_token
+
+
+class _ListTopicSubscriptionsResponsePB(object):
+
+    def __init__(self, subscriptions, next_page_token=None):
+        self.subscriptions = subscriptions
+        self.next_page_token = next_page_token

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -16,11 +16,13 @@ import unittest2
 
 
 try:
-    # pylint: disable=no-name-in-module
-    from gcloud.pubsub._gax import _HAVE_GAX
-    # pylint: enable=no-name-in-module
+    # pylint: disable=unused-import
+    import gcloud.pubsub._gax
+    # pylint: enable=unused-import
 except ImportError:  # pragma: NO COVER
     _HAVE_GAX = False
+else:
+    _HAVE_GAX = True
 
 
 @unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
@@ -235,7 +237,6 @@ class _GAXPublisherAPI(object):
         return self._make_grpc_error(StatusCode.FAILED_PRECONDITION)
 
     def create_topic(self, name, options=None):
-        # pylint: disable=no-name-in-module
         from google.gax.errors import GaxError
         self._create_topic_called_with = name, options
         if self._create_topic_conflict:
@@ -243,7 +244,6 @@ class _GAXPublisherAPI(object):
         return self._create_topic_response
 
     def get_topic(self, name, options=None):
-        # pylint: disable=no-name-in-module
         from google.gax.errors import GaxError
         self._get_topic_called_with = name, options
         try:
@@ -252,14 +252,12 @@ class _GAXPublisherAPI(object):
             raise GaxError('miss', self._make_grpc_not_found())
 
     def delete_topic(self, name, options=None):
-        # pylint: disable=no-name-in-module
         from google.gax.errors import GaxError
         self._delete_topic_called_with = name, options
         if not self._delete_topic_ok:
             raise GaxError('miss', self._make_grpc_not_found())
 
     def publish(self, topic, messages, options=None):
-        # pylint: disable=no-name-in-module
         from google.gax.errors import GaxError
         self._publish_called_with = topic, messages, options
         try:
@@ -268,7 +266,6 @@ class _GAXPublisherAPI(object):
             raise GaxError('miss', self._make_grpc_not_found())
 
     def list_topic_subscriptions(self, topic, options=None):
-        # pylint: disable=no-name-in-module
         from google.gax.errors import GaxError
         self._list_topic_subscriptions_called_with = topic, options
         try:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 ]
 
 GRPC_EXTRAS = [
-    'grpcio >= 0.13.1',
+    'grpcio == 0.13.1',
     'gax-google-pubsub-v1',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,8 @@ commands =
 deps =
     {[testenv]deps}
     coverage
+setenv =
+    PYTHONPATH =
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,8 @@ commands =
 deps =
     {[testenv:cover]deps}
     coveralls
+setenv =
+    PYTHONPATH =
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}
 commands =
+    pip install gcloud[grpc]
     {[testenv]covercmd}
     coveralls
 deps =


### PR DESCRIPTION
Note:  paging methods (`list_topics` and `list_topic_subscriptions`) are only partially implemented, because the GAX API does not permit passing in a page token (it cam be coerced into *returning* only a single page of results, and its token, though).  See:

- googleapis/gax-python#86
- googleapis/gax-python#94