### PR TITLE
Dry Run for bigquery queries

### DIFF
--- a/gcloud/bigquery/query.py
+++ b/gcloud/bigquery/query.py
@@ -29,6 +29,7 @@ class _SyncQueryConfiguration(object):
     Values which are ``None`` -> server defaults.
     """
     _default_dataset = None
+    _dry_run = None
     _max_results = None
     _timeout_ms = None
     _preserve_nulls = None
@@ -207,6 +208,11 @@ class QueryResults(object):
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#defaultDataset
     """
 
+    dry_run = _TypedProperty('dry_run', bool)
+    """See:
+    https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#dryRun
+    """
+
     max_results = _TypedProperty('max_results', six.integer_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#maxResults
@@ -257,6 +263,9 @@ class QueryResults(object):
 
         if self.use_query_cache is not None:
             resource['useQueryCache'] = self.use_query_cache
+
+        if self.dry_run is not None:
+            resource['dryRun'] = self.dry_run
 
         return resource
 

--- a/gcloud/bigquery/test_query.py
+++ b/gcloud/bigquery/test_query.py
@@ -206,6 +206,7 @@ class TestQueryResults(unittest2.TestCase):
         query.preserve_nulls = True
         query.timeout_ms = 20000
         query.use_query_cache = False
+        query.dry_run = True
 
         query.run(client=client2)
 
@@ -220,6 +221,7 @@ class TestQueryResults(unittest2.TestCase):
                 'projectId': self.PROJECT,
                 'datasetId': DATASET,
             },
+            'dryRun': True,
             'maxResults': 100,
             'preserveNulls': True,
             'timeoutMs': 20000,


### PR DESCRIPTION
Hi,

I needed to get an estimated cost for some bigquery queries and found that there is a dryRun option for queries.

Unfortunately the dryRun option wasn't exposed via gcloud, so here is a PR to add that ability.

Thanks