### PR TITLE
Drop 'Table.rename'.

### DIFF
--- a/docs/bigtable-table-api.rst
+++ b/docs/bigtable-table-api.rst
@@ -65,17 +65,6 @@ Make a `DeleteTable`_ API request with
 
     table.delete()
 
-Rename an existing Table
-------------------------
-
-Though the `RenameTable`_ API request is listed in the service
-definition, requests to that method return::
-
-    BigtableTableService.RenameTable is not yet implemented
-
-We have implemented :meth:`rename() <gcloud.bigtable.table.Table.rename>`
-but it will not work unless the backend supports the method.
-
 List Column Families in a Table
 -------------------------------
 

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -176,36 +176,6 @@ class Table(object):
         # We expect a `._generated.bigtable_table_data_pb2.Table`
         client._table_stub.CreateTable(request_pb, client.timeout_seconds)
 
-    def rename(self, new_table_id):
-        """Rename this table.
-
-        .. note::
-
-            This cannot be used to move tables between clusters,
-            zones, or projects.
-
-        .. note::
-
-            The Bigtable Table Admin API currently (``v1``) returns
-
-                ``BigtableTableService.RenameTable is not yet implemented``
-
-            when this method is used. It's unclear when this method will
-            actually be supported by the API.
-
-        :type new_table_id: str
-        :param new_table_id: The new name table ID.
-        """
-        request_pb = messages_pb2.RenameTableRequest(
-            name=self.name,
-            new_id=new_table_id,
-        )
-        client = self._cluster._client
-        # We expect a `google.protobuf.empty_pb2.Empty`
-        client._table_stub.RenameTable(request_pb, client.timeout_seconds)
-
-        self.table_id = new_table_id
-
     def delete(self):
         """Delete this table."""
         request_pb = messages_pb2.DeleteTableRequest(name=self.name)

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -176,51 +176,6 @@ class TestTable(unittest2.TestCase):
         initial_split_keys = ['s1', 's2']
         self._create_test_helper(initial_split_keys)
 
-    def test_rename(self):
-        from google.protobuf import empty_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_service_messages_pb2 as messages_pb2)
-        from gcloud.bigtable._testing import _FakeStub
-
-        project_id = 'project-id'
-        zone = 'zone'
-        cluster_id = 'cluster-id'
-        table_id = 'table-id'
-        new_table_id = 'new_table_id'
-        timeout_seconds = 97
-        self.assertNotEqual(new_table_id, table_id)
-
-        client = _Client(timeout_seconds=timeout_seconds)
-        cluster_name = ('projects/' + project_id + '/zones/' + zone +
-                        '/clusters/' + cluster_id)
-        cluster = _Cluster(cluster_name, client=client)
-        table = self._makeOne(table_id, cluster)
-
-        # Create request_pb
-        table_name = cluster_name + '/tables/' + table_id
-        request_pb = messages_pb2.RenameTableRequest(
-            name=table_name,
-            new_id=new_table_id,
-        )
-
-        # Create response_pb
-        response_pb = empty_pb2.Empty()
-
-        # Patch the stub used by the API method.
-        client._table_stub = stub = _FakeStub(response_pb)
-
-        # Create expected_result.
-        expected_result = None  # rename() has no return value.
-
-        # Perform the method and check the result.
-        result = table.rename(new_table_id)
-        self.assertEqual(result, expected_result)
-        self.assertEqual(stub.method_calls, [(
-            'RenameTable',
-            (request_pb, timeout_seconds),
-            {},
-        )])
-
     def _list_column_families_helper(self, column_family_name=None):
         from gcloud.bigtable._generated import (
             bigtable_table_data_pb2 as data_pb2)

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -232,25 +232,6 @@ class TestTableAdminAPI(unittest2.TestCase):
         sorted_tables = sorted(tables, key=name_attr)
         self.assertEqual(sorted_tables, expected_tables)
 
-    def test_rename_table(self):
-        from grpc.beta import interfaces
-        from grpc.framework.interfaces.face import face
-
-        temp_table_id = 'foo-bar-baz-table'
-        temp_table = Config.CLUSTER.table(temp_table_id)
-        temp_table.create()
-        self.tables_to_delete.append(temp_table)
-
-        with self.assertRaises(face.LocalError) as exc_manager:
-            temp_table.rename(temp_table_id + '-alt')
-        exc_caught = exc_manager.exception
-        self.assertNotEqual(exc_caught, None)
-        self.assertEqual(exc_caught.code,
-                         interfaces.StatusCode.UNIMPLEMENTED)
-        self.assertEqual(
-            exc_caught.details,
-            'BigtableTableService.RenameTable is not yet implemented')
-
     def test_create_column_family(self):
         temp_table_id = 'foo-bar-baz-table'
         temp_table = Config.CLUSTER.table(temp_table_id)


### PR DESCRIPTION
It was never actually implemented on the back-end in V1, and has been dropped altogether in V2.