### PR TITLE
Update bigtable.column_family to use V2 protos

### DIFF
--- a/gcloud/bigtable/column_family.py
+++ b/gcloud/bigtable/column_family.py
@@ -20,10 +20,10 @@ import datetime
 from google.protobuf import duration_pb2
 
 from gcloud._helpers import _total_seconds
-from gcloud.bigtable._generated import (
-    bigtable_table_data_pb2 as data_v1_pb2)
-from gcloud.bigtable._generated import (
-    bigtable_table_service_messages_pb2 as messages_v1_pb2)
+from gcloud.bigtable._generated_v2 import (
+    table_pb2 as table_v2_pb2)
+from gcloud.bigtable._generated_v2 import (
+    bigtable_table_admin_pb2 as table_admin_v2_pb2)
 
 
 def _timedelta_to_duration_pb(timedelta_val):
@@ -111,10 +111,10 @@ class MaxVersionsGCRule(GarbageCollectionRule):
     def to_pb(self):
         """Converts the garbage collection rule to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.GcRule`
+        :rtype: :class:`.table_v2_pb2.GcRule`
         :returns: The converted current object.
         """
-        return data_v1_pb2.GcRule(max_num_versions=self.max_num_versions)
+        return table_v2_pb2.GcRule(max_num_versions=self.max_num_versions)
 
 
 class MaxAgeGCRule(GarbageCollectionRule):
@@ -135,11 +135,11 @@ class MaxAgeGCRule(GarbageCollectionRule):
     def to_pb(self):
         """Converts the garbage collection rule to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.GcRule`
+        :rtype: :class:`.table_v2_pb2.GcRule`
         :returns: The converted current object.
         """
         max_age = _timedelta_to_duration_pb(self.max_age)
-        return data_v1_pb2.GcRule(max_age=max_age)
+        return table_v2_pb2.GcRule(max_age=max_age)
 
 
 class GCRuleUnion(GarbageCollectionRule):
@@ -160,12 +160,12 @@ class GCRuleUnion(GarbageCollectionRule):
     def to_pb(self):
         """Converts the union into a single GC rule as a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.GcRule`
+        :rtype: :class:`.table_v2_pb2.GcRule`
         :returns: The converted current object.
         """
-        union = data_v1_pb2.GcRule.Union(
+        union = table_v2_pb2.GcRule.Union(
             rules=[rule.to_pb() for rule in self.rules])
-        return data_v1_pb2.GcRule(union=union)
+        return table_v2_pb2.GcRule(union=union)
 
 
 class GCRuleIntersection(GarbageCollectionRule):
@@ -186,12 +186,12 @@ class GCRuleIntersection(GarbageCollectionRule):
     def to_pb(self):
         """Converts the intersection into a single GC rule as a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.GcRule`
+        :rtype: :class:`.table_v2_pb2.GcRule`
         :returns: The converted current object.
         """
-        intersection = data_v1_pb2.GcRule.Intersection(
+        intersection = table_v2_pb2.GcRule.Intersection(
             rules=[rule.to_pb() for rule in self.rules])
-        return data_v1_pb2.GcRule(intersection=intersection)
+        return table_v2_pb2.GcRule(intersection=intersection)
 
 
 class ColumnFamily(object):
@@ -251,21 +251,22 @@ class ColumnFamily(object):
     def create(self):
         """Create this column family."""
         if self.gc_rule is None:
-            column_family = data_v1_pb2.ColumnFamily()
+            column_family = table_v2_pb2.ColumnFamily()
         else:
-            column_family = data_v1_pb2.ColumnFamily(
+            column_family = table_v2_pb2.ColumnFamily(
                 gc_rule=self.gc_rule.to_pb())
-        request_pb = messages_v1_pb2.CreateColumnFamilyRequest(
-            name=self._table.name,
-            column_family_id=self.column_family_id,
-            column_family=column_family,
+        request_pb = table_admin_v2_pb2.ModifyColumnFamiliesRequest(
+            name=self._table.name)
+        request_pb.modifications.add(
+            id=self.column_family_id,
+            create=column_family,
         )
         client = self._table._cluster._client
-        # We expect a `.data_v1_pb2.ColumnFamily`. We ignore it since the only
+        # We expect a `.table_v2_pb2.ColumnFamily`. We ignore it since the only
         # data it contains are the GC rule and the column family ID already
         # stored on this instance.
-        client._table_stub.CreateColumnFamily(request_pb,
-                                              client.timeout_seconds)
+        client._table_stub.ModifyColumnFamilies(request_pb,
+                                                client.timeout_seconds)
 
     def update(self):
         """Update this column family.
@@ -275,30 +276,40 @@ class ColumnFamily(object):
             Only the GC rule can be updated. By changing the column family ID,
             you will simply be referring to a different column family.
         """
-        request_kwargs = {'name': self.name}
-        if self.gc_rule is not None:
-            request_kwargs['gc_rule'] = self.gc_rule.to_pb()
-        request_pb = data_v1_pb2.ColumnFamily(**request_kwargs)
+        if self.gc_rule is None:
+            column_family = table_v2_pb2.ColumnFamily()
+        else:
+            column_family = table_v2_pb2.ColumnFamily(
+                gc_rule=self.gc_rule.to_pb())
+        request_pb = table_admin_v2_pb2.ModifyColumnFamiliesRequest(
+            name=self._table.name)
+        request_pb.modifications.add(
+            id=self.column_family_id,
+            update=column_family)
         client = self._table._cluster._client
-        # We expect a `.data_v1_pb2.ColumnFamily`. We ignore it since the only
+        # We expect a `.table_v2_pb2.ColumnFamily`. We ignore it since the only
         # data it contains are the GC rule and the column family ID already
         # stored on this instance.
-        client._table_stub.UpdateColumnFamily(request_pb,
-                                              client.timeout_seconds)
+        client._table_stub.ModifyColumnFamilies(request_pb,
+                                                client.timeout_seconds)
 
     def delete(self):
         """Delete this column family."""
-        request_pb = messages_v1_pb2.DeleteColumnFamilyRequest(name=self.name)
+        request_pb = table_admin_v2_pb2.ModifyColumnFamiliesRequest(
+            name=self._table.name)
+        request_pb.modifications.add(
+            id=self.column_family_id,
+            drop=True)
         client = self._table._cluster._client
         # We expect a `google.protobuf.empty_pb2.Empty`
-        client._table_stub.DeleteColumnFamily(request_pb,
-                                              client.timeout_seconds)
+        client._table_stub.ModifyColumnFamilies(request_pb,
+                                                client.timeout_seconds)
 
 
 def _gc_rule_from_pb(gc_rule_pb):
     """Convert a protobuf GC rule to a native object.
 
-    :type gc_rule_pb: :class:`.data_v1_pb2.GcRule`
+    :type gc_rule_pb: :class:`.table_v2_pb2.GcRule`
     :param gc_rule_pb: The GC rule to convert.
 
     :rtype: :class:`GarbageCollectionRule` or :data:`NoneType <types.NoneType>`

--- a/gcloud/bigtable/test_column_family.py
+++ b/gcloud/bigtable/test_column_family.py
@@ -107,12 +107,10 @@ class TestMaxVersionsGCRule(unittest2.TestCase):
         self.assertFalse(comparison_val)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         max_num_versions = 1337
         gc_rule = self._makeOne(max_num_versions=max_num_versions)
         pb_val = gc_rule.to_pb()
-        expected = data_v1_pb2.GcRule(max_num_versions=max_num_versions)
+        expected = _GcRulePB(max_num_versions=max_num_versions)
         self.assertEqual(pb_val, expected)
 
 
@@ -147,14 +145,12 @@ class TestMaxAgeGCRule(unittest2.TestCase):
     def test_to_pb(self):
         import datetime
         from google.protobuf import duration_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
 
         max_age = datetime.timedelta(seconds=1)
         duration = duration_pb2.Duration(seconds=1)
         gc_rule = self._makeOne(max_age=max_age)
         pb_val = gc_rule.to_pb()
-        self.assertEqual(pb_val, data_v1_pb2.GcRule(max_age=duration))
+        self.assertEqual(pb_val, _GcRulePB(max_age=duration))
 
 
 class TestGCRuleUnion(unittest2.TestCase):
@@ -193,23 +189,21 @@ class TestGCRuleUnion(unittest2.TestCase):
     def test_to_pb(self):
         import datetime
         from google.protobuf import duration_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.column_family import MaxAgeGCRule
         from gcloud.bigtable.column_family import MaxVersionsGCRule
 
         max_num_versions = 42
         rule1 = MaxVersionsGCRule(max_num_versions)
-        pb_rule1 = data_v1_pb2.GcRule(max_num_versions=max_num_versions)
+        pb_rule1 = _GcRulePB(max_num_versions=max_num_versions)
 
         max_age = datetime.timedelta(seconds=1)
         rule2 = MaxAgeGCRule(max_age)
-        pb_rule2 = data_v1_pb2.GcRule(
+        pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
         rule3 = self._makeOne(rules=[rule1, rule2])
-        pb_rule3 = data_v1_pb2.GcRule(
-            union=data_v1_pb2.GcRule.Union(rules=[pb_rule1, pb_rule2]))
+        pb_rule3 = _GcRulePB(
+            union=_GcRuleUnionPB(rules=[pb_rule1, pb_rule2]))
 
         gc_rule_pb = rule3.to_pb()
         self.assertEqual(gc_rule_pb, pb_rule3)
@@ -217,31 +211,29 @@ class TestGCRuleUnion(unittest2.TestCase):
     def test_to_pb_nested(self):
         import datetime
         from google.protobuf import duration_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.column_family import MaxAgeGCRule
         from gcloud.bigtable.column_family import MaxVersionsGCRule
 
         max_num_versions1 = 42
         rule1 = MaxVersionsGCRule(max_num_versions1)
-        pb_rule1 = data_v1_pb2.GcRule(max_num_versions=max_num_versions1)
+        pb_rule1 = _GcRulePB(max_num_versions=max_num_versions1)
 
         max_age = datetime.timedelta(seconds=1)
         rule2 = MaxAgeGCRule(max_age)
-        pb_rule2 = data_v1_pb2.GcRule(
+        pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
         rule3 = self._makeOne(rules=[rule1, rule2])
-        pb_rule3 = data_v1_pb2.GcRule(
-            union=data_v1_pb2.GcRule.Union(rules=[pb_rule1, pb_rule2]))
+        pb_rule3 = _GcRulePB(
+            union=_GcRuleUnionPB(rules=[pb_rule1, pb_rule2]))
 
         max_num_versions2 = 1337
         rule4 = MaxVersionsGCRule(max_num_versions2)
-        pb_rule4 = data_v1_pb2.GcRule(max_num_versions=max_num_versions2)
+        pb_rule4 = _GcRulePB(max_num_versions=max_num_versions2)
 
         rule5 = self._makeOne(rules=[rule3, rule4])
-        pb_rule5 = data_v1_pb2.GcRule(
-            union=data_v1_pb2.GcRule.Union(rules=[pb_rule3, pb_rule4]))
+        pb_rule5 = _GcRulePB(
+            union=_GcRuleUnionPB(rules=[pb_rule3, pb_rule4]))
 
         gc_rule_pb = rule5.to_pb()
         self.assertEqual(gc_rule_pb, pb_rule5)
@@ -283,23 +275,21 @@ class TestGCRuleIntersection(unittest2.TestCase):
     def test_to_pb(self):
         import datetime
         from google.protobuf import duration_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.column_family import MaxAgeGCRule
         from gcloud.bigtable.column_family import MaxVersionsGCRule
 
         max_num_versions = 42
         rule1 = MaxVersionsGCRule(max_num_versions)
-        pb_rule1 = data_v1_pb2.GcRule(max_num_versions=max_num_versions)
+        pb_rule1 = _GcRulePB(max_num_versions=max_num_versions)
 
         max_age = datetime.timedelta(seconds=1)
         rule2 = MaxAgeGCRule(max_age)
-        pb_rule2 = data_v1_pb2.GcRule(
+        pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
         rule3 = self._makeOne(rules=[rule1, rule2])
-        pb_rule3 = data_v1_pb2.GcRule(
-            intersection=data_v1_pb2.GcRule.Intersection(
+        pb_rule3 = _GcRulePB(
+            intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule1, pb_rule2]))
 
         gc_rule_pb = rule3.to_pb()
@@ -308,32 +298,30 @@ class TestGCRuleIntersection(unittest2.TestCase):
     def test_to_pb_nested(self):
         import datetime
         from google.protobuf import duration_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.column_family import MaxAgeGCRule
         from gcloud.bigtable.column_family import MaxVersionsGCRule
 
         max_num_versions1 = 42
         rule1 = MaxVersionsGCRule(max_num_versions1)
-        pb_rule1 = data_v1_pb2.GcRule(max_num_versions=max_num_versions1)
+        pb_rule1 = _GcRulePB(max_num_versions=max_num_versions1)
 
         max_age = datetime.timedelta(seconds=1)
         rule2 = MaxAgeGCRule(max_age)
-        pb_rule2 = data_v1_pb2.GcRule(
+        pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
         rule3 = self._makeOne(rules=[rule1, rule2])
-        pb_rule3 = data_v1_pb2.GcRule(
-            intersection=data_v1_pb2.GcRule.Intersection(
+        pb_rule3 = _GcRulePB(
+            intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule1, pb_rule2]))
 
         max_num_versions2 = 1337
         rule4 = MaxVersionsGCRule(max_num_versions2)
-        pb_rule4 = data_v1_pb2.GcRule(max_num_versions=max_num_versions2)
+        pb_rule4 = _GcRulePB(max_num_versions=max_num_versions2)
 
         rule5 = self._makeOne(rules=[rule3, rule4])
-        pb_rule5 = data_v1_pb2.GcRule(
-            intersection=data_v1_pb2.GcRule.Intersection(
+        pb_rule5 = _GcRulePB(
+            intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule3, pb_rule4]))
 
         gc_rule_pb = rule5.to_pb()
@@ -402,8 +390,6 @@ class TestColumnFamily(unittest2.TestCase):
 
     def _create_test_helper(self, gc_rule=None):
         from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
-        from gcloud.bigtable._generated import (
             bigtable_table_service_messages_pb2 as messages_v1_pb2)
         from gcloud.bigtable._testing import _FakeStub
 
@@ -423,9 +409,9 @@ class TestColumnFamily(unittest2.TestCase):
 
         # Create request_pb
         if gc_rule is None:
-            column_family_pb = data_v1_pb2.ColumnFamily()
+            column_family_pb = _ColumnFamilyPB()
         else:
-            column_family_pb = data_v1_pb2.ColumnFamily(
+            column_family_pb = _ColumnFamilyPB(
                 gc_rule=gc_rule.to_pb())
         request_pb = messages_v1_pb2.CreateColumnFamilyRequest(
             name=table_name,
@@ -434,7 +420,7 @@ class TestColumnFamily(unittest2.TestCase):
         )
 
         # Create response_pb
-        response_pb = data_v1_pb2.ColumnFamily()
+        response_pb = _ColumnFamilyPB()
 
         # Patch the stub used by the API method.
         client._table_stub = stub = _FakeStub(response_pb)
@@ -462,8 +448,6 @@ class TestColumnFamily(unittest2.TestCase):
         self._create_test_helper(gc_rule=gc_rule)
 
     def _update_test_helper(self, gc_rule=None):
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
         from gcloud.bigtable._testing import _FakeStub
 
         project_id = 'project-id'
@@ -484,15 +468,15 @@ class TestColumnFamily(unittest2.TestCase):
 
         # Create request_pb
         if gc_rule is None:
-            request_pb = data_v1_pb2.ColumnFamily(name=column_family_name)
+            request_pb = _ColumnFamilyPB(name=column_family_name)
         else:
-            request_pb = data_v1_pb2.ColumnFamily(
+            request_pb = _ColumnFamilyPB(
                 name=column_family_name,
                 gc_rule=gc_rule.to_pb(),
             )
 
         # Create response_pb
-        response_pb = data_v1_pb2.ColumnFamily()
+        response_pb = _ColumnFamilyPB()
 
         # Patch the stub used by the API method.
         client._table_stub = stub = _FakeStub(response_pb)
@@ -572,10 +556,8 @@ class Test__gc_rule_from_pb(unittest2.TestCase):
         return _gc_rule_from_pb(*args, **kwargs)
 
     def test_empty(self):
-        from gcloud.bigtable._generated import (
-            bigtable_table_data_pb2 as data_v1_pb2)
 
-        gc_rule_pb = data_v1_pb2.GcRule()
+        gc_rule_pb = _GcRulePB()
         self.assertEqual(self._callFUT(gc_rule_pb), None)
 
     def test_max_num_versions(self):
@@ -638,6 +620,30 @@ class Test__gc_rule_from_pb(unittest2.TestCase):
         self.assertEqual(MockProto.names, [])
         self.assertRaises(ValueError, self._callFUT, MockProto)
         self.assertEqual(MockProto.names, ['rule'])
+
+
+def _GcRulePB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_table_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.GcRule(*args, **kw)
+
+
+def _GcRuleIntersectionPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_table_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.GcRule.Intersection(*args, **kw)
+
+
+def _GcRuleUnionPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_table_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.GcRule.Union(*args, **kw)
+
+
+def _ColumnFamilyPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_table_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.ColumnFamily(*args, **kw)
 
 
 class _Cluster(object):


### PR DESCRIPTION
~~Uses #1912 as a base.~~

Note that `{Create,Update,Delete}ColumnFamily` messages all collapse to `ModifyColumnFamilies`.