### PR TITLE
More gax paging fixes

### DIFF
--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -165,12 +165,14 @@ class _PublisherAPI(object):
         message_pbs = [_message_pb_from_dict(message)
                        for message in messages]
         try:
-            response = self._gax_api.publish(topic_path, message_pbs)
+            event = self._gax_api.publish(topic_path, message_pbs)
+            if not event.is_set():
+                event.wait()
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
             raise
-        return response.message_ids
+        return event.result.message_ids
 
     def topic_list_subscriptions(self, topic_path, page_size=0,
                                  page_token=None):

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -217,8 +217,8 @@ class _PublisherAPI(object):
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :type page_size: int
-        :param page_size: maximum number of topics to return, If not passed,
-                          defaults to a value set by the API.
+        :param page_size: maximum number of subscriptions to return, If not
+                          passed, defaults to a value set by the API.
 
         :type page_token: string
         :param page_token: opaque marker for the next "page" of topics. If not


### PR DESCRIPTION
Work toward fixing Pubsub system tests using GAX.

Correcting incomplete fixes in #1855.

Note that `Topic.pull` is still problematic (#1869).