### PR TITLE
Adjust anchor scroll in docs to show actual line.

### DIFF
--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -23,6 +23,14 @@ html {
     line-height: 1.4;
 }
 
+*[id]:before {
+  display: block;
+  content: " ";
+  margin-top: -70px;
+  height: 70px;
+  visibility: hidden;
+}
+
 /*
  * Remove text-shadow in selection highlight: h5bp.com/i
  * These selection rule sets have to be separate.


### PR DESCRIPTION
The fixed header isn't accounted for when scrolling to anchor points so the original anchor text is obscured.

I would actually prefer to remove the fixed header instead of merging this PR. If it's ok to remove the fixed header let me know and I can do that instead!