### PR TITLE
Fix 'Sink.from_api_repr'.

### DIFF
--- a/gcloud/logging/metric.py
+++ b/gcloud/logging/metric.py
@@ -14,37 +14,7 @@
 
 """Define Logging API Metrics."""
 
-import re
-
-from gcloud._helpers import _name_from_project_path
 from gcloud.exceptions import NotFound
-
-
-_METRIC_TEMPLATE = re.compile(r"""
-    projects/            # static prefix
-    (?P<project>[^/]+)   # initial letter, wordchars + hyphen
-    /metrics/            # static midfix
-    (?P<name>[^/]+)      # initial letter, wordchars + allowed punc
-""", re.VERBOSE)
-
-
-def _metric_name_from_path(path, project):
-    """Validate a metric URI path and get the metric name.
-
-    :type path: string
-    :param path: URI path for a metric API request.
-
-    :type project: string
-    :param project: The project associated with the request. It is
-                    included for validation purposes.
-
-    :rtype: string
-    :returns: Metric name parsed from ``path``.
-    :raises: :class:`ValueError` if the ``path`` is ill-formed or if
-             the project from the ``path`` does not agree with the
-             ``project`` passed in.
-    """
-    return _name_from_project_path(path, project, _METRIC_TEMPLATE)
 
 
 class Metric(object):

--- a/gcloud/logging/sink.py
+++ b/gcloud/logging/sink.py
@@ -14,34 +14,7 @@
 
 """Define Logging API Sinks."""
 
-import re
-
-from gcloud._helpers import _name_from_project_path
 from gcloud.exceptions import NotFound
-
-
-_SINK_TEMPLATE = re.compile(r"""
-    projects/            # static prefix
-    (?P<project>[^/]+)   # initial letter, wordchars + hyphen
-    /sinks/              # static midfix
-    (?P<name>[^/]+)      # initial letter, wordchars + allowed punc
-""", re.VERBOSE)
-
-
-def _sink_name_from_path(path, project):
-    """Validate a sink URI path and get the sink name.
-    :type path: string
-    :param path: URI path for a sink API request.
-    :type project: string
-    :param project: The project associated with the request. It is
-                    included for validation purposes.
-    :rtype: string
-    :returns: Metric name parsed from ``path``.
-    :raises: :class:`ValueError` if the ``path`` is ill-formed or if
-             the project from the ``path`` does not agree with the
-             ``project`` passed in.
-    """
-    return _name_from_project_path(path, project, _SINK_TEMPLATE)
 
 
 class Sink(object):
@@ -107,7 +80,7 @@ class Sink(object):
                  project from the resource does not agree with the project
                  from the client.
         """
-        sink_name = _sink_name_from_path(resource['name'], client.project)
+        sink_name = resource['name']
         filter_ = resource['filter']
         destination = resource['destination']
         return cls(sink_name, filter_, destination, client=client)

--- a/gcloud/logging/test_client.py
+++ b/gcloud/logging/test_client.py
@@ -210,9 +210,8 @@ class TestClient(unittest2.TestCase):
         TOKEN = 'TOKEN'
         SINK_NAME = 'sink_name'
         FILTER = 'logName:syslog AND severity>=ERROR'
-        SINK_PATH = 'projects/%s/sinks/%s' % (PROJECT, SINK_NAME)
         SINKS = [{
-            'name': SINK_PATH,
+            'name': SINK_NAME,
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]
@@ -238,11 +237,10 @@ class TestClient(unittest2.TestCase):
         PROJECT = 'PROJECT'
         SINK_NAME = 'sink_name'
         FILTER = 'logName:syslog AND severity>=ERROR'
-        SINK_PATH = 'projects/%s/sinks/%s' % (PROJECT, SINK_NAME)
         TOKEN = 'TOKEN'
         PAGE_SIZE = 42
         SINKS = [{
-            'name': SINK_PATH,
+            'name': SINK_NAME,
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]

--- a/gcloud/logging/test_metric.py
+++ b/gcloud/logging/test_metric.py
@@ -15,38 +15,6 @@
 import unittest2
 
 
-class Test__metric_name_from_path(unittest2.TestCase):
-
-    def _callFUT(self, path, project):
-        from gcloud.logging.metric import _metric_name_from_path
-        return _metric_name_from_path(path, project)
-
-    def test_invalid_path_length(self):
-        PATH = 'projects/foo'
-        PROJECT = None
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_path_format(self):
-        METRIC_NAME = 'METRIC_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'foo/%s/bar/%s' % (PROJECT, METRIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_project(self):
-        METRIC_NAME = 'METRIC_NAME'
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        PATH = 'projects/%s/metrics/%s' % (PROJECT1, METRIC_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT2)
-
-    def test_valid_data(self):
-        METRIC_NAME = 'METRIC_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/metrics/%s' % (PROJECT, METRIC_NAME)
-        metric_name = self._callFUT(PATH, PROJECT)
-        self.assertEqual(metric_name, METRIC_NAME)
-
-
 class TestMetric(unittest2.TestCase):
 
     PROJECT = 'test-project'

--- a/gcloud/logging/test_sink.py
+++ b/gcloud/logging/test_sink.py
@@ -15,38 +15,6 @@
 import unittest2
 
 
-class Test__sink_name_from_path(unittest2.TestCase):
-
-    def _callFUT(self, path, project):
-        from gcloud.logging.sink import _sink_name_from_path
-        return _sink_name_from_path(path, project)
-
-    def test_invalid_path_length(self):
-        PATH = 'projects/foo'
-        PROJECT = None
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_path_format(self):
-        SINK_NAME = 'SINK_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'foo/%s/bar/%s' % (PROJECT, SINK_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT)
-
-    def test_invalid_project(self):
-        SINK_NAME = 'SINK_NAME'
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        PATH = 'projects/%s/sinks/%s' % (PROJECT1, SINK_NAME)
-        self.assertRaises(ValueError, self._callFUT, PATH, PROJECT2)
-
-    def test_valid_data(self):
-        SINK_NAME = 'SINK_NAME'
-        PROJECT = 'PROJECT'
-        PATH = 'projects/%s/sinks/%s' % (PROJECT, SINK_NAME)
-        sink_name = self._callFUT(PATH, PROJECT)
-        self.assertEqual(sink_name, SINK_NAME)
-
-
 class TestSink(unittest2.TestCase):
 
     PROJECT = 'test-project'
@@ -78,7 +46,7 @@ class TestSink(unittest2.TestCase):
         client = _Client(project=self.PROJECT)
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
         RESOURCE = {
-            'name': FULL,
+            'name': self.SINK_NAME,
             'filter': self.FILTER,
             'destination': self.DESTINATION_URI,
         }
@@ -95,7 +63,7 @@ class TestSink(unittest2.TestCase):
         client = _Client(project=self.PROJECT)
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
         RESOURCE = {
-            'name': FULL,
+            'name': self.SINK_NAME,
             'filter': self.FILTER,
             'destination': self.DESTINATION_URI,
         }
@@ -107,20 +75,6 @@ class TestSink(unittest2.TestCase):
         self.assertTrue(sink._client is client)
         self.assertEqual(sink.project, self.PROJECT)
         self.assertEqual(sink.full_name, FULL)
-
-    def test_from_api_repr_with_mismatched_project(self):
-        PROJECT1 = 'PROJECT1'
-        PROJECT2 = 'PROJECT2'
-        client = _Client(project=PROJECT1)
-        FULL = 'projects/%s/sinks/%s' % (PROJECT2, self.SINK_NAME)
-        RESOURCE = {
-            'name': FULL,
-            'filter': self.FILTER,
-            'destination': self.DESTINATION_URI,
-        }
-        klass = self._getTargetClass()
-        self.assertRaises(ValueError, klass.from_api_repr,
-                          RESOURCE, client=client)
 
     def test_create_w_bound_client(self):
         client = _Client(project=self.PROJECT)

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -277,6 +277,20 @@ class TestLogging(unittest2.TestCase):
         self.to_delete.append(sink)
         self.assertTrue(sink.exists())
 
+    def test_list_sinks(self):
+        uri = self._init_storage_bucket()
+        sink = Config.CLIENT.sink(DEFAULT_SINK_NAME, DEFAULT_FILTER, uri)
+        self.assertFalse(sink.exists())
+        before_sinks, _ = Config.CLIENT.list_sinks()
+        before_names = set(sink.name for sink in before_sinks)
+        sink.create()
+        self.to_delete.append(sink)
+        self.assertTrue(sink.exists())
+        after_sinks, _ = Config.CLIENT.list_sinks()
+        after_names = set(sink.name for sink in after_sinks)
+        self.assertEqual(after_names - before_names,
+                         set([DEFAULT_SINK_NAME]))
+
     def test_reload_sink(self):
         uri = self._init_bigquery_dataset()
         sink = Config.CLIENT.sink(DEFAULT_SINK_NAME, DEFAULT_FILTER, uri)


### PR DESCRIPTION
Resource's `name` field is not a path (like metric).

Also, drop the no-longer-needed name-from-path regexps/helpers for metric and sink.

Add a system test for `Client.list_sinks` which exercises `Sink.from_api_repr` against real resource data.

Closes #1817.