### PR TITLE
Add tox cover task to travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - tox -e py26
   - tox -e py27
   - tox -e py34
+  - tox -e cover
   - tox -e lint
   - tox -e system-tests
   - tox -e system-tests3


### PR DESCRIPTION
Running the `cover` task in the travis build process will catch what coveralls.io misses in code branch coverage.