### PR TITLE
Docstring parse errors and switch from 'string' to 'str'

### DIFF
--- a/gcloud/bigquery/client.py
+++ b/gcloud/bigquery/client.py
@@ -28,7 +28,7 @@ from gcloud.bigquery.query import QueryResults
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. Will be
                     passed when creating a dataset / job.  If not passed,
                     falls back to the default inferred from the environment.
@@ -62,7 +62,7 @@ class Client(JSONClient):
         :param max_results: maximum number of datasets to return, If not
                             passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of datasets. If
                            not passed, the API will return the first page of
                            datasets.
@@ -94,7 +94,7 @@ class Client(JSONClient):
     def dataset(self, dataset_name):
         """Construct a dataset bound to this client.
 
-        :type dataset_name: string
+        :type dataset_name: str
         :param dataset_name: Name of the dataset.
 
         :rtype: :class:`gcloud.bigquery.dataset.Dataset`
@@ -108,7 +108,7 @@ class Client(JSONClient):
         :type resource: dict
         :param resource: one job resource from API response
 
-        :rtype; One of:
+        :rtype: One of:
                 :class:`gcloud.bigquery.job.LoadTableFromStorageJob`,
                 :class:`gcloud.bigquery.job.CopyJob`,
                 :class:`gcloud.bigquery.job.ExtractTableToStorageJob`,
@@ -138,7 +138,7 @@ class Client(JSONClient):
         :param max_results: maximum number of jobs to return, If not
                             passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of jobs. If
                            not passed, the API will return the first page of
                            jobs.
@@ -147,7 +147,7 @@ class Client(JSONClient):
         :param all_users: if true, include jobs owned by all users in the
                           project.
 
-        :type state_filter: string
+        :type state_filter: str
         :param state_filter: if passed, include only jobs matching the given
                              state.  One of
 
@@ -187,7 +187,7 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load
 
-        :type job_name: string
+        :type job_name: str
         :param job_name: Name of the job.
 
         :type destination: :class:`gcloud.bigquery.table.Table`
@@ -209,7 +209,7 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy
 
-        :type job_name: string
+        :type job_name: str
         :param job_name: Name of the job.
 
         :type destination: :class:`gcloud.bigquery.table.Table`
@@ -229,7 +229,7 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.extract
 
-        :type job_name: string
+        :type job_name: str
         :param job_name: Name of the job.
 
         :type source: :class:`gcloud.bigquery.table.Table`
@@ -252,10 +252,10 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query
 
-        :type job_name: string
+        :type job_name: str
         :param job_name: Name of the job.
 
-        :type query: string
+        :type query: str
         :param query: SQL query to be executed
 
         :rtype: :class:`gcloud.bigquery.job.QueryJob`
@@ -266,7 +266,7 @@ class Client(JSONClient):
     def run_sync_query(self, query):
         """Run a SQL query synchronously.
 
-        :type query: string
+        :type query: str
         :param query: SQL query to be executed
 
         :rtype: :class:`gcloud.bigquery.query.QueryResults`

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -37,18 +37,18 @@ _MARKER = object()
 class SchemaField(object):
     """Describe a single field within a table schema.
 
-    :type name: string
+    :type name: str
     :param name: the name of the field
 
-    :type field_type: string
+    :type field_type: str
     :param field_type: the type of the field (one of 'STRING', 'INTEGER',
                        'FLOAT', 'BOOLEAN', 'TIMESTAMP' or 'RECORD')
 
-    :type mode: string
+    :type mode: str
     :param mode: the type of the field (one of 'NULLABLE', 'REQUIRED',
                  or 'REPEATED')
 
-    :type description: string
+    :type description: str
     :param description: optional description for the field
 
     :type fields: list of :class:`SchemaField`, or None
@@ -69,7 +69,7 @@ class Table(object):
     See:
     https://cloud.google.com/bigquery/docs/reference/v2/tables
 
-    :type name: string
+    :type name: str
     :param name: the name of the table
 
     :type dataset: :class:`gcloud.bigquery.dataset.Dataset`
@@ -92,7 +92,7 @@ class Table(object):
     def project(self):
         """Project bound to the table.
 
-        :rtype: string
+        :rtype: str
         :returns: the project (derived from the dataset).
         """
         return self._dataset.project
@@ -101,7 +101,7 @@ class Table(object):
     def dataset_name(self):
         """Name of dataset containing the table.
 
-        :rtype: string
+        :rtype: str
         :returns: the ID (derived from the dataset).
         """
         return self._dataset.name
@@ -110,7 +110,7 @@ class Table(object):
     def path(self):
         """URL path for the table's APIs.
 
-        :rtype: string
+        :rtype: str
         :returns: the path based on project and dataste name.
         """
         return '%s/tables/%s' % (self._dataset.path, self.name)
@@ -154,7 +154,7 @@ class Table(object):
     def etag(self):
         """ETag for the table resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ETag (None until set from the server).
         """
         return self._properties.get('etag')
@@ -197,7 +197,7 @@ class Table(object):
     def self_link(self):
         """URL for the table resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('selfLink')
@@ -206,7 +206,7 @@ class Table(object):
     def table_id(self):
         """ID for the table resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ID (None until set from the server).
         """
         return self._properties.get('id')
@@ -217,7 +217,7 @@ class Table(object):
 
         Possible values are "TABLE" or "VIEW".
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('type')
@@ -226,7 +226,7 @@ class Table(object):
     def description(self):
         """Description of the table.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The description as set by the user, or None (the default).
         """
         return self._properties.get('description')
@@ -235,7 +235,7 @@ class Table(object):
     def description(self, value):
         """Update description of the table.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new description
 
         :raises: ValueError for invalid value types.
@@ -271,7 +271,7 @@ class Table(object):
     def friendly_name(self):
         """Title of the table.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The name as set by the user, or None (the default).
         """
         return self._properties.get('friendlyName')
@@ -280,7 +280,7 @@ class Table(object):
     def friendly_name(self, value):
         """Update title of the table.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new title
 
         :raises: ValueError for invalid value types.
@@ -293,7 +293,7 @@ class Table(object):
     def location(self):
         """Location in which the table is hosted.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The location as set by the user, or None (the default).
         """
         return self._properties.get('location')
@@ -302,7 +302,7 @@ class Table(object):
     def location(self, value):
         """Update location in which the table is hosted.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new location
 
         :raises: ValueError for invalid value types.
@@ -315,7 +315,7 @@ class Table(object):
     def view_query(self):
         """SQL query defining the table as a view.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The query as set by the user, or None (the default).
         """
         view = self._properties.get('view')
@@ -326,7 +326,7 @@ class Table(object):
     def view_query(self, value):
         """Update SQL query defining the table as a view.
 
-        :type value: string
+        :type value: str
         :param value: new query
 
         :raises: ValueError for invalid value types.
@@ -497,19 +497,19 @@ class Table(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
 
-        :type friendly_name: string or ``NoneType``
+        :type friendly_name: str or ``NoneType``
         :param friendly_name: point in time at which the table expires.
 
-        :type description: string or ``NoneType``
+        :type description: str or ``NoneType``
         :param description: point in time at which the table expires.
 
-        :type location: string or ``NoneType``
+        :type location: str or ``NoneType``
         :param location: point in time at which the table expires.
 
         :type expires: :class:`datetime.datetime` or ``NoneType``
         :param expires: point in time at which the table expires.
 
-        :type view_query: string
+        :type view_query: str
         :param view_query: SQL query defining the table as a view
 
         :type schema: list of :class:`SchemaField`
@@ -598,7 +598,7 @@ class Table(object):
         :type max_results: integer or ``NoneType``
         :param max_results: maximum number of rows to return.
 
-        :type page_token: string or ``NoneType``
+        :type page_token: str or ``NoneType``
         :param page_token: token representing a cursor into the table's rows.
 
         :type client: :class:`gcloud.bigquery.client.Client` or ``NoneType``
@@ -658,7 +658,7 @@ class Table(object):
         :type ignore_unknown_values: boolean or ``NoneType``
         :param ignore_unknown_values: ignore columns beyond schema?
 
-        :type template_suffix: string or ``NoneType``
+        :type template_suffix: str or ``NoneType``
         :param template_suffix: treat ``name`` as a template table and provide
                                 a suffix. BigQuery will create the table
                                 ``<name> + <template_suffix>`` based on the
@@ -743,7 +743,7 @@ class Table(object):
         :type file_obj: file
         :param file_obj: A file handle open for reading.
 
-        :type source_format: string
+        :type source_format: str
         :param source_format: one of 'CSV' or 'NEWLINE_DELIMITED_JSON'.
                               job configuration option; see
                               :meth:`gcloud.bigquery.job.LoadJob`
@@ -769,15 +769,15 @@ class Table(object):
         :param allow_quoted_newlines: job configuration option; see
                                       :meth:`gcloud.bigquery.job.LoadJob`
 
-        :type create_disposition: string
+        :type create_disposition: str
         :param create_disposition: job configuration option; see
                                    :meth:`gcloud.bigquery.job.LoadJob`
 
-        :type encoding: string
+        :type encoding: str
         :param encoding: job configuration option; see
                          :meth:`gcloud.bigquery.job.LoadJob`
 
-        :type field_delimiter: string
+        :type field_delimiter: str
         :param field_delimiter: job configuration option; see
                                 :meth:`gcloud.bigquery.job.LoadJob`
 
@@ -789,7 +789,7 @@ class Table(object):
         :param max_bad_records: job configuration option; see
                                 :meth:`gcloud.bigquery.job.LoadJob`
 
-        :type quote_character: string
+        :type quote_character: str
         :param quote_character: job configuration option; see
                                 :meth:`gcloud.bigquery.job.LoadJob`
 
@@ -797,7 +797,7 @@ class Table(object):
         :param skip_leading_rows: job configuration option; see
                                   :meth:`gcloud.bigquery.job.LoadJob`
 
-        :type write_disposition: string
+        :type write_disposition: str
         :param write_disposition: job configuration option; see
                                   :meth:`gcloud.bigquery.job.LoadJob`
 
@@ -969,7 +969,7 @@ def _build_schema_resource(fields):
     :param fields: schema to be dumped
 
     :rtype: mapping
-    :returns; a mapping describing the schema of the supplied fields.
+    :returns: a mapping describing the schema of the supplied fields.
     """
     infos = []
     for field in fields:

--- a/gcloud/logging/client.py
+++ b/gcloud/logging/client.py
@@ -28,7 +28,7 @@ from gcloud.logging.sink import Sink
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of.
                     If not passed, falls back to the default inferred
                     from the environment.
@@ -51,7 +51,7 @@ class Client(JSONClient):
     def logger(self, name):
         """Creates a logger bound to the current client.
 
-        :type name: string
+        :type name: str
         :param name: the name of the logger to be constructed.
 
         :rtype: :class:`gcloud.logging.logger.Logger`
@@ -69,7 +69,7 @@ class Client(JSONClient):
         :param loggers: A mapping of logger fullnames -> loggers.  If not
                         passed, the entry will have a newly-created logger.
 
-        :rtype; One of:
+        :rtype: One of:
                 :class:`gcloud.logging.entries.TextEntry`,
                 :class:`gcloud.logging.entries.StructEntry`,
                 :class:`gcloud.logging.entries.ProtobufEntry`
@@ -94,11 +94,11 @@ class Client(JSONClient):
         :param projects: project IDs to include. If not passed,
                             defaults to the project bound to the client.
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: a filter expression. See:
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
-        :type order_by: string
+        :type order_by: str
         :param order_by: One of :data:`gcloud.logging.ASCENDING` or
                          :data:`gcloud.logging.DESCENDING`.
 
@@ -106,7 +106,7 @@ class Client(JSONClient):
         :param page_size: maximum number of entries to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of entries. If not
                            passed, the API will return the first page of
                            entries.
@@ -144,14 +144,14 @@ class Client(JSONClient):
     def sink(self, name, filter_, destination):
         """Creates a sink bound to the current client.
 
-        :type name: string
+        :type name: str
         :param name: the name of the sink to be constructed.
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the sink.
 
-        :type destination: string
+        :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
 
@@ -170,7 +170,7 @@ class Client(JSONClient):
         :param page_size: maximum number of sinks to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of sinks. If not
                            passed, the API will return the first page of
                            sinks.
@@ -199,14 +199,14 @@ class Client(JSONClient):
     def metric(self, name, filter_, description=''):
         """Creates a metric bound to the current client.
 
-        :type name: string
+        :type name: str
         :param name: the name of the metric to be constructed.
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries tracked by the metric.
 
-        :type description: string
+        :type description: str
         :param description: the description of the metric to be constructed.
 
         :rtype: :class:`gcloud.logging.metric.Metric`
@@ -224,7 +224,7 @@ class Client(JSONClient):
         :param page_size: maximum number of metrics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of metrics. If not
                            passed, the API will return the first page of
                            metrics.

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -219,6 +219,7 @@ class Query(object):
             query = query.select_projects('project-1')
             query = query.select_projects('project-1', 'project-2')
 
+        :type args: str
         :param args: Project IDs limiting the resources to be included
             in the query.
 
@@ -268,10 +269,12 @@ class Query(object):
             not a resource label. You would filter on it using
             ``select_metrics(instance_name=...)``.
 
+        :type args: str
         :param args: Raw filter expression strings to include in the
             conjunction. If just one is provided and no keyword arguments
             are provided, it can be a disjunction.
 
+        :type kwargs: str
         :param kwargs: Label filters to include in the conjunction as
             described above.
 
@@ -309,10 +312,12 @@ class Query(object):
 
             metric.label.<label> = ends_with("<value>")
 
+        :type args: str
         :param args: Raw filter expression strings to include in the
             conjunction. If just one is provided and no keyword arguments
             are provided, it can be a disjunction.
 
+        :type kwargs: str
         :param kwargs: Label filters to include in the conjunction as
             described above.
 

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -219,7 +219,7 @@ class Query(object):
             query = query.select_projects('project-1')
             query = query.select_projects('project-1', 'project-2')
 
-        :type args: str
+        :type args: tuple
         :param args: Project IDs limiting the resources to be included
             in the query.
 
@@ -269,12 +269,12 @@ class Query(object):
             not a resource label. You would filter on it using
             ``select_metrics(instance_name=...)``.
 
-        :type args: str
+        :type args: tuple
         :param args: Raw filter expression strings to include in the
             conjunction. If just one is provided and no keyword arguments
             are provided, it can be a disjunction.
 
-        :type kwargs: str
+        :type kwargs: dict
         :param kwargs: Label filters to include in the conjunction as
             described above.
 
@@ -312,12 +312,12 @@ class Query(object):
 
             metric.label.<label> = ends_with("<value>")
 
-        :type args: str
+        :type args: tuple
         :param args: Raw filter expression strings to include in the
             conjunction. If just one is provided and no keyword arguments
             are provided, it can be a disjunction.
 
-        :type kwargs: str
+        :type kwargs: dict
         :param kwargs: Label filters to include in the conjunction as
             described above.
 

--- a/gcloud/monitoring/timeseries.py
+++ b/gcloud/monitoring/timeseries.py
@@ -127,7 +127,7 @@ class Point(collections.namedtuple('Point', 'end_time start_time value')):
     :type start_time: string or None
     :param start_time: An optional start time in RFC3339 UTC "Zulu" format.
 
-    :type value: int
+    :type value: object
     :param value: The metric value. This can be a scalar or a distribution.
     """
     __slots__ = ()

--- a/gcloud/monitoring/timeseries.py
+++ b/gcloud/monitoring/timeseries.py
@@ -127,6 +127,7 @@ class Point(collections.namedtuple('Point', 'end_time start_time value')):
     :type start_time: string or None
     :param start_time: An optional start time in RFC3339 UTC "Zulu" format.
 
+    :type value: int
     :param value: The metric value. This can be a scalar or a distribution.
     """
     __slots__ = ()

--- a/gcloud/storage/batch.py
+++ b/gcloud/storage/batch.py
@@ -35,17 +35,18 @@ class MIMEApplicationHTTP(MIMEApplication):
 
     Constructs payload from headers and body
 
-    :type method: string
+    :type method: str
     :param method: HTTP method
 
-    :type uri: string
+    :type uri: str
     :param uri: URI for HTTP request
 
     :type headers:  dict
     :param headers: HTTP headers
 
-    :type body: text or None
+    :type body: str or None
     :param body: HTTP payload
+
     """
     def __init__(self, method, uri, headers, body):
         if isinstance(body, dict):
@@ -141,16 +142,16 @@ class Batch(Connection):
 
         Only allow up to ``_MAX_BATCH_SIZE`` requests to be deferred.
 
-        :type method: string
+        :type method: str
         :param method: The HTTP method to use in the request.
 
-        :type url: string
+        :type url: str
         :param url: The URL to send the request to.
 
         :type headers: dict
         :param headers: A dictionary of HTTP headers to send with the request.
 
-        :type data: string
+        :type data: str
         :param data: The data to send as the body of the request.
 
         :type target_object: object or :class:`NoneType`
@@ -176,7 +177,7 @@ class Batch(Connection):
     def _prepare_batch_request(self):
         """Prepares headers and body for a batch request.
 
-        :rtype: tuple (dict, string)
+        :rtype: tuple (dict, str)
         :returns: The pair of headers and body of the batch request to be sent.
         :raises: :class:`ValueError` if no requests have been deferred.
         """
@@ -300,7 +301,7 @@ def _unpack_batch_response(response, content):
     :type response: :class:`httplib2.Response`
     :param response: HTTP response / headers from a request.
 
-    :type content: string
+    :type content: str
     :param content: Response payload with a batch response.
 
     :rtype: generator

--- a/gcloud/streaming/http_wrapper.py
+++ b/gcloud/streaming/http_wrapper.py
@@ -115,16 +115,16 @@ def _httplib2_debug_level(http_request, level, http=None):
 class Request(object):
     """Encapsulates the data for an HTTP request.
 
-    :type url: string
+    :type url: str
     :param url: the URL for the request
 
-    :type http_method: string
+    :type http_method: str
     :param http_method: the HTTP method to use for the request
 
     :type headers: mapping or None
     :param headers: headers to be sent with the request
 
-    :type body: string
+    :type body: str
     :param body: body to be sent with the request
     """
     def __init__(self, url='', http_method='GET', headers=None, body=''):
@@ -139,7 +139,7 @@ class Request(object):
     def loggable_body(self):
         """Request body for logging purposes
 
-        :rtype: string
+        :rtype: str
         """
         return self.__loggable_body
 
@@ -147,7 +147,7 @@ class Request(object):
     def loggable_body(self, value):
         """Update request body for logging purposes
 
-        :type value: string
+        :type value: str
         :param value: updated body
 
         :raises: :exc:`RequestError` if the request does not have a body.
@@ -161,7 +161,7 @@ class Request(object):
     def body(self):
         """Request body
 
-        :rtype: string
+        :rtype: str
         """
         return self.__body
 
@@ -171,7 +171,7 @@ class Request(object):
 
         Handles logging and length measurement.
 
-        :type value: string
+        :type value: str
         :param value: updated body
         """
         self.__body = value
@@ -192,7 +192,7 @@ def _process_content_range(content_range):
 
     Helper for :meth:`Response.length`.
 
-    :type content_range: string
+    :type content_range: str
     :param content_range: the header value being parsed.
 
     :rtype: integer
@@ -434,6 +434,7 @@ def _register_http_factory(factory):
 def get_http(**kwds):
     """Construct an Http instance.
 
+    :type kwds: str, int
     :param kwds:  keyword arguments to pass to factories.
 
     :rtype: :class:`httplib2.Http` (or a workalike)

--- a/gcloud/streaming/http_wrapper.py
+++ b/gcloud/streaming/http_wrapper.py
@@ -434,7 +434,7 @@ def _register_http_factory(factory):
 def get_http(**kwds):
     """Construct an Http instance.
 
-    :type kwds: str, int
+    :type kwds: dict
     :param kwds:  keyword arguments to pass to factories.
 
     :rtype: :class:`httplib2.Http` (or a workalike)


### PR DESCRIPTION
- There were just a couple typos with a semi-colon instead of a colon.
- Also, in the files that I had touched I converted types from `string` to `str` which is better supported by the documentation parsers.