### PR TITLE
logger.list_entries optimization using equals  and docs update

### DIFF
--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -65,8 +65,8 @@ Fetch entries for the default project.
    >>> entries, token = client.list_entries()  # API call
    >>> for entry in entries:
    ...    timestamp = entry.timestamp.isoformat()
-   ...    print('%sZ: %s | %s' %
-   ...          (timestamp, entry.text_payload, entry.struct_payload))
+   ...    print('%sZ: %s' %
+   ...          (timestamp, entry.payload))
    2016-02-17T20:35:49.031864072Z: A simple entry | None
    2016-02-17T20:38:15.944418531Z: None | {'message': 'My second entry', 'weather': 'partly cloudy'}
 
@@ -129,7 +129,7 @@ Delete all entries for a logger
    >>> from gcloud import logging
    >>> client = logging.Client()
    >>> logger = client.logger('log_name')
-   >>> logger.delete_entries()  # API call
+   >>> logger.delete()  # API call
 
 
 Manage log metrics
@@ -220,8 +220,8 @@ Create a Cloud Storage sink:
    >>> client = logging.Client()
    >>> sink = client.sink(
    ...     "robots-storage",
-   ...     filter='log:apache-access AND textPayload:robot')
-   >>> sink.storage_bucket = "my-bucket-name"
+   ...     'log:apache-access AND textPayload:robot',
+   ...     'storage.googleapis.com/my-bucket-name')
    >>> sink.exists()  # API call
    False
    >>> sink.create()  # API call
@@ -236,8 +236,8 @@ Create a BigQuery sink:
    >>> client = logging.Client()
    >>> sink = client.sink(
    ...     "robots-bq",
-   ...     filter='log:apache-access AND textPayload:robot')
-   >>> sink.bigquery_dataset = "projects/my-project/datasets/my-dataset"
+   ...     'log:apache-access AND textPayload:robot',
+   ...     'bigquery.googleapis.com/projects/projects/my-project/datasets/my-dataset')
    >>> sink.exists()  # API call
    False
    >>> sink.create()  # API call
@@ -250,10 +250,11 @@ Create a Cloud Pub/Sub sink:
 
    >>> from gcloud import logging
    >>> client = logging.Client()
+
    >>> sink = client.sink(
    ...     "robots-pubsub",
-   ...     filter='log:apache-access AND textPayload:robot')
-   >>> sink.pubsub_topic = 'projects/my-project/topics/my-topic'
+   ...      'log:apache-access AND textPayload:robot',
+   ...      'pubsub.googleapis.com/projects/my-project/topics/my-topic')
    >>> sink.exists()  # API call
    False
    >>> sink.create()  # API call

--- a/gcloud/logging/logger.py
+++ b/gcloud/logging/logger.py
@@ -298,7 +298,7 @@ class Logger(object):
                   more entries can be retrieved with another call (pass that
                   value as ``page_token``).
         """
-        log_filter = 'logName:%s' % (self.name,)
+        log_filter = 'logName=%s' % (self.full_name,)
         if filter_ is not None:
             filter_ = '%s AND %s' % (filter_, log_filter)
         else:

--- a/gcloud/logging/test_logger.py
+++ b/gcloud/logging/test_logger.py
@@ -348,7 +348,8 @@ class TestLogger(unittest2.TestCase):
     def test_list_entries_defaults(self):
         LISTED = {
             'projects': None,
-            'filter_': 'logName:%s' % (self.LOGGER_NAME),
+            'filter_': 'logName=projects/%s/logs/%s' %
+                       (self.PROJECT, self.LOGGER_NAME),
             'order_by': None,
             'page_size': None,
             'page_token': None,
@@ -371,7 +372,8 @@ class TestLogger(unittest2.TestCase):
         PAGE_SIZE = 42
         LISTED = {
             'projects': ['PROJECT1', 'PROJECT2'],
-            'filter_': '%s AND logName:%s' % (FILTER, self.LOGGER_NAME),
+            'filter_': '%s AND logName=projects/%s/logs/%s' %
+                       (FILTER, self.PROJECT, self.LOGGER_NAME),
             'order_by': DESCENDING,
             'page_size': PAGE_SIZE,
             'page_token': TOKEN,


### PR DESCRIPTION
Two changes here:

logger.list_entries() was using just the logger name rather than the fully qualified name, you can see an example on [the docs ](https://cloud.google.com/logging/docs/view/advanced_filters#names)that from v1 to v2 the change from log to logName also changed to expect fully qualified name.

The query was also using the colon operator, which is a "has" operator. Problem 1 is that this is a slower query because it's not indexed, problem 2 is that I'm pretty sure there's a bug because it's not working.

Second set of changes is the docs, just some random small discrepancies between them and the actual API. The biggest discrepancy was in the Sink constructor, the samples all use keyword arguments and special names for different sink types, the actual code seems to take these all as general positional arguments.