### PR TITLE
Pubsub snippet fixups

### DIFF
--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -311,11 +311,6 @@ def subscription_pull(client, to_delete):
     subscription.create()
     to_delete.append(subscription)
 
-    # [START subscription_pull_none_pending]
-    pulled = subscription.pull(max_messages=1)
-    # [END subscription_pull_none_pending]
-    assert len(pulled) == 0
-
     # [START subscription_pull_return_immediately]
     pulled = subscription.pull(return_immediately=True)
     # [END subscription_pull_return_immediately]

--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -314,16 +314,18 @@ def subscription_pull(client, to_delete):
     # [START subscription_pull_return_immediately]
     pulled = subscription.pull(return_immediately=True)
     # [END subscription_pull_return_immediately]
-    assert len(pulled) == 0
+    assert len(pulled) == 0, "unexpeccted message"
 
     topic.publish(PAYLOAD1)
     topic.publish(PAYLOAD2, extra=EXTRA)
+
+    time.sleep(1)  # eventually-consistent
 
     # [START subscription_pull]
     pulled = subscription.pull(max_messages=2)
     # [END subscription_pull]
 
-    assert len(pulled) == 2
+    assert len(pulled) == 2, "eventual consistency"
 
     # [START subscription_modify_ack_deadline]
     for ack_id, _ in pulled:

--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -314,7 +314,7 @@ def subscription_pull(client, to_delete):
     # [START subscription_pull_return_immediately]
     pulled = subscription.pull(return_immediately=True)
     # [END subscription_pull_return_immediately]
-    assert len(pulled) == 0, "unexpeccted message"
+    assert len(pulled) == 0, "unexpected message"
 
     topic.publish(PAYLOAD1)
     topic.publish(PAYLOAD2, extra=EXTRA)

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -416,7 +416,7 @@ class _SubscriberAPI(object):
             'maxMessages': max_messages,
         }
         response = conn.api_request(method='POST', path=path, data=data)
-        return response['receivedMessages']
+        return response.get('receivedMessages', ())
 
     def subscription_acknowledge(self, subscription_path, ack_ids):
         """API call:  acknowledge retrieved messages for the subscription.


### PR DESCRIPTION
In response to #1756.

Tweaking pubsub snippets to ensure that running them actually passes:

- Dropping a long-hanging example, never pulled into the Sphinx docs.
- Adding a `time.sleep(1)` between the last `topic.publish` call and the `subscription.pull`.

Also, fixes a bug exposed by running the snippets:  the API object's `subscription_pull` method was not tolerant of an empty response.