### PR TITLE
Ensure that mulitpart bodies are always bytes.

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -809,8 +809,9 @@ class Table(object):
         :rtype: :class:`gcloud.bigquery.jobs.LoadTableFromStorageJob`
         :returns: the job instance used to load the data (e.g., for
                   querying status)
-        :raises: :class:`ValueError` if size is not passed in and can not be
-                 determined
+        :raises: :class:`ValueError` if ``size`` is not passed in and can not
+                 be determined, or if the ``file_obj`` can be detected to be
+                 a file opened in text mode.
         """
         client = self._require_client(client)
         connection = client.connection
@@ -819,6 +820,12 @@ class Table(object):
         # Rewind the file if desired.
         if rewind:
             file_obj.seek(0, os.SEEK_SET)
+
+        mode = getattr(file_obj, 'mode', None)
+        if mode is not None and mode != 'rb':
+            raise ValueError(
+                "Cannot upload files opened in text mode:  use "
+                "open(filename, mode='rb')")
 
         # Get the basic stats about the file.
         total_bytes = size

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -742,7 +742,7 @@ class Table(object):
         - ``text/csv``.
 
         :type file_obj: file
-        :param file_obj: A file handle open for reading.
+        :param file_obj: A file handle opened in binary mode for reading.
 
         :type source_format: str
         :param source_format: one of 'CSV' or 'NEWLINE_DELIMITED_JSON'.

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -1289,6 +1289,19 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         self.assertEqual(req['path'], '/%s' % PATH)
         self.assertEqual(req['data'], SENT)
 
+    def test_upload_from_file_text_mode_file_failure(self):
+
+        class TextModeFile(object):
+            mode = 'r'
+
+        conn = _Connection()
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        file_obj = TextModeFile()
+        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        with self.assertRaises(ValueError):
+            table.upload_from_file(file_obj, 'CSV', size=1234)
+
     def test_upload_from_file_size_failure(self):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)

--- a/gcloud/streaming/test_transfer.py
+++ b/gcloud/streaming/test_transfer.py
@@ -1787,7 +1787,9 @@ class Test_Upload(unittest2.TestCase):
 def _email_chunk_parser():
     import six
     if six.PY3:  # pragma: NO COVER  Python3
-        from email.parser import BytesParser  # pylint: disable=E0611
+        # pylint: disable=no-name-in-module
+        from email.parser import BytesParser
+        # pylint: enable=no-name-in-module
         parser = BytesParser()
         return parser.parsebytes
     else:

--- a/gcloud/streaming/test_transfer.py
+++ b/gcloud/streaming/test_transfer.py
@@ -1787,9 +1787,7 @@ class Test_Upload(unittest2.TestCase):
 def _email_chunk_parser():
     import six
     if six.PY3:  # pragma: NO COVER  Python3
-        # pylint: disable=no-name-in-module
         from email.parser import BytesParser
-        # pylint: enable=no-name-in-module
         parser = BytesParser()
         return parser.parsebytes
     else:

--- a/gcloud/streaming/transfer.py
+++ b/gcloud/streaming/transfer.py
@@ -852,7 +852,7 @@ class Upload(_Transfer):
 
         # NOTE: generate multipart message as bytes, not text
         stream = six.BytesIO()
-        if six.PY3:  # pragma: NO COVER  Pythone
+        if six.PY3:  # pragma: NO COVER  Python3
             generator_class = email_generator.BytesGenerator
         else:
             generator_class = email_generator.Generator

--- a/gcloud/streaming/transfer.py
+++ b/gcloud/streaming/transfer.py
@@ -9,6 +9,7 @@ import os
 import six
 from six.moves import http_client
 
+from gcloud._helpers import _to_bytes
 from gcloud.streaming.buffered_stream import BufferedStream
 from gcloud.streaming.exceptions import CommunicationError
 from gcloud.streaming.exceptions import HttpError
@@ -849,13 +850,13 @@ class Upload(_Transfer):
         msg.set_payload(self.stream.read())
         msg_root.attach(msg)
 
-        # NOTE: We encode the body, but can't use
-        #       `email.message.Message.as_string` because it prepends
-        #       `> ` to `From ` lines.
-        # NOTE: We must use six.StringIO() instead of io.StringIO() since the
-        #       `email` library uses cStringIO in Py2 and io.StringIO in Py3.
-        stream = six.StringIO()
-        generator = email_generator.Generator(stream, mangle_from_=False)
+        # NOTE: generate multipart message as bytes, not text
+        stream = six.BytesIO()
+        if six.PY3:  # pragma: NO COVER  Pythone
+            generator_class = email_generator.BytesGenerator
+        else:
+            generator_class = email_generator.Generator
+        generator = generator_class(stream, mangle_from_=False)
         generator.flatten(msg_root, unixfrom=False)
         http_request.body = stream.getvalue()
 
@@ -863,10 +864,11 @@ class Upload(_Transfer):
         http_request.headers['content-type'] = (
             'multipart/related; boundary="%s"' % multipart_boundary)
 
-        body_components = http_request.body.split(multipart_boundary)
-        headers, _, _ = body_components[-2].partition('\n\n')
-        body_components[-2] = '\n\n'.join([headers, '<media body>\n\n--'])
-        http_request.loggable_body = multipart_boundary.join(body_components)
+        boundary_bytes = _to_bytes(multipart_boundary)
+        body_components = http_request.body.split(boundary_bytes)
+        headers, _, _ = body_components[-2].partition(b'\n\n')
+        body_components[-2] = b'\n\n'.join([headers, b'<media body>\n\n--'])
+        http_request.loggable_body = boundary_bytes.join(body_components)
 
     def _configure_resumable_request(self, http_request):
         """Helper for 'configure_request': set up resumable request."""


### PR DESCRIPTION
Loosely based on [@joar's gist](https://gist.github.com/joar/ce5e54c0befd5ff24c312fcd62caab10)

Fixes #1760.