### PR TITLE
Making grpcio install require fewer keystrokes.

### DIFF
--- a/docs/bigtable-client-intro.rst
+++ b/docs/bigtable-client-intro.rst
@@ -5,7 +5,7 @@ Base for Everything
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python in other versions of Python will fail.
 
 To use the API, the :class:`Client <gcloud.bigtable.client.Client>`
 class defines a high-level interface which handles authorization

--- a/docs/bigtable-client-intro.rst
+++ b/docs/bigtable-client-intro.rst
@@ -1,6 +1,12 @@
 Base for Everything
 ===================
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 To use the API, the :class:`Client <gcloud.bigtable.client.Client>`
 class defines a high-level interface which handles authorization
 and creating other objects:

--- a/docs/bigtable-client-intro.rst
+++ b/docs/bigtable-client-intro.rst
@@ -5,7 +5,7 @@ Base for Everything
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` in other versions of Python in other versions of Python will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 To use the API, the :class:`Client <gcloud.bigtable.client.Client>`
 class defines a high-level interface which handles authorization

--- a/docs/bigtable-client.rst
+++ b/docs/bigtable-client.rst
@@ -5,7 +5,7 @@ Client
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.client
   :members:

--- a/docs/bigtable-client.rst
+++ b/docs/bigtable-client.rst
@@ -1,6 +1,12 @@
 Client
 ~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.client
   :members:
   :show-inheritance:

--- a/docs/bigtable-cluster-api.rst
+++ b/docs/bigtable-cluster-api.rst
@@ -5,7 +5,7 @@ Cluster Admin API
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 After creating a :class:`Client <gcloud.bigtable.client.Client>`, you can
 interact with individual clusters, groups of clusters or available

--- a/docs/bigtable-cluster-api.rst
+++ b/docs/bigtable-cluster-api.rst
@@ -1,6 +1,12 @@
 Cluster Admin API
 =================
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 After creating a :class:`Client <gcloud.bigtable.client.Client>`, you can
 interact with individual clusters, groups of clusters or available
 zones for a project.

--- a/docs/bigtable-cluster.rst
+++ b/docs/bigtable-cluster.rst
@@ -5,7 +5,7 @@ Cluster
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.cluster
   :members:

--- a/docs/bigtable-cluster.rst
+++ b/docs/bigtable-cluster.rst
@@ -1,6 +1,12 @@
 Cluster
 ~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.cluster
   :members:
   :show-inheritance:

--- a/docs/bigtable-column-family.rst
+++ b/docs/bigtable-column-family.rst
@@ -5,7 +5,7 @@ Column Families
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 When creating a
 :class:`ColumnFamily <gcloud.bigtable.column_family.ColumnFamily>`, it is

--- a/docs/bigtable-column-family.rst
+++ b/docs/bigtable-column-family.rst
@@ -1,6 +1,12 @@
 Column Families
 ===============
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 When creating a
 :class:`ColumnFamily <gcloud.bigtable.column_family.ColumnFamily>`, it is
 possible to set garbage collection rules for expired data.

--- a/docs/bigtable-data-api.rst
+++ b/docs/bigtable-data-api.rst
@@ -5,7 +5,7 @@ Data API
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 After creating a :class:`Table <gcloud.bigtable.table.Table>` and some
 column families, you are ready to store and retrieve data.

--- a/docs/bigtable-data-api.rst
+++ b/docs/bigtable-data-api.rst
@@ -1,6 +1,12 @@
 Data API
 ========
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 After creating a :class:`Table <gcloud.bigtable.table.Table>` and some
 column families, you are ready to store and retrieve data.
 

--- a/docs/bigtable-row-data.rst
+++ b/docs/bigtable-row-data.rst
@@ -5,7 +5,7 @@ Row Data
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.row_data
   :members:

--- a/docs/bigtable-row-data.rst
+++ b/docs/bigtable-row-data.rst
@@ -1,6 +1,12 @@
 Row Data
 ~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.row_data
   :members:
   :show-inheritance:

--- a/docs/bigtable-row-filters.rst
+++ b/docs/bigtable-row-filters.rst
@@ -5,7 +5,7 @@ Bigtable Row Filters
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 It is possible to use a
 :class:`RowFilter <gcloud.bigtable.row_filters.RowFilter>`

--- a/docs/bigtable-row-filters.rst
+++ b/docs/bigtable-row-filters.rst
@@ -1,6 +1,12 @@
 Bigtable Row Filters
 ====================
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 It is possible to use a
 :class:`RowFilter <gcloud.bigtable.row_filters.RowFilter>`
 when adding mutations to a

--- a/docs/bigtable-row.rst
+++ b/docs/bigtable-row.rst
@@ -5,7 +5,7 @@ Bigtable Row
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.row
   :members:

--- a/docs/bigtable-row.rst
+++ b/docs/bigtable-row.rst
@@ -1,6 +1,12 @@
 Bigtable Row
 ============
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.row
   :members:
   :show-inheritance:

--- a/docs/bigtable-table-api.rst
+++ b/docs/bigtable-table-api.rst
@@ -5,7 +5,7 @@ Table Admin API
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 After creating a :class:`Cluster <gcloud.bigtable.cluster.Cluster>`, you can
 interact with individual tables, groups of tables or column families within

--- a/docs/bigtable-table-api.rst
+++ b/docs/bigtable-table-api.rst
@@ -1,6 +1,12 @@
 Table Admin API
 ===============
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 After creating a :class:`Cluster <gcloud.bigtable.cluster.Cluster>`, you can
 interact with individual tables, groups of tables or column families within
 a table.

--- a/docs/bigtable-table.rst
+++ b/docs/bigtable-table.rst
@@ -1,6 +1,12 @@
 Table
 ~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.table
   :members:
   :show-inheritance:

--- a/docs/bigtable-table.rst
+++ b/docs/bigtable-table.rst
@@ -5,7 +5,7 @@ Table
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.table
   :members:

--- a/docs/bigtable-usage.rst
+++ b/docs/bigtable-usage.rst
@@ -5,7 +5,7 @@ Using the API
 
     `gRPC`_ is required for using the Cloud Bigtable API. As of May 2016,
     `grpcio`_ is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 API requests are sent to the `Google Cloud Bigtable`_ API via RPC over HTTP/2.
 In order to support this, we'll rely on `gRPC`_. We are working with the gRPC

--- a/docs/bigtable-usage.rst
+++ b/docs/bigtable-usage.rst
@@ -1,6 +1,12 @@
 Using the API
 =============
 
+.. warning::
+
+    `gRPC`_ is required for using the Cloud Bigtable API. As of May 2016,
+    `grpcio`_ is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 API requests are sent to the `Google Cloud Bigtable`_ API via RPC over HTTP/2.
 In order to support this, we'll rely on `gRPC`_. We are working with the gRPC
 team to rapidly make the install story more user-friendly.
@@ -23,3 +29,4 @@ In the hierarchy of API concepts
 
 .. _Google Cloud Bigtable: https://cloud.google.com/bigtable/docs/
 .. _gRPC: http://www.grpc.io/
+.. _grpcio: https://pypi.python.org/pypi/grpcio

--- a/docs/happybase-batch.rst
+++ b/docs/happybase-batch.rst
@@ -1,6 +1,12 @@
 HappyBase Batch
 ~~~~~~~~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.happybase.batch
   :members:
   :show-inheritance:

--- a/docs/happybase-batch.rst
+++ b/docs/happybase-batch.rst
@@ -5,7 +5,7 @@ HappyBase Batch
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.happybase.batch
   :members:

--- a/docs/happybase-connection.rst
+++ b/docs/happybase-connection.rst
@@ -1,6 +1,12 @@
 HappyBase Connection
 ~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.happybase.connection
   :members:
   :show-inheritance:

--- a/docs/happybase-connection.rst
+++ b/docs/happybase-connection.rst
@@ -5,7 +5,7 @@ HappyBase Connection
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.happybase.connection
   :members:

--- a/docs/happybase-package.rst
+++ b/docs/happybase-package.rst
@@ -5,7 +5,7 @@ HappyBase Package
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.happybase.__init__
   :members:

--- a/docs/happybase-package.rst
+++ b/docs/happybase-package.rst
@@ -1,6 +1,12 @@
 HappyBase Package
 ~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.happybase.__init__
   :members:
   :show-inheritance:

--- a/docs/happybase-pool.rst
+++ b/docs/happybase-pool.rst
@@ -1,6 +1,12 @@
 HappyBase Connection Pool
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.happybase.pool
   :members:
   :show-inheritance:

--- a/docs/happybase-pool.rst
+++ b/docs/happybase-pool.rst
@@ -5,7 +5,7 @@ HappyBase Connection Pool
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.happybase.pool
   :members:

--- a/docs/happybase-table.rst
+++ b/docs/happybase-table.rst
@@ -5,7 +5,7 @@ HappyBase Table
 
     gRPC is required for using the Cloud Bigtable API. As of May 2016,
     ``grpcio`` is only supported in Python 2.7, so importing
-    :mod:`gcloud.bigtable` will fail.
+    :mod:`gcloud.bigtable` in other versions of Python will fail.
 
 .. automodule:: gcloud.bigtable.happybase.table
   :members:

--- a/docs/happybase-table.rst
+++ b/docs/happybase-table.rst
@@ -1,6 +1,12 @@
 HappyBase Table
 ~~~~~~~~~~~~~~~
 
+.. warning::
+
+    gRPC is required for using the Cloud Bigtable API. As of May 2016,
+    ``grpcio`` is only supported in Python 2.7, so importing
+    :mod:`gcloud.bigtable` will fail.
+
 .. automodule:: gcloud.bigtable.happybase.table
   :members:
   :show-inheritance:

--- a/gcloud/bigtable/__init__.py
+++ b/gcloud/bigtable/__init__.py
@@ -16,3 +16,11 @@
 
 
 from gcloud.bigtable.client import Client
+
+try:
+    import grpc.beta.implementations
+except ImportError as exc:
+    message = ('gRPC is required for using the Cloud Bigtable API. '
+               'Importing the grpc library (grpcio in PyPI) has failed. '
+               'As of May 2016, grpcio is only supported in Python 2.7.')
+    raise ImportError(message, exc)

--- a/gcloud/bigtable/__init__.py
+++ b/gcloud/bigtable/__init__.py
@@ -17,10 +17,22 @@
 
 from gcloud.bigtable.client import Client
 
+
+_ERR_MSG = """\
+gRPC is required for using the Cloud Bigtable API, but
+importing the gRPC library (grpcio in PyPI) has failed.
+
+As of June 2016, grpcio is only supported in Python 2.7,
+which unfortunately means the Cloud Bigtable API isn't
+available if you're using Python 3 or Python < 2.7.
+
+If you're using Python 2.7 and importing / installing
+grpcio has failed, this likely means you have a non-standard version
+of Python installed. Check http://grpc.io if you're
+having trouble installing the grpcio package.
+"""
+
 try:
     import grpc.beta.implementations
-except ImportError as exc:
-    message = ('gRPC is required for using the Cloud Bigtable API. '
-               'Importing the grpc library (grpcio in PyPI) has failed. '
-               'As of May 2016, grpcio is only supported in Python 2.7.')
-    raise ImportError(message, exc)
+except ImportError as exc:  # pragma: NO COVER
+    raise ImportError(_ERR_MSG, exc)

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -126,9 +126,11 @@ def main():
     public_mods = set(public_mods)
 
     if not sphinx_mods <= public_mods:
-        message = ('Unexpected error. There were modules referenced by '
-                   'Sphinx that are not among the public modules.')
-        print(message, file=sys.stderr)
+        unexpected_mods = sphinx_mods - public_mods
+        message = ['Unexpected error. There were modules referenced by '
+                   'Sphinx that are not among the public modules.']
+        message.extend(['- %s' % (mod,) for mod in unexpected_mods])
+        print('\n'.join(message), file=sys.stderr)
         sys.exit(1)
 
     undocumented_mods = public_mods - sphinx_mods

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from setuptools import setup
 from setuptools import find_packages
@@ -22,6 +23,9 @@ GRPC_EXTRAS = [
     'grpcio == 0.13.1',
     'gax-google-pubsub-v1',
 ]
+
+if sys.version_info[:2] == (2, 7):
+    REQUIREMENTS.extend(GRPC_EXTRAS)
 
 setup(
     name='gcloud',


### PR DESCRIPTION
- Adding an import error with a nice failure message in `gcloud.bigtable` in the absence of `grpcio`
- Making `setup.py` include `grpcio` conditional on being Python 2.7
- Adding a warning to every single Bigtable docs page explaining that it can't be used outside of Python 2.7

/cc @jgeewax 