### PR TITLE
Drop Python 2.6 on appveyor, install 'grpcio' unconditionally.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,29 +13,16 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    # Python 2.6.6 is the latest Python 2.6 with a Windows installer
-    # Python 2.6.9 is the overall latest
-    # https://www.python.org/ftp/python/2.6.6/
-    - PYTHON: "C:\\Python26"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python26-x64"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
-
     # Python 2.7.11 is the latest Python 2.7 with a Windows installer
     # Python 2.7.11 is the overall latest
     # https://www.python.org/ftp/python/2.7.11/
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "32"
-      INSTALL_GRPC: "1"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "64"
-      INSTALL_GRPC: "1"
 
     # Python 3.4.4 is the latest Python 3.4 with a Windows installer
     # Python 3.4.4 is the overall latest
@@ -87,10 +74,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install wheel nose nose-exclude unittest2 cryptography"
-
-  # Work around https://github.com/grpc/grpc/issues/6939
-  - '%CMD_IN_ENV% if "%INSTALL_GRPC%"=="1" (pip install grpcio)'
+  - "%CMD_IN_ENV% pip install wheel nose nose-exclude unittest2 cryptography grpcio"
 
 build_script:
   # Build the compiled extension


### PR DESCRIPTION
`grpcio` 0.14.0 installs without errors on Python 3.4+.

See #1863, failures after merging #1877.