### PR TITLE
Wrapping gRPC "already exists" with a HappyBase exception.

### DIFF
--- a/_testing/grpc/beta/interfaces.py
+++ b/_testing/grpc/beta/interfaces.py
@@ -1,0 +1,13 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/_testing/grpc/framework/interfaces/face/face.py
+++ b/_testing/grpc/framework/interfaces/face/face.py
@@ -1,0 +1,13 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -22,6 +22,11 @@ from grpc.beta import interfaces
 from grpc.framework.interfaces.face import face
 import six
 
+try:
+    from happybase.hbase.ttypes import AlreadyExists
+except ImportError:
+    from gcloud.exceptions import Conflict as AlreadyExists
+
 from gcloud.bigtable.client import Client
 from gcloud.bigtable.column_family import GCRuleIntersection
 from gcloud.bigtable.column_family import MaxAgeGCRule
@@ -344,8 +349,7 @@ class Connection(object):
             low_level_table.create()
         except face.NetworkError as network_err:
             if network_err.code == interfaces.StatusCode.ALREADY_EXISTS:
-                from happybase.hbase import ttypes
-                raise ttypes.AlreadyExists(name)
+                raise AlreadyExists(name)
             else:
                 raise
 

--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -18,9 +18,10 @@
 import datetime
 import warnings
 
+import six
+
 from grpc.beta import interfaces
 from grpc.framework.interfaces.face import face
-import six
 
 try:
     from happybase.hbase.ttypes import AlreadyExists

--- a/gcloud/bigtable/happybase/connection.py
+++ b/gcloud/bigtable/happybase/connection.py
@@ -18,6 +18,8 @@
 import datetime
 import warnings
 
+from grpc.beta import interfaces
+from grpc.framework.interfaces.face import face
 import six
 
 from gcloud.bigtable.client import Client
@@ -338,7 +340,14 @@ class Connection(object):
         # Create table instance and then make API calls.
         name = self._table_name(name)
         low_level_table = _LowLevelTable(name, self._cluster)
-        low_level_table.create()
+        try:
+            low_level_table.create()
+        except face.NetworkError as network_err:
+            if network_err.code == interfaces.StatusCode.ALREADY_EXISTS:
+                from happybase.hbase import ttypes
+                raise ttypes.AlreadyExists(name)
+            else:
+                raise
 
         for column_family_name, gc_rule in gc_rule_dict.items():
             column_family = low_level_table.column_family(

--- a/gcloud/bigtable/happybase/test_connection.py
+++ b/gcloud/bigtable/happybase/test_connection.py
@@ -422,11 +422,11 @@ class TestConnection(unittest2.TestCase):
     def test_create_table_already_exists(self):
         from grpc.beta import interfaces
         from grpc.framework.interfaces.face import face
-        from happybase.hbase import ttypes
+        from gcloud.bigtable.happybase.connection import AlreadyExists
 
         err_val = face.NetworkError(None, None,
                                     interfaces.StatusCode.ALREADY_EXISTS, None)
-        self._create_table_error_helper(err_val, ttypes.AlreadyExists)
+        self._create_table_error_helper(err_val, AlreadyExists)
 
     def test_create_table_connection_error(self):
         from grpc.beta import interfaces

--- a/gcloud/bigtable/happybase/test_connection.py
+++ b/gcloud/bigtable/happybase/test_connection.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import sys
+
 import unittest2
 
 
@@ -419,6 +421,8 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(len(tables_created), 1)
         self.assertEqual(tables_created[0].create_calls, 1)
 
+    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
+                          'gRPC only in Python 2.7')
     def test_create_table_already_exists(self):
         from grpc.beta import interfaces
         from grpc.framework.interfaces.face import face
@@ -428,6 +432,8 @@ class TestConnection(unittest2.TestCase):
                                     interfaces.StatusCode.ALREADY_EXISTS, None)
         self._create_table_error_helper(err_val, AlreadyExists)
 
+    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
+                          'gRPC only in Python 2.7')
     def test_create_table_connection_error(self):
         from grpc.beta import interfaces
         from grpc.framework.interfaces.face import face
@@ -435,6 +441,8 @@ class TestConnection(unittest2.TestCase):
                                     interfaces.StatusCode.INTERNAL, None)
         self._create_table_error_helper(err_val, face.NetworkError)
 
+    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
+                          'gRPC only in Python 2.7')
     def test_create_table_other_error(self):
         self._create_table_error_helper(RuntimeError, RuntimeError)
 


### PR DESCRIPTION
Fixes #1818.

NOTE: For now I just used a `happybase` import so that I could get the tests passing locally via `nosetests`. However, these tests will fail on Travis. I don't think we should take on the [Happybase][1] library as a dependency. Maybe @tswast has some opinions?

Potential option: try to import it (like we do with `pytz` / `pandas` / etc.) and then use it if it's there for the "native" exception

/cc @tswast 

[1]: https://pypi.python.org/pypi/happybase