### PR TITLE
Return self in Bigtable client __enter__.

### DIFF
--- a/gcloud/bigtable/client.py
+++ b/gcloud/bigtable/client.py
@@ -344,6 +344,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
     def __enter__(self):
         """Starts the client as a context manager."""
         self.start()
+        return self
 
     def stop(self):
         """Closes all the open gRPC clients."""

--- a/gcloud/bigtable/test_client.py
+++ b/gcloud/bigtable/test_client.py
@@ -131,6 +131,10 @@ class TestClient(unittest2.TestCase):
             self.assertTrue(client.is_started())
         self.assertFalse(client.is_started())
 
+    def test_context_manager_as_keyword(self):
+        with self._context_manager_helper() as client:
+            self.assertIsNotNone(client)
+
     def test_context_manager_with_exception(self):
         client = self._context_manager_helper()
         self.assertFalse(client.is_started())


### PR DESCRIPTION
This makes the `as` keyword work correctly in a with statement.

I missed this when fixing https://github.com/GoogleCloudPlatform/gcloud-python/issues/1793.
