### PR TITLE
Clarify handling of V2 'ReadRowsResponse' error cases

### DIFF
--- a/gcloud/bigtable/row_data.py
+++ b/gcloud/bigtable/row_data.py
@@ -323,14 +323,18 @@ class PartialRowsData(object):
                 break
 
 
-class ReadRowsResponseError(RuntimeError):
-    """Exception raised to to invalid chunk / response data from back-end."""
+class InvalidReadRowsResponse(RuntimeError):
+    """Exception raised to to invalid response data from back-end."""
 
 
-def _raise_if(predicate):
+class InvalidChunk(RuntimeError):
+    """Exception raised to to invalid chunk data from back-end."""
+
+
+def _raise_if(predicate, *args):
     """Helper for validation methods."""
     if predicate:
-        raise ReadRowsResponseError()
+        raise InvalidChunk(*args)
 
 
 class PartialCellV2(object):
@@ -533,7 +537,7 @@ class PartialRowsDataV2(object):
 
         if self._last_scanned_row_key is None:  # first response
             if response.last_scanned_row_key:
-                raise ReadRowsResponseError()
+                raise InvalidReadRowsResponse()
 
         self._last_scanned_row_key = response.last_scanned_row_key
 

--- a/gcloud/bigtable/row_data.py
+++ b/gcloud/bigtable/row_data.py
@@ -408,7 +408,6 @@ class PartialRowsDataV2(object):
         :rtype: dict
         :returns: Dictionary of :class:`PartialRowData`.
         """
-        _raise_if(self.state not in (self.NEW_ROW,))
         # NOTE: To avoid duplicating large objects, this is just the
         #       mutable private data.
         return self._rows


### PR DESCRIPTION
Distinguish response-level errors from invalid chunks.

JSON testcases ending in an incomplete row should not raise errors.

For "invalid" JSON testcases, verify that completed, non-error rows match expected results.