### PR TITLE
Drop ':undoc-members:' from Sphinx API docs

### DIFF
--- a/docs/bigquery-client.rst
+++ b/docs/bigquery-client.rst
@@ -3,7 +3,6 @@ BigQuery Client
 
 .. automodule:: gcloud.bigquery.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,5 +10,4 @@ Connection
 
 .. automodule:: gcloud.bigquery.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigquery-dataset.rst
+++ b/docs/bigquery-dataset.rst
@@ -3,5 +3,4 @@ Datasets
 
 .. automodule:: gcloud.bigquery.dataset
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigquery-job.rst
+++ b/docs/bigquery-job.rst
@@ -3,5 +3,4 @@ Jobs
 
 .. automodule:: gcloud.bigquery.job
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigquery-query.rst
+++ b/docs/bigquery-query.rst
@@ -3,5 +3,4 @@ Query
 
 .. automodule:: gcloud.bigquery.query
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigquery-table.rst
+++ b/docs/bigquery-table.rst
@@ -3,5 +3,4 @@ Tables
 
 .. automodule:: gcloud.bigquery.table
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigtable-client.rst
+++ b/docs/bigtable-client.rst
@@ -3,5 +3,4 @@ Client
 
 .. automodule:: gcloud.bigtable.client
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigtable-cluster.rst
+++ b/docs/bigtable-cluster.rst
@@ -3,5 +3,4 @@ Cluster
 
 .. automodule:: gcloud.bigtable.cluster
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigtable-column-family.rst
+++ b/docs/bigtable-column-family.rst
@@ -46,5 +46,4 @@ at the lowest level of the nesting:
 
 .. automodule:: gcloud.bigtable.column_family
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigtable-row-data.rst
+++ b/docs/bigtable-row-data.rst
@@ -3,5 +3,4 @@ Row Data
 
 .. automodule:: gcloud.bigtable.row_data
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/bigtable-row-filters.rst
+++ b/docs/bigtable-row-filters.rst
@@ -62,7 +62,6 @@ level. For example:
 
 .. automodule:: gcloud.bigtable.row_filters
   :members:
-  :undoc-members:
   :show-inheritance:
 
 .. _RowFilter definition: https://github.com/GoogleCloudPlatform/cloud-bigtable-client/blob/1ff247c2e3b7cd0a2dd49071b2d95beaf6563092/bigtable-protos/src/main/proto/google/bigtable/v1/bigtable_data.proto#L195

--- a/docs/bigtable-row.rst
+++ b/docs/bigtable-row.rst
@@ -3,6 +3,5 @@ Bigtable Row
 
 .. automodule:: gcloud.bigtable.row
   :members:
-  :undoc-members:
   :show-inheritance:
   :inherited-members:

--- a/docs/bigtable-table.rst
+++ b/docs/bigtable-table.rst
@@ -3,5 +3,4 @@ Table
 
 .. automodule:: gcloud.bigtable.table
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-batches.rst
+++ b/docs/datastore-batches.rst
@@ -3,5 +3,4 @@ Batches
 
 .. automodule:: gcloud.datastore.batch
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-client.rst
+++ b/docs/datastore-client.rst
@@ -3,7 +3,6 @@ Datastore Client
 
 .. automodule:: gcloud.datastore.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,5 +10,4 @@ Connection
 
 .. automodule:: gcloud.datastore.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-entities.rst
+++ b/docs/datastore-entities.rst
@@ -3,5 +3,4 @@ Entities
 
 .. automodule:: gcloud.datastore.entity
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-helpers.rst
+++ b/docs/datastore-helpers.rst
@@ -3,5 +3,4 @@ Helpers
 
 .. automodule:: gcloud.datastore.helpers
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-keys.rst
+++ b/docs/datastore-keys.rst
@@ -3,5 +3,4 @@ Keys
 
 .. automodule:: gcloud.datastore.key
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-queries.rst
+++ b/docs/datastore-queries.rst
@@ -3,5 +3,4 @@ Queries
 
 .. automodule:: gcloud.datastore.query
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/datastore-transactions.rst
+++ b/docs/datastore-transactions.rst
@@ -3,6 +3,5 @@ Transactions
 
 .. automodule:: gcloud.datastore.transaction
   :members:
-  :undoc-members:
   :show-inheritance:
   :inherited-members:

--- a/docs/dns-changes.rst
+++ b/docs/dns-changes.rst
@@ -3,5 +3,4 @@ Change Sets
 
 .. automodule:: gcloud.dns.changes
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/dns-client.rst
+++ b/docs/dns-client.rst
@@ -3,7 +3,6 @@ DNS Client
 
 .. automodule:: gcloud.dns.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,5 +10,4 @@ Connection
 
 .. automodule:: gcloud.dns.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/dns-resource-record-set.rst
+++ b/docs/dns-resource-record-set.rst
@@ -3,5 +3,4 @@ Resource Record Sets
 
 .. automodule:: gcloud.dns.resource_record_set
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/dns-zone.rst
+++ b/docs/dns-zone.rst
@@ -3,5 +3,4 @@ Managed Zones
 
 .. automodule:: gcloud.dns.zone
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/gcloud-api.rst
+++ b/docs/gcloud-api.rst
@@ -6,7 +6,6 @@ Base Client
 
 .. automodule:: gcloud.client
   :members:
-  :undoc-members:
   :show-inheritance:
   :inherited-members:
 
@@ -15,7 +14,6 @@ Credentials Helpers
 
 .. automodule:: gcloud.credentials
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Base Connections
@@ -23,7 +21,6 @@ Base Connections
 
 .. automodule:: gcloud.connection
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Exceptions
@@ -31,7 +28,6 @@ Exceptions
 
 .. automodule:: gcloud.exceptions
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Environment Variables
@@ -39,5 +35,4 @@ Environment Variables
 
 .. automodule:: gcloud.environment_vars
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/happybase-batch.rst
+++ b/docs/happybase-batch.rst
@@ -3,5 +3,4 @@ HappyBase Batch
 
 .. automodule:: gcloud.bigtable.happybase.batch
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/happybase-connection.rst
+++ b/docs/happybase-connection.rst
@@ -3,5 +3,4 @@ HappyBase Connection
 
 .. automodule:: gcloud.bigtable.happybase.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/happybase-package.rst
+++ b/docs/happybase-package.rst
@@ -3,5 +3,4 @@ HappyBase Package
 
 .. automodule:: gcloud.bigtable.happybase.__init__
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/happybase-pool.rst
+++ b/docs/happybase-pool.rst
@@ -3,5 +3,4 @@ HappyBase Connection Pool
 
 .. automodule:: gcloud.bigtable.happybase.pool
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/happybase-table.rst
+++ b/docs/happybase-table.rst
@@ -3,5 +3,4 @@ HappyBase Table
 
 .. automodule:: gcloud.bigtable.happybase.table
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/logging-client.rst
+++ b/docs/logging-client.rst
@@ -3,7 +3,6 @@ Logging Client
 
 .. automodule:: gcloud.logging.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,6 +10,5 @@ Connection
 
 .. automodule:: gcloud.logging.connection
   :members:
-  :undoc-members:
   :show-inheritance:
 

--- a/docs/logging-entries.rst
+++ b/docs/logging-entries.rst
@@ -3,6 +3,5 @@ Entries
 
 .. automodule:: gcloud.logging.entries
   :members:
-  :undoc-members:
   :show-inheritance:
 

--- a/docs/logging-logger.rst
+++ b/docs/logging-logger.rst
@@ -3,6 +3,5 @@ Logger
 
 .. automodule:: gcloud.logging.logger
   :members:
-  :undoc-members:
   :show-inheritance:
 

--- a/docs/logging-metric.rst
+++ b/docs/logging-metric.rst
@@ -3,5 +3,4 @@ Metrics
 
 .. automodule:: gcloud.logging.metric
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/logging-sink.rst
+++ b/docs/logging-sink.rst
@@ -3,5 +3,4 @@ Sinks
 
 .. automodule:: gcloud.logging.sink
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/monitoring-client.rst
+++ b/docs/monitoring-client.rst
@@ -3,7 +3,6 @@ Monitoring Client
 
 .. automodule:: gcloud.monitoring.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,6 +10,5 @@ Connection
 
 .. automodule:: gcloud.monitoring.connection
   :members:
-  :undoc-members:
   :show-inheritance:
 

--- a/docs/monitoring-label.rst
+++ b/docs/monitoring-label.rst
@@ -3,5 +3,4 @@ Label Descriptors
 
 .. automodule:: gcloud.monitoring.label
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/monitoring-metric.rst
+++ b/docs/monitoring-metric.rst
@@ -3,5 +3,4 @@ Metric Descriptors
 
 .. automodule:: gcloud.monitoring.metric
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/monitoring-query.rst
+++ b/docs/monitoring-query.rst
@@ -3,5 +3,4 @@ Time Series Query
 
 .. automodule:: gcloud.monitoring.query
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/monitoring-resource.rst
+++ b/docs/monitoring-resource.rst
@@ -3,5 +3,4 @@ Monitored Resource Descriptors
 
 .. automodule:: gcloud.monitoring.resource
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/monitoring-timeseries.rst
+++ b/docs/monitoring-timeseries.rst
@@ -3,5 +3,4 @@ Time Series
 
 .. automodule:: gcloud.monitoring.timeseries
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-client.rst
+++ b/docs/pubsub-client.rst
@@ -3,7 +3,6 @@ Pub/Sub Client
 
 .. automodule:: gcloud.pubsub.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,5 +10,4 @@ Connection
 
 .. automodule:: gcloud.pubsub.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-iam.rst
+++ b/docs/pubsub-iam.rst
@@ -4,6 +4,5 @@ IAM Policy
 .. automodule:: gcloud.pubsub.iam
   :members:
   :member-order: bysource
-  :undoc-members:
   :show-inheritance:
 

--- a/docs/pubsub-message.rst
+++ b/docs/pubsub-message.rst
@@ -3,5 +3,4 @@ Message
 
 .. automodule:: gcloud.pubsub.message
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-subscription.rst
+++ b/docs/pubsub-subscription.rst
@@ -4,5 +4,4 @@ Subscriptions
 .. automodule:: gcloud.pubsub.subscription
   :members:
   :member-order: bysource
-  :undoc-members:
   :show-inheritance:

--- a/docs/pubsub-topic.rst
+++ b/docs/pubsub-topic.rst
@@ -4,5 +4,4 @@ Topics
 .. automodule:: gcloud.pubsub.topic
   :members:
   :member-order: bysource
-  :undoc-members:
   :show-inheritance:

--- a/docs/resource-manager-client.rst
+++ b/docs/resource-manager-client.rst
@@ -7,7 +7,6 @@ Client
 
 .. automodule:: gcloud.resource_manager.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -15,5 +14,4 @@ Connection
 
 .. automodule:: gcloud.resource_manager.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/resource-manager-project.rst
+++ b/docs/resource-manager-project.rst
@@ -3,5 +3,4 @@ Projects
 
 .. automodule:: gcloud.resource_manager.project
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/storage-acl.rst
+++ b/docs/storage-acl.rst
@@ -3,5 +3,4 @@ ACL
 
 .. automodule:: gcloud.storage.acl
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/storage-batch.rst
+++ b/docs/storage-batch.rst
@@ -3,5 +3,4 @@ Batches
 
 .. automodule:: gcloud.storage.batch
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/storage-blobs.rst
+++ b/docs/storage-blobs.rst
@@ -3,5 +3,4 @@ Blobs / Objects
 
 .. automodule:: gcloud.storage.blob
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/storage-buckets.rst
+++ b/docs/storage-buckets.rst
@@ -3,5 +3,4 @@ Buckets
 
 .. automodule:: gcloud.storage.bucket
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/docs/storage-client.rst
+++ b/docs/storage-client.rst
@@ -3,7 +3,6 @@ Storage Client
 
 .. automodule:: gcloud.storage.client
   :members:
-  :undoc-members:
   :show-inheritance:
 
 Connection
@@ -11,5 +10,4 @@ Connection
 
 .. automodule:: gcloud.storage.connection
   :members:
-  :undoc-members:
   :show-inheritance:

--- a/gcloud/bigquery/_helpers.py
+++ b/gcloud/bigquery/_helpers.py
@@ -18,31 +18,37 @@ from gcloud._helpers import _datetime_from_microseconds
 
 
 def _not_null(value, field):
+    """Check whether 'value' should be coerced to 'field' type."""
     return value is not None or field.mode != 'NULLABLE'
 
 
 def _int_from_json(value, field):
+    """Coerce 'value' to an int, if set or not nullable."""
     if _not_null(value, field):
         return int(value)
 
 
 def _float_from_json(value, field):
+    """Coerce 'value' to a float, if set or not nullable."""
     if _not_null(value, field):
         return float(value)
 
 
 def _bool_from_json(value, field):
+    """Coerce 'value' to a bool, if set or not nullable."""
     if _not_null(value, field):
         return value.lower() in ['t', 'true', '1']
 
 
 def _datetime_from_json(value, field):
+    """Coerce 'value' to a datetime, if set or not nullable."""
     if _not_null(value, field):
         # value will be a float in seconds, to microsecond precision, in UTC.
         return _datetime_from_microseconds(1e6 * float(value))
 
 
 def _record_from_json(value, field):
+    """Coerce 'value' to a mapping, if set or not nullable."""
     if _not_null(value, field):
         record = {}
         for subfield, cell in zip(field.fields, value['f']):
@@ -56,6 +62,7 @@ def _record_from_json(value, field):
 
 
 def _string_from_json(value, _):
+    """NOOP string -> string coercion"""
     return value
 
 
@@ -70,6 +77,7 @@ _CELLDATA_FROM_JSON = {
 
 
 def _rows_from_json(rows, schema):
+    """Convert JSON row data to rows w/ appropriate types."""
     rows_data = []
     for row in rows:
         row_data = []
@@ -132,6 +140,10 @@ class _TypedProperty(_ConfigurationProperty):
         self.property_type = property_type
 
     def _validate(self, value):
+        """Ensure that 'value' is of the appropriate type.
+
+        :raises: ValueError on a type mismatch.
+        """
         if not isinstance(value, self.property_type):
             raise ValueError('Required type: %s' % (self.property_type,))
 

--- a/gcloud/bigquery/job.py
+++ b/gcloud/bigquery/job.py
@@ -933,6 +933,11 @@ class QueryJob(_AsyncJob):
     """
 
     def _destination_table_resource(self):
+        """Create a JSON resource for the destination table.
+
+        Helper for :meth:`_populate_config_resource` and
+        :meth:`_scrub_local_properties`
+        """
         if self.destination is not None:
             return {
                 'projectId': self.destination.project,

--- a/gcloud/bigtable/cluster.py
+++ b/gcloud/bigtable/cluster.py
@@ -241,6 +241,10 @@ class Cluster(object):
         return Table(table_id, self)
 
     def _update_from_pb(self, cluster_pb):
+        """Refresh self from the server-provided protobuf.
+
+        Helper for :meth:`from_pb` and :meth:`reload`.
+        """
         if not cluster_pb.display_name:  # Simple field (string)
             raise ValueError('Cluster protobuf does not contain display_name')
         if not cluster_pb.serve_nodes:  # Simple field (int32)

--- a/gcloud/client.py
+++ b/gcloud/client.py
@@ -150,6 +150,7 @@ class _ClientProjectMixin(object):
 
     @staticmethod
     def _determine_default(project):
+        """Helper:  use default project detection."""
         return _determine_default_project(project)
 
 

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -174,6 +174,7 @@ class Client(_BaseClient, _ClientProjectMixin):
 
     @staticmethod
     def _determine_default(project):
+        """Helper:  override default project detection."""
         return _determine_default_project(project)
 
     def _push_batch(self, batch):

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -299,7 +299,7 @@ method-rgx=[a-z_][a-z0-9_]{2,35}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-# DEFAULT:  no-docstring-rgx=__.*__
+no-docstring-rgx=__.*__
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.


### PR DESCRIPTION
Set explicit pylint pattern for `no-docstring-rgx`.  Leaving it unset disabled the `missing-docstring` check.

Add missing docstrings uncovered thereby.

Closes #1800.