### PR TITLE
Disable pubsub-over-gax by default.

### DIFF
--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -39,7 +39,7 @@ else:
     _HAVE_GAX = True
 
 
-_USE_GAX = _HAVE_GAX and os.environ.get('GCLOUD_DISABLE_GAX') is None
+_USE_GAX = _HAVE_GAX and (os.environ.get('GCLOUD_ENABLE_GAX') is not None)
 
 
 class Client(JSONClient):


### PR DESCRIPTION
Re-enable via environment variable, 'GCLOUD_ENABLE_GAX'.

See #1873 for post-0.16.0 follow-up.