### PR TITLE
Don't enforce project ID validation when unmarshallig log entries

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -433,9 +433,10 @@ def _name_from_project_path(path, project, template):
     :type path: string
     :param path: URI path containing the name.
 
-    :type project: string
+    :type project: string or NoneType
     :param project: The project associated with the request. It is
-                    included for validation purposes.
+                    included for validation purposes.  If passed as None,
+                    disables validation.
 
     :type template: string
     :param template: Template regex describing the expected form of the path.
@@ -457,11 +458,12 @@ def _name_from_project_path(path, project, template):
         raise ValueError('path "%s" did not match expected pattern "%s"' % (
             path, template.pattern,))
 
-    found_project = match.group('project')
-    if found_project != project:
-        raise ValueError(
-            'Project from client (%s) should agree with '
-            'project from resource(%s).' % (project, found_project))
+    if project is not None:
+        found_project = match.group('project')
+        if found_project != project:
+            raise ValueError(
+                'Project from client (%s) should agree with '
+                'project from resource(%s).' % (project, found_project))
 
     return match.group('name')
 

--- a/gcloud/logging/_helpers.py
+++ b/gcloud/logging/_helpers.py
@@ -27,15 +27,11 @@ _LOGGER_TEMPLATE = re.compile(r"""
 """, re.VERBOSE)
 
 
-def logger_name_from_path(path, project):
+def logger_name_from_path(path):
     """Validate a logger URI path and get the logger name.
 
     :type path: string
     :param path: URI path for a logger API request.
-
-    :type project: string
-    :param project: The project associated with the request. It is
-                    included for validation purposes.
 
     :rtype: string
     :returns: Logger name parsed from ``path``.
@@ -43,4 +39,4 @@ def logger_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _LOGGER_TEMPLATE)
+    return _name_from_project_path(path, None, _LOGGER_TEMPLATE)

--- a/gcloud/logging/entries.py
+++ b/gcloud/logging/entries.py
@@ -82,8 +82,7 @@ class _BaseEntry(object):
         logger_fullname = resource['logName']
         logger = loggers.get(logger_fullname)
         if logger is None:
-            logger_name = logger_name_from_path(
-                logger_fullname, client.project)
+            logger_name = logger_name_from_path(logger_fullname)
             logger = loggers[logger_fullname] = client.logger(logger_name)
         payload = resource[cls._PAYLOAD_KEY]
         insert_id = resource.get('insertId')

--- a/gcloud/logging/test__helpers.py
+++ b/gcloud/logging/test__helpers.py
@@ -17,20 +17,20 @@ import unittest2
 
 class Test_logger_name_from_path(unittest2.TestCase):
 
-    def _callFUT(self, path, project):
+    def _callFUT(self, path):
         from gcloud.logging._helpers import logger_name_from_path
-        return logger_name_from_path(path, project)
+        return logger_name_from_path(path)
 
     def test_w_simple_name(self):
         LOGGER_NAME = 'LOGGER_NAME'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/logs/%s' % (PROJECT, LOGGER_NAME)
-        logger_name = self._callFUT(PATH, PROJECT)
+        logger_name = self._callFUT(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
 
     def test_w_name_w_all_extras(self):
         LOGGER_NAME = 'LOGGER_NAME-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/logs/%s' % (PROJECT, LOGGER_NAME)
-        logger_name = self._callFUT(PATH, PROJECT)
+        logger_name = self._callFUT(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -662,6 +662,13 @@ class Test__name_from_project_path(unittest2.TestCase):
         name = self._callFUT(PATH, self.PROJECT, template)
         self.assertEqual(name, self.THING_NAME)
 
+    def test_w_project_passed_as_none(self):
+        PROJECT1 = 'PROJECT1'
+        PATH = 'projects/%s/things/%s' % (PROJECT1, self.THING_NAME)
+        self._callFUT(PATH, None, self.TEMPLATE)
+        name = self._callFUT(PATH, None, self.TEMPLATE)
+        self.assertEqual(name, self.THING_NAME)
+
 
 class _AppIdentity(object):
 


### PR DESCRIPTION
The back-end apparently returns numeric project IDs in some cases.

Update `gcloud._helpers._name_from_project_path` to allow passing its `project` argument as `None` to disable the validation.

Closes: #1806.