### PR TITLE
Convert non-instance-admin protos to Bigtable V2

### DIFF
--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -22,10 +22,10 @@ import six
 from gcloud._helpers import _datetime_from_microseconds
 from gcloud._helpers import _microseconds_from_datetime
 from gcloud._helpers import _to_bytes
-from gcloud.bigtable._generated import (
-    bigtable_data_pb2 as data_v1_pb2)
-from gcloud.bigtable._generated import (
-    bigtable_service_messages_pb2 as messages_v1_pb2)
+from gcloud.bigtable._generated_v2 import (
+    data_pb2 as data_v2_pb2)
+from gcloud.bigtable._generated_v2 import (
+    bigtable_pb2 as messages_v2_pb2)
 
 
 _PACK_I64 = struct.Struct('>q').pack
@@ -134,13 +134,13 @@ class _SetDeleteRow(Row):
             # Truncate to millisecond granularity.
             timestamp_micros -= (timestamp_micros % 1000)
 
-        mutation_val = data_v1_pb2.Mutation.SetCell(
+        mutation_val = data_v2_pb2.Mutation.SetCell(
             family_name=column_family_id,
             column_qualifier=column,
             timestamp_micros=timestamp_micros,
             value=value,
         )
-        mutation_pb = data_v1_pb2.Mutation(set_cell=mutation_val)
+        mutation_pb = data_v2_pb2.Mutation(set_cell=mutation_val)
         self._get_mutations(state).append(mutation_pb)
 
     def _delete(self, state=None):
@@ -156,8 +156,8 @@ class _SetDeleteRow(Row):
         :param state: (Optional) The state that is passed along to
                       :meth:`_get_mutations`.
         """
-        mutation_val = data_v1_pb2.Mutation.DeleteFromRow()
-        mutation_pb = data_v1_pb2.Mutation(delete_from_row=mutation_val)
+        mutation_val = data_v2_pb2.Mutation.DeleteFromRow()
+        mutation_pb = data_v2_pb2.Mutation(delete_from_row=mutation_val)
         self._get_mutations(state).append(mutation_pb)
 
     def _delete_cells(self, column_family_id, columns, time_range=None,
@@ -188,10 +188,10 @@ class _SetDeleteRow(Row):
         """
         mutations_list = self._get_mutations(state)
         if columns is self.ALL_COLUMNS:
-            mutation_val = data_v1_pb2.Mutation.DeleteFromFamily(
+            mutation_val = data_v2_pb2.Mutation.DeleteFromFamily(
                 family_name=column_family_id,
             )
-            mutation_pb = data_v1_pb2.Mutation(delete_from_family=mutation_val)
+            mutation_pb = data_v2_pb2.Mutation(delete_from_family=mutation_val)
             mutations_list.append(mutation_pb)
         else:
             delete_kwargs = {}
@@ -207,9 +207,9 @@ class _SetDeleteRow(Row):
                     family_name=column_family_id,
                     column_qualifier=column,
                 )
-                mutation_val = data_v1_pb2.Mutation.DeleteFromColumn(
+                mutation_val = data_v2_pb2.Mutation.DeleteFromColumn(
                     **delete_kwargs)
-                mutation_pb = data_v1_pb2.Mutation(
+                mutation_pb = data_v2_pb2.Mutation(
                     delete_from_column=mutation_val)
                 to_append.append(mutation_pb)
 
@@ -389,7 +389,7 @@ class DirectRow(_SetDeleteRow):
         if num_mutations > MAX_MUTATIONS:
             raise ValueError('%d total mutations exceed the maximum allowable '
                              '%d.' % (num_mutations, MAX_MUTATIONS))
-        request_pb = messages_v1_pb2.MutateRowRequest(
+        request_pb = messages_v2_pb2.MutateRowRequest(
             table_name=self._table.name,
             row_key=self._row_key,
             mutations=mutations_list,
@@ -504,14 +504,14 @@ class ConditionalRow(_SetDeleteRow):
                 'mutations and %d false mutations.' % (
                     MAX_MUTATIONS, num_true_mutations, num_false_mutations))
 
-        request_pb = messages_v1_pb2.CheckAndMutateRowRequest(
+        request_pb = messages_v2_pb2.CheckAndMutateRowRequest(
             table_name=self._table.name,
             row_key=self._row_key,
             predicate_filter=self._filter.to_pb(),
             true_mutations=true_mutations,
             false_mutations=false_mutations,
         )
-        # We expect a `.messages_v1_pb2.CheckAndMutateRowResponse`
+        # We expect a `.messages_v2_pb2.CheckAndMutateRowResponse`
         client = self._table._cluster._client
         resp = client._data_stub.CheckAndMutateRow(
             request_pb, client.timeout_seconds)
@@ -701,7 +701,7 @@ class AppendRow(Row):
         """
         column = _to_bytes(column)
         value = _to_bytes(value)
-        rule_pb = data_v1_pb2.ReadModifyWriteRule(
+        rule_pb = data_v2_pb2.ReadModifyWriteRule(
             family_name=column_family_id,
             column_qualifier=column,
             append_value=value)
@@ -738,7 +738,7 @@ class AppendRow(Row):
                           will fail.
         """
         column = _to_bytes(column)
-        rule_pb = data_v1_pb2.ReadModifyWriteRule(
+        rule_pb = data_v2_pb2.ReadModifyWriteRule(
             family_name=column_family_id,
             column_qualifier=column,
             increment_amount=int_value)
@@ -794,12 +794,12 @@ class AppendRow(Row):
         if num_mutations > MAX_MUTATIONS:
             raise ValueError('%d total append mutations exceed the maximum '
                              'allowable %d.' % (num_mutations, MAX_MUTATIONS))
-        request_pb = messages_v1_pb2.ReadModifyWriteRowRequest(
+        request_pb = messages_v2_pb2.ReadModifyWriteRowRequest(
             table_name=self._table.name,
             row_key=self._row_key,
             rules=self._rule_pb_list,
         )
-        # We expect a `.data_v1_pb2.Row`
+        # We expect a `.data_v2_pb2.Row`
         client = self._table._cluster._client
         row_response = client._data_stub.ReadModifyWriteRow(
             request_pb, client.timeout_seconds)
@@ -814,7 +814,7 @@ class AppendRow(Row):
 def _parse_rmw_row_response(row_response):
     """Parses the response to a ``ReadModifyWriteRow`` request.
 
-    :type row_response: :class:`.data_v1_pb2.Row`
+    :type row_response: :class:`.data_v2_pb2.Row`
     :param row_response: The response row (with only modified cells) from a
                          ``ReadModifyWriteRow`` request.
 

--- a/gcloud/bigtable/row_filters.py
+++ b/gcloud/bigtable/row_filters.py
@@ -17,8 +17,8 @@
 
 from gcloud._helpers import _microseconds_from_datetime
 from gcloud._helpers import _to_bytes
-from gcloud.bigtable._generated import (
-    bigtable_data_pb2 as data_v1_pb2)
+from gcloud.bigtable._generated_v2 import (
+    data_pb2 as data_v2_pb2)
 
 
 class RowFilter(object):
@@ -66,10 +66,10 @@ class SinkFilter(_BoolFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(sink=self.flag)
+        return data_v2_pb2.RowFilter(sink=self.flag)
 
 
 class PassAllFilter(_BoolFilter):
@@ -84,10 +84,10 @@ class PassAllFilter(_BoolFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(pass_all_filter=self.flag)
+        return data_v2_pb2.RowFilter(pass_all_filter=self.flag)
 
 
 class BlockAllFilter(_BoolFilter):
@@ -101,10 +101,10 @@ class BlockAllFilter(_BoolFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(block_all_filter=self.flag)
+        return data_v2_pb2.RowFilter(block_all_filter=self.flag)
 
 
 class _RegexFilter(RowFilter):
@@ -154,10 +154,10 @@ class RowKeyRegexFilter(_RegexFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(row_key_regex_filter=self.regex)
+        return data_v2_pb2.RowFilter(row_key_regex_filter=self.regex)
 
 
 class RowSampleFilter(RowFilter):
@@ -179,10 +179,10 @@ class RowSampleFilter(RowFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(row_sample_filter=self.sample)
+        return data_v2_pb2.RowFilter(row_sample_filter=self.sample)
 
 
 class FamilyNameRegexFilter(_RegexFilter):
@@ -203,10 +203,10 @@ class FamilyNameRegexFilter(_RegexFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(family_name_regex_filter=self.regex)
+        return data_v2_pb2.RowFilter(family_name_regex_filter=self.regex)
 
 
 class ColumnQualifierRegexFilter(_RegexFilter):
@@ -233,10 +233,10 @@ class ColumnQualifierRegexFilter(_RegexFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(column_qualifier_regex_filter=self.regex)
+        return data_v2_pb2.RowFilter(column_qualifier_regex_filter=self.regex)
 
 
 class TimestampRange(object):
@@ -267,7 +267,7 @@ class TimestampRange(object):
     def to_pb(self):
         """Converts the :class:`TimestampRange` to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.TimestampRange`
+        :rtype: :class:`.data_v2_pb2.TimestampRange`
         :returns: The converted current object.
         """
         timestamp_range_kwargs = {}
@@ -277,7 +277,7 @@ class TimestampRange(object):
         if self.end is not None:
             timestamp_range_kwargs['end_timestamp_micros'] = (
                 _microseconds_from_datetime(self.end))
-        return data_v1_pb2.TimestampRange(**timestamp_range_kwargs)
+        return data_v2_pb2.TimestampRange(**timestamp_range_kwargs)
 
 
 class TimestampRangeFilter(RowFilter):
@@ -301,10 +301,10 @@ class TimestampRangeFilter(RowFilter):
         First converts the ``range_`` on the current object to a protobuf and
         then uses it in the ``timestamp_range_filter`` field.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(
+        return data_v2_pb2.RowFilter(
             timestamp_range_filter=self.range_.to_pb())
 
 
@@ -377,28 +377,28 @@ class ColumnRangeFilter(RowFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        First converts to a :class:`.data_v1_pb2.ColumnRange` and then uses it
+        First converts to a :class:`.data_v2_pb2.ColumnRange` and then uses it
         in the ``column_range_filter`` field.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
         column_range_kwargs = {'family_name': self.column_family_id}
         if self.start_column is not None:
             if self.inclusive_start:
-                key = 'start_qualifier_inclusive'
+                key = 'start_qualifier_closed'
             else:
-                key = 'start_qualifier_exclusive'
+                key = 'start_qualifier_open'
             column_range_kwargs[key] = _to_bytes(self.start_column)
         if self.end_column is not None:
             if self.inclusive_end:
-                key = 'end_qualifier_inclusive'
+                key = 'end_qualifier_closed'
             else:
-                key = 'end_qualifier_exclusive'
+                key = 'end_qualifier_open'
             column_range_kwargs[key] = _to_bytes(self.end_column)
 
-        column_range = data_v1_pb2.ColumnRange(**column_range_kwargs)
-        return data_v1_pb2.RowFilter(column_range_filter=column_range)
+        column_range = data_v2_pb2.ColumnRange(**column_range_kwargs)
+        return data_v2_pb2.RowFilter(column_range_filter=column_range)
 
 
 class ValueRegexFilter(_RegexFilter):
@@ -425,10 +425,10 @@ class ValueRegexFilter(_RegexFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(value_regex_filter=self.regex)
+        return data_v2_pb2.RowFilter(value_regex_filter=self.regex)
 
 
 class ValueRangeFilter(RowFilter):
@@ -494,28 +494,28 @@ class ValueRangeFilter(RowFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        First converts to a :class:`.data_v1_pb2.ValueRange` and then uses
+        First converts to a :class:`.data_v2_pb2.ValueRange` and then uses
         it to create a row filter protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
         value_range_kwargs = {}
         if self.start_value is not None:
             if self.inclusive_start:
-                key = 'start_value_inclusive'
+                key = 'start_value_closed'
             else:
-                key = 'start_value_exclusive'
+                key = 'start_value_open'
             value_range_kwargs[key] = _to_bytes(self.start_value)
         if self.end_value is not None:
             if self.inclusive_end:
-                key = 'end_value_inclusive'
+                key = 'end_value_closed'
             else:
-                key = 'end_value_exclusive'
+                key = 'end_value_open'
             value_range_kwargs[key] = _to_bytes(self.end_value)
 
-        value_range = data_v1_pb2.ValueRange(**value_range_kwargs)
-        return data_v1_pb2.RowFilter(value_range_filter=value_range)
+        value_range = data_v2_pb2.ValueRange(**value_range_kwargs)
+        return data_v2_pb2.RowFilter(value_range_filter=value_range)
 
 
 class _CellCountFilter(RowFilter):
@@ -547,10 +547,10 @@ class CellsRowOffsetFilter(_CellCountFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(
+        return data_v2_pb2.RowFilter(
             cells_per_row_offset_filter=self.num_cells)
 
 
@@ -564,10 +564,10 @@ class CellsRowLimitFilter(_CellCountFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(cells_per_row_limit_filter=self.num_cells)
+        return data_v2_pb2.RowFilter(cells_per_row_limit_filter=self.num_cells)
 
 
 class CellsColumnLimitFilter(_CellCountFilter):
@@ -582,10 +582,10 @@ class CellsColumnLimitFilter(_CellCountFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(
+        return data_v2_pb2.RowFilter(
             cells_per_column_limit_filter=self.num_cells)
 
 
@@ -601,10 +601,10 @@ class StripValueTransformerFilter(_BoolFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(strip_value_transformer=self.flag)
+        return data_v2_pb2.RowFilter(strip_value_transformer=self.flag)
 
 
 class ApplyLabelFilter(RowFilter):
@@ -637,10 +637,10 @@ class ApplyLabelFilter(RowFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        return data_v1_pb2.RowFilter(apply_label_transformer=self.label)
+        return data_v2_pb2.RowFilter(apply_label_transformer=self.label)
 
 
 class _FilterCombination(RowFilter):
@@ -679,12 +679,12 @@ class RowFilterChain(_FilterCombination):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        chain = data_v1_pb2.RowFilter.Chain(
+        chain = data_v2_pb2.RowFilter.Chain(
             filters=[row_filter.to_pb() for row_filter in self.filters])
-        return data_v1_pb2.RowFilter(chain=chain)
+        return data_v2_pb2.RowFilter(chain=chain)
 
 
 class RowFilterUnion(_FilterCombination):
@@ -703,12 +703,12 @@ class RowFilterUnion(_FilterCombination):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
-        interleave = data_v1_pb2.RowFilter.Interleave(
+        interleave = data_v2_pb2.RowFilter.Interleave(
             filters=[row_filter.to_pb() for row_filter in self.filters])
-        return data_v1_pb2.RowFilter(interleave=interleave)
+        return data_v2_pb2.RowFilter(interleave=interleave)
 
 
 class ConditionalRowFilter(RowFilter):
@@ -756,7 +756,7 @@ class ConditionalRowFilter(RowFilter):
     def to_pb(self):
         """Converts the row filter to a protobuf.
 
-        :rtype: :class:`.data_v1_pb2.RowFilter`
+        :rtype: :class:`.data_v2_pb2.RowFilter`
         :returns: The converted current object.
         """
         condition_kwargs = {'predicate_filter': self.base_filter.to_pb()}
@@ -764,5 +764,5 @@ class ConditionalRowFilter(RowFilter):
             condition_kwargs['true_filter'] = self.true_filter.to_pb()
         if self.false_filter is not None:
             condition_kwargs['false_filter'] = self.false_filter.to_pb()
-        condition = data_v1_pb2.RowFilter.Condition(**condition_kwargs)
-        return data_v1_pb2.RowFilter(condition=condition)
+        condition = data_v2_pb2.RowFilter.Condition(**condition_kwargs)
+        return data_v2_pb2.RowFilter(condition=condition)

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -75,9 +75,6 @@ class TestDirectRow(unittest2.TestCase):
                          timestamp_micros=-1):
         import six
         import struct
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_key = b'row_key'
         column_family_id = u'column_family_id'
         if column is None:
@@ -90,8 +87,8 @@ class TestDirectRow(unittest2.TestCase):
 
         if isinstance(value, six.integer_types):
             value = struct.pack('>q', value)
-        expected_pb = data_v1_pb2.Mutation(
-            set_cell=data_v1_pb2.Mutation.SetCell(
+        expected_pb = _MutationPB(
+            set_cell=_MutationSetCellPB(
                 family_name=column_family_id,
                 column_qualifier=column_bytes or column,
                 timestamp_micros=timestamp_micros,
@@ -135,16 +132,13 @@ class TestDirectRow(unittest2.TestCase):
                               timestamp_micros=millis_granularity)
 
     def test_delete(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_key = b'row_key'
         row = self._makeOne(row_key, object())
         self.assertEqual(row._pb_mutations, [])
         row.delete()
 
-        expected_pb = data_v1_pb2.Mutation(
-            delete_from_row=data_v1_pb2.Mutation.DeleteFromRow(),
+        expected_pb = _MutationPB(
+            delete_from_row=_MutationDeleteFromRowPB(),
         )
         self.assertEqual(row._pb_mutations, [expected_pb])
 
@@ -195,9 +189,6 @@ class TestDirectRow(unittest2.TestCase):
             row.delete_cells(column_family_id, columns)
 
     def test_delete_cells_all_columns(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_key = b'row_key'
         column_family_id = u'column_family_id'
         table = object()
@@ -207,8 +198,8 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, klass.ALL_COLUMNS)
 
-        expected_pb = data_v1_pb2.Mutation(
-            delete_from_family=data_v1_pb2.Mutation.DeleteFromFamily(
+        expected_pb = _MutationPB(
+            delete_from_family=_MutationDeleteFromFamilyPB(
                 family_name=column_family_id,
             ),
         )
@@ -226,9 +217,6 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(row._pb_mutations, [])
 
     def _delete_cells_helper(self, time_range=None):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_key = b'row_key'
         column = b'column'
         column_family_id = u'column_family_id'
@@ -239,8 +227,8 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, columns, time_range=time_range)
 
-        expected_pb = data_v1_pb2.Mutation(
-            delete_from_column=data_v1_pb2.Mutation.DeleteFromColumn(
+        expected_pb = _MutationPB(
+            delete_from_column=_MutationDeleteFromColumnPB(
                 family_name=column_family_id,
                 column_qualifier=column,
             ),
@@ -279,9 +267,6 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(row._pb_mutations, [])
 
     def test_delete_cells_with_string_columns(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_key = b'row_key'
         column_family_id = u'column_family_id'
         column1 = u'column1'
@@ -295,14 +280,14 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, columns)
 
-        expected_pb1 = data_v1_pb2.Mutation(
-            delete_from_column=data_v1_pb2.Mutation.DeleteFromColumn(
+        expected_pb1 = _MutationPB(
+            delete_from_column=_MutationDeleteFromColumnPB(
                 family_name=column_family_id,
                 column_qualifier=column1_bytes,
             ),
         )
-        expected_pb2 = data_v1_pb2.Mutation(
-            delete_from_column=data_v1_pb2.Mutation.DeleteFromColumn(
+        expected_pb2 = _MutationPB(
+            delete_from_column=_MutationDeleteFromColumnPB(
                 family_name=column_family_id,
                 column_qualifier=column2_bytes,
             ),
@@ -311,10 +296,6 @@ class TestDirectRow(unittest2.TestCase):
 
     def test_commit(self):
         from google.protobuf import empty_pb2
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-        from gcloud.bigtable._generated import (
-            bigtable_service_messages_pb2 as messages_v1_pb2)
         from gcloud.bigtable._testing import _FakeStub
 
         row_key = b'row_key'
@@ -328,15 +309,15 @@ class TestDirectRow(unittest2.TestCase):
 
         # Create request_pb
         value = b'bytes-value'
-        mutation = data_v1_pb2.Mutation(
-            set_cell=data_v1_pb2.Mutation.SetCell(
+        mutation = _MutationPB(
+            set_cell=_MutationSetCellPB(
                 family_name=column_family_id,
                 column_qualifier=column,
                 timestamp_micros=-1,  # Default value.
                 value=value,
             ),
         )
-        request_pb = messages_v1_pb2.MutateRowRequest(
+        request_pb = _MutateRowRequestPB(
             table_name=table_name,
             row_key=row_key,
             mutations=[mutation],
@@ -427,10 +408,6 @@ class TestConditionalRow(unittest2.TestCase):
         self.assertTrue(false_mutations is row._get_mutations(None))
 
     def test_commit(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-        from gcloud.bigtable._generated import (
-            bigtable_service_messages_pb2 as messages_v1_pb2)
         from gcloud.bigtable._testing import _FakeStub
         from gcloud.bigtable.row_filters import RowSampleFilter
 
@@ -449,29 +426,29 @@ class TestConditionalRow(unittest2.TestCase):
 
         # Create request_pb
         value1 = b'bytes-value'
-        mutation1 = data_v1_pb2.Mutation(
-            set_cell=data_v1_pb2.Mutation.SetCell(
+        mutation1 = _MutationPB(
+            set_cell=_MutationSetCellPB(
                 family_name=column_family_id1,
                 column_qualifier=column1,
                 timestamp_micros=-1,  # Default value.
                 value=value1,
             ),
         )
-        mutation2 = data_v1_pb2.Mutation(
-            delete_from_row=data_v1_pb2.Mutation.DeleteFromRow(),
+        mutation2 = _MutationPB(
+            delete_from_row=_MutationDeleteFromRowPB(),
         )
-        mutation3 = data_v1_pb2.Mutation(
-            delete_from_column=data_v1_pb2.Mutation.DeleteFromColumn(
+        mutation3 = _MutationPB(
+            delete_from_column=_MutationDeleteFromColumnPB(
                 family_name=column_family_id2,
                 column_qualifier=column2,
             ),
         )
-        mutation4 = data_v1_pb2.Mutation(
-            delete_from_family=data_v1_pb2.Mutation.DeleteFromFamily(
+        mutation4 = _MutationPB(
+            delete_from_family=_MutationDeleteFromFamilyPB(
                 family_name=column_family_id3,
             ),
         )
-        request_pb = messages_v1_pb2.CheckAndMutateRowRequest(
+        request_pb = _CheckAndMutateRowRequestPB(
             table_name=table_name,
             row_key=row_key,
             predicate_filter=row_filter.to_pb(),
@@ -481,7 +458,7 @@ class TestConditionalRow(unittest2.TestCase):
 
         # Create response_pb
         predicate_matched = True
-        response_pb = messages_v1_pb2.CheckAndMutateRowResponse(
+        response_pb = _CheckAndMutateRowResponsePB(
             predicate_matched=predicate_matched)
 
         # Patch the stub used by the API method.
@@ -567,9 +544,6 @@ class TestAppendRow(unittest2.TestCase):
         self.assertEqual(row._rule_pb_list, [])
 
     def test_append_cell_value(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         table = object()
         row_key = b'row_key'
         row = self._makeOne(row_key, table)
@@ -579,15 +553,12 @@ class TestAppendRow(unittest2.TestCase):
         column_family_id = u'column_family_id'
         value = b'bytes-val'
         row.append_cell_value(column_family_id, column, value)
-        expected_pb = data_v1_pb2.ReadModifyWriteRule(
+        expected_pb = _ReadModifyWriteRulePB(
             family_name=column_family_id, column_qualifier=column,
             append_value=value)
         self.assertEqual(row._rule_pb_list, [expected_pb])
 
     def test_increment_cell_value(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         table = object()
         row_key = b'row_key'
         row = self._makeOne(row_key, table)
@@ -597,17 +568,13 @@ class TestAppendRow(unittest2.TestCase):
         column_family_id = u'column_family_id'
         int_value = 281330
         row.increment_cell_value(column_family_id, column, int_value)
-        expected_pb = data_v1_pb2.ReadModifyWriteRule(
+        expected_pb = _ReadModifyWriteRulePB(
             family_name=column_family_id, column_qualifier=column,
             increment_amount=int_value)
         self.assertEqual(row._rule_pb_list, [expected_pb])
 
     def test_commit(self):
         from gcloud._testing import _Monkey
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-        from gcloud.bigtable._generated import (
-            bigtable_service_messages_pb2 as messages_v1_pb2)
         from gcloud.bigtable._testing import _FakeStub
         from gcloud.bigtable import row as MUT
 
@@ -623,11 +590,11 @@ class TestAppendRow(unittest2.TestCase):
         # Create request_pb
         value = b'bytes-value'
         # We will call row.append_cell_value(COLUMN_FAMILY_ID, COLUMN, value).
-        request_pb = messages_v1_pb2.ReadModifyWriteRowRequest(
+        request_pb = _ReadModifyWriteRowRequestPB(
             table_name=table_name,
             row_key=row_key,
             rules=[
-                data_v1_pb2.ReadModifyWriteRule(
+                _ReadModifyWriteRulePB(
                     family_name=column_family_id,
                     column_qualifier=column,
                     append_value=value,
@@ -703,9 +670,6 @@ class Test__parse_rmw_row_response(unittest2.TestCase):
 
     def test_it(self):
         from gcloud._helpers import _datetime_from_microseconds
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         col_fam1 = u'col-fam-id'
         col_fam2 = u'col-fam-id2'
         col_name1 = b'col-name1'
@@ -734,28 +698,28 @@ class Test__parse_rmw_row_response(unittest2.TestCase):
                 ],
             },
         }
-        sample_input = data_v1_pb2.Row(
+        sample_input = _RowPB(
             families=[
-                data_v1_pb2.Family(
+                _FamilyPB(
                     name=col_fam1,
                     columns=[
-                        data_v1_pb2.Column(
+                        _ColumnPB(
                             qualifier=col_name1,
                             cells=[
-                                data_v1_pb2.Cell(
+                                _CellPB(
                                     value=cell_val1,
                                     timestamp_micros=microseconds,
                                 ),
-                                data_v1_pb2.Cell(
+                                _CellPB(
                                     value=cell_val2,
                                     timestamp_micros=microseconds,
                                 ),
                             ],
                         ),
-                        data_v1_pb2.Column(
+                        _ColumnPB(
                             qualifier=col_name2,
                             cells=[
-                                data_v1_pb2.Cell(
+                                _CellPB(
                                     value=cell_val3,
                                     timestamp_micros=microseconds,
                                 ),
@@ -763,13 +727,13 @@ class Test__parse_rmw_row_response(unittest2.TestCase):
                         ),
                     ],
                 ),
-                data_v1_pb2.Family(
+                _FamilyPB(
                     name=col_fam2,
                     columns=[
-                        data_v1_pb2.Column(
+                        _ColumnPB(
                             qualifier=col_name3,
                             cells=[
-                                data_v1_pb2.Cell(
+                                _CellPB(
                                     value=cell_val4,
                                     timestamp_micros=microseconds,
                                 ),
@@ -790,9 +754,6 @@ class Test__parse_family_pb(unittest2.TestCase):
 
     def test_it(self):
         from gcloud._helpers import _datetime_from_microseconds
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         col_fam1 = u'col-fam-id'
         col_name1 = b'col-name1'
         col_name2 = b'col-name2'
@@ -812,26 +773,26 @@ class Test__parse_family_pb(unittest2.TestCase):
             ],
         }
         expected_output = (col_fam1, expected_dict)
-        sample_input = data_v1_pb2.Family(
+        sample_input = _FamilyPB(
             name=col_fam1,
             columns=[
-                data_v1_pb2.Column(
+                _ColumnPB(
                     qualifier=col_name1,
                     cells=[
-                        data_v1_pb2.Cell(
+                        _CellPB(
                             value=cell_val1,
                             timestamp_micros=microseconds,
                         ),
-                        data_v1_pb2.Cell(
+                        _CellPB(
                             value=cell_val2,
                             timestamp_micros=microseconds,
                         ),
                     ],
                 ),
-                data_v1_pb2.Column(
+                _ColumnPB(
                     qualifier=col_name2,
                     cells=[
-                        data_v1_pb2.Cell(
+                        _CellPB(
                             value=cell_val3,
                             timestamp_micros=microseconds,
                         ),
@@ -840,6 +801,90 @@ class Test__parse_family_pb(unittest2.TestCase):
             ],
         )
         self.assertEqual(expected_output, self._callFUT(sample_input))
+
+
+def _CheckAndMutateRowRequestPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        bigtable_pb2 as messages_v2_pb2)
+    return messages_v2_pb2.CheckAndMutateRowRequest(*args, **kw)
+
+
+def _CheckAndMutateRowResponsePB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        bigtable_pb2 as messages_v2_pb2)
+    return messages_v2_pb2.CheckAndMutateRowResponse(*args, **kw)
+
+
+def _MutateRowRequestPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        bigtable_pb2 as messages_v2_pb2)
+    return messages_v2_pb2.MutateRowRequest(*args, **kw)
+
+
+def _ReadModifyWriteRowRequestPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        bigtable_pb2 as messages_v2_pb2)
+    return messages_v2_pb2.ReadModifyWriteRowRequest(*args, **kw)
+
+
+def _CellPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Cell(*args, **kw)
+
+
+def _ColumnPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Column(*args, **kw)
+
+
+def _FamilyPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Family(*args, **kw)
+
+
+def _MutationPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Mutation(*args, **kw)
+
+
+def _MutationSetCellPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Mutation.SetCell(*args, **kw)
+
+
+def _MutationDeleteFromColumnPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Mutation.DeleteFromColumn(*args, **kw)
+
+
+def _MutationDeleteFromFamilyPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Mutation.DeleteFromFamily(*args, **kw)
+
+
+def _MutationDeleteFromRowPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Mutation.DeleteFromRow(*args, **kw)
+
+
+def _RowPB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.Row(*args, **kw)
+
+
+def _ReadModifyWriteRulePB(*args, **kw):
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.ReadModifyWriteRule(*args, **kw)
 
 
 class _Client(object):

--- a/gcloud/bigtable/test_row_filters.py
+++ b/gcloud/bigtable/test_row_filters.py
@@ -60,13 +60,10 @@ class TestSinkFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         flag = True
         row_filter = self._makeOne(flag)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(sink=flag)
+        expected_pb = _RowFilterPB(sink=flag)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -80,13 +77,10 @@ class TestPassAllFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         flag = True
         row_filter = self._makeOne(flag)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(pass_all_filter=flag)
+        expected_pb = _RowFilterPB(pass_all_filter=flag)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -100,13 +94,10 @@ class TestBlockAllFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         flag = True
         row_filter = self._makeOne(flag)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(block_all_filter=flag)
+        expected_pb = _RowFilterPB(block_all_filter=flag)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -159,13 +150,10 @@ class TestRowKeyRegexFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         regex = b'row-key-regex'
         row_filter = self._makeOne(regex)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(row_key_regex_filter=regex)
+        expected_pb = _RowFilterPB(row_key_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -196,13 +184,10 @@ class TestRowSampleFilter(unittest2.TestCase):
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         sample = 0.25
         row_filter = self._makeOne(sample)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(row_sample_filter=sample)
+        expected_pb = _RowFilterPB(row_sample_filter=sample)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -216,13 +201,10 @@ class TestFamilyNameRegexFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         regex = u'family-regex'
         row_filter = self._makeOne(regex)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(family_name_regex_filter=regex)
+        expected_pb = _RowFilterPB(family_name_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -236,13 +218,10 @@ class TestColumnQualifierRegexFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         regex = b'column-regex'
         row_filter = self._makeOne(regex)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(
+        expected_pb = _RowFilterPB(
             column_qualifier_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
 
@@ -288,9 +267,6 @@ class TestTimestampRange(unittest2.TestCase):
     def _to_pb_helper(self, start_micros=None, end_micros=None):
         import datetime
         from gcloud._helpers import _EPOCH
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         pb_kwargs = {}
 
         start = None
@@ -303,7 +279,7 @@ class TestTimestampRange(unittest2.TestCase):
             pb_kwargs['end_timestamp_micros'] = end_micros
         time_range = self._makeOne(start=start, end=end)
 
-        expected_pb = data_v1_pb2.TimestampRange(**pb_kwargs)
+        expected_pb = _TimestampRangePB(**pb_kwargs)
         self.assertEqual(time_range.to_pb(), expected_pb)
 
     def test_to_pb(self):
@@ -351,15 +327,13 @@ class TestTimestampRangeFilter(unittest2.TestCase):
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import TimestampRange
 
         range_ = TimestampRange()
         row_filter = self._makeOne(range_)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(
-            timestamp_range_filter=data_v1_pb2.TimestampRange())
+        expected_pb = _RowFilterPB(
+            timestamp_range_filter=_TimestampRangePB())
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -434,71 +408,56 @@ class TestColumnRangeFilter(unittest2.TestCase):
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         column_family_id = u'column-family-id'
         row_filter = self._makeOne(column_family_id)
-        col_range_pb = data_v1_pb2.ColumnRange(family_name=column_family_id)
-        expected_pb = data_v1_pb2.RowFilter(column_range_filter=col_range_pb)
+        col_range_pb = _ColumnRangePB(family_name=column_family_id)
+        expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_start(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._makeOne(column_family_id, start_column=column)
-        col_range_pb = data_v1_pb2.ColumnRange(
+        col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             start_qualifier_inclusive=column,
         )
-        expected_pb = data_v1_pb2.RowFilter(column_range_filter=col_range_pb)
+        expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_start(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._makeOne(column_family_id, start_column=column,
                                    inclusive_start=False)
-        col_range_pb = data_v1_pb2.ColumnRange(
+        col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             start_qualifier_exclusive=column,
         )
-        expected_pb = data_v1_pb2.RowFilter(column_range_filter=col_range_pb)
+        expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_end(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._makeOne(column_family_id, end_column=column)
-        col_range_pb = data_v1_pb2.ColumnRange(
+        col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             end_qualifier_inclusive=column,
         )
-        expected_pb = data_v1_pb2.RowFilter(column_range_filter=col_range_pb)
+        expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_end(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._makeOne(column_family_id, end_column=column,
                                    inclusive_end=False)
-        col_range_pb = data_v1_pb2.ColumnRange(
+        col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             end_qualifier_exclusive=column,
         )
-        expected_pb = data_v1_pb2.RowFilter(column_range_filter=col_range_pb)
+        expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
 
@@ -512,13 +471,10 @@ class TestValueRegexFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         regex = b'value-regex'
         row_filter = self._makeOne(regex)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(value_regex_filter=regex)
+        expected_pb = _RowFilterPB(value_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -579,52 +535,37 @@ class TestValueRangeFilter(unittest2.TestCase):
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         row_filter = self._makeOne()
-        expected_pb = data_v1_pb2.RowFilter(
-            value_range_filter=data_v1_pb2.ValueRange())
+        expected_pb = _RowFilterPB(
+            value_range_filter=_ValueRangePB())
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_start(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         value = b'some-value'
         row_filter = self._makeOne(start_value=value)
-        val_range_pb = data_v1_pb2.ValueRange(start_value_inclusive=value)
-        expected_pb = data_v1_pb2.RowFilter(value_range_filter=val_range_pb)
+        val_range_pb = _ValueRangePB(start_value_inclusive=value)
+        expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_start(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         value = b'some-value'
         row_filter = self._makeOne(start_value=value, inclusive_start=False)
-        val_range_pb = data_v1_pb2.ValueRange(start_value_exclusive=value)
-        expected_pb = data_v1_pb2.RowFilter(value_range_filter=val_range_pb)
+        val_range_pb = _ValueRangePB(start_value_exclusive=value)
+        expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_end(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         value = b'some-value'
         row_filter = self._makeOne(end_value=value)
-        val_range_pb = data_v1_pb2.ValueRange(end_value_inclusive=value)
-        expected_pb = data_v1_pb2.RowFilter(value_range_filter=val_range_pb)
+        val_range_pb = _ValueRangePB(end_value_inclusive=value)
+        expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_end(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         value = b'some-value'
         row_filter = self._makeOne(end_value=value, inclusive_end=False)
-        val_range_pb = data_v1_pb2.ValueRange(end_value_exclusive=value)
-        expected_pb = data_v1_pb2.RowFilter(value_range_filter=val_range_pb)
+        val_range_pb = _ValueRangePB(end_value_exclusive=value)
+        expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
 
@@ -672,13 +613,10 @@ class TestCellsRowOffsetFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         num_cells = 76
         row_filter = self._makeOne(num_cells)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(
+        expected_pb = _RowFilterPB(
             cells_per_row_offset_filter=num_cells)
         self.assertEqual(pb_val, expected_pb)
 
@@ -693,13 +631,10 @@ class TestCellsRowLimitFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         num_cells = 189
         row_filter = self._makeOne(num_cells)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(
+        expected_pb = _RowFilterPB(
             cells_per_row_limit_filter=num_cells)
         self.assertEqual(pb_val, expected_pb)
 
@@ -714,13 +649,10 @@ class TestCellsColumnLimitFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         num_cells = 10
         row_filter = self._makeOne(num_cells)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(
+        expected_pb = _RowFilterPB(
             cells_per_column_limit_filter=num_cells)
         self.assertEqual(pb_val, expected_pb)
 
@@ -735,13 +667,10 @@ class TestStripValueTransformerFilter(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         flag = True
         row_filter = self._makeOne(flag)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(strip_value_transformer=flag)
+        expected_pb = _RowFilterPB(strip_value_transformer=flag)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -772,13 +701,10 @@ class TestApplyLabelFilter(unittest2.TestCase):
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
-
         label = u'label'
         row_filter = self._makeOne(label)
         pb_val = row_filter.to_pb()
-        expected_pb = data_v1_pb2.RowFilter(apply_label_transformer=label)
+        expected_pb = _RowFilterPB(apply_label_transformer=label)
         self.assertEqual(pb_val, expected_pb)
 
 
@@ -823,8 +749,6 @@ class TestRowFilterChain(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
 
@@ -837,16 +761,14 @@ class TestRowFilterChain(unittest2.TestCase):
         row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
         filter_pb = row_filter3.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            chain=data_v1_pb2.RowFilter.Chain(
+        expected_pb = _RowFilterPB(
+            chain=_RowFilterChainPB(
                 filters=[row_filter1_pb, row_filter2_pb],
             ),
         )
         self.assertEqual(filter_pb, expected_pb)
 
     def test_to_pb_nested(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import CellsRowLimitFilter
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
@@ -863,8 +785,8 @@ class TestRowFilterChain(unittest2.TestCase):
         row_filter5 = self._makeOne(filters=[row_filter3, row_filter4])
         filter_pb = row_filter5.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            chain=data_v1_pb2.RowFilter.Chain(
+        expected_pb = _RowFilterPB(
+            chain=_RowFilterChainPB(
                 filters=[row_filter3_pb, row_filter4_pb],
             ),
         )
@@ -881,8 +803,6 @@ class TestRowFilterUnion(unittest2.TestCase):
         return self._getTargetClass()(*args, **kwargs)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
 
@@ -895,16 +815,14 @@ class TestRowFilterUnion(unittest2.TestCase):
         row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
         filter_pb = row_filter3.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            interleave=data_v1_pb2.RowFilter.Interleave(
+        expected_pb = _RowFilterPB(
+            interleave=_RowFilterInterleavePB(
                 filters=[row_filter1_pb, row_filter2_pb],
             ),
         )
         self.assertEqual(filter_pb, expected_pb)
 
     def test_to_pb_nested(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import CellsRowLimitFilter
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
@@ -921,8 +839,8 @@ class TestRowFilterUnion(unittest2.TestCase):
         row_filter5 = self._makeOne(filters=[row_filter3, row_filter4])
         filter_pb = row_filter5.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            interleave=data_v1_pb2.RowFilter.Interleave(
+        expected_pb = _RowFilterPB(
+            interleave=_RowFilterInterleavePB(
                 filters=[row_filter3_pb, row_filter4_pb],
             ),
         )
@@ -972,8 +890,6 @@ class TestConditionalRowFilter(unittest2.TestCase):
         self.assertNotEqual(cond_filter1, cond_filter2)
 
     def test_to_pb(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import CellsRowOffsetFilter
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
@@ -991,8 +907,8 @@ class TestConditionalRowFilter(unittest2.TestCase):
                                     false_filter=row_filter3)
         filter_pb = row_filter4.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            condition=data_v1_pb2.RowFilter.Condition(
+        expected_pb = _RowFilterPB(
+            condition=_RowFilterConditionPB(
                 predicate_filter=row_filter1_pb,
                 true_filter=row_filter2_pb,
                 false_filter=row_filter3_pb,
@@ -1001,8 +917,6 @@ class TestConditionalRowFilter(unittest2.TestCase):
         self.assertEqual(filter_pb, expected_pb)
 
     def test_to_pb_true_only(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
 
@@ -1015,8 +929,8 @@ class TestConditionalRowFilter(unittest2.TestCase):
         row_filter3 = self._makeOne(row_filter1, true_filter=row_filter2)
         filter_pb = row_filter3.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            condition=data_v1_pb2.RowFilter.Condition(
+        expected_pb = _RowFilterPB(
+            condition=_RowFilterConditionPB(
                 predicate_filter=row_filter1_pb,
                 true_filter=row_filter2_pb,
             ),
@@ -1024,8 +938,6 @@ class TestConditionalRowFilter(unittest2.TestCase):
         self.assertEqual(filter_pb, expected_pb)
 
     def test_to_pb_false_only(self):
-        from gcloud.bigtable._generated import (
-            bigtable_data_pb2 as data_v1_pb2)
         from gcloud.bigtable.row_filters import RowSampleFilter
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
 
@@ -1038,10 +950,52 @@ class TestConditionalRowFilter(unittest2.TestCase):
         row_filter3 = self._makeOne(row_filter1, false_filter=row_filter2)
         filter_pb = row_filter3.to_pb()
 
-        expected_pb = data_v1_pb2.RowFilter(
-            condition=data_v1_pb2.RowFilter.Condition(
+        expected_pb = _RowFilterPB(
+            condition=_RowFilterConditionPB(
                 predicate_filter=row_filter1_pb,
                 false_filter=row_filter2_pb,
             ),
         )
         self.assertEqual(filter_pb, expected_pb)
+
+
+def _ColumnRangePB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.ColumnRange(*args, **kw)
+
+
+def _RowFilterPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.RowFilter(*args, **kw)
+
+
+def _RowFilterChainPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.RowFilter.Chain(*args, **kw)
+
+
+def _RowFilterConditionPB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.RowFilter.Condition(*args, **kw)
+
+
+def _RowFilterInterleavePB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.RowFilter.Interleave(*args, **kw)
+
+
+def _TimestampRangePB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.TimestampRange(*args, **kw)
+
+
+def _ValueRangePB(*args, **kw):
+    from gcloud.bigtable._generated import (
+        bigtable_data_pb2 as data_v1_pb2)
+    return data_v1_pb2.ValueRange(*args, **kw)

--- a/gcloud/bigtable/test_row_filters.py
+++ b/gcloud/bigtable/test_row_filters.py
@@ -420,7 +420,7 @@ class TestColumnRangeFilter(unittest2.TestCase):
         row_filter = self._makeOne(column_family_id, start_column=column)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
-            start_qualifier_inclusive=column,
+            start_qualifier_closed=column,
         )
         expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -432,7 +432,7 @@ class TestColumnRangeFilter(unittest2.TestCase):
                                    inclusive_start=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
-            start_qualifier_exclusive=column,
+            start_qualifier_open=column,
         )
         expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -443,7 +443,7 @@ class TestColumnRangeFilter(unittest2.TestCase):
         row_filter = self._makeOne(column_family_id, end_column=column)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
-            end_qualifier_inclusive=column,
+            end_qualifier_closed=column,
         )
         expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -455,7 +455,7 @@ class TestColumnRangeFilter(unittest2.TestCase):
                                    inclusive_end=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
-            end_qualifier_exclusive=column,
+            end_qualifier_open=column,
         )
         expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -543,28 +543,28 @@ class TestValueRangeFilter(unittest2.TestCase):
     def test_to_pb_inclusive_start(self):
         value = b'some-value'
         row_filter = self._makeOne(start_value=value)
-        val_range_pb = _ValueRangePB(start_value_inclusive=value)
+        val_range_pb = _ValueRangePB(start_value_closed=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_start(self):
         value = b'some-value'
         row_filter = self._makeOne(start_value=value, inclusive_start=False)
-        val_range_pb = _ValueRangePB(start_value_exclusive=value)
+        val_range_pb = _ValueRangePB(start_value_open=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_end(self):
         value = b'some-value'
         row_filter = self._makeOne(end_value=value)
-        val_range_pb = _ValueRangePB(end_value_inclusive=value)
+        val_range_pb = _ValueRangePB(end_value_closed=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_end(self):
         value = b'some-value'
         row_filter = self._makeOne(end_value=value, inclusive_end=False)
-        val_range_pb = _ValueRangePB(end_value_exclusive=value)
+        val_range_pb = _ValueRangePB(end_value_open=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
@@ -960,42 +960,42 @@ class TestConditionalRowFilter(unittest2.TestCase):
 
 
 def _ColumnRangePB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.ColumnRange(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.ColumnRange(*args, **kw)
 
 
 def _RowFilterPB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.RowFilter(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.RowFilter(*args, **kw)
 
 
 def _RowFilterChainPB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.RowFilter.Chain(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.RowFilter.Chain(*args, **kw)
 
 
 def _RowFilterConditionPB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.RowFilter.Condition(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.RowFilter.Condition(*args, **kw)
 
 
 def _RowFilterInterleavePB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.RowFilter.Interleave(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.RowFilter.Interleave(*args, **kw)
 
 
 def _TimestampRangePB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.TimestampRange(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.TimestampRange(*args, **kw)
 
 
 def _ValueRangePB(*args, **kw):
-    from gcloud.bigtable._generated import (
-        bigtable_data_pb2 as data_v1_pb2)
-    return data_v1_pb2.ValueRange(*args, **kw)
+    from gcloud.bigtable._generated_v2 import (
+        data_pb2 as data_v2_pb2)
+    return data_v2_pb2.ValueRange(*args, **kw)


### PR DESCRIPTION
Folds new `ReadRowsResponse` logic from #1907, #1915 into table row handling.

Apologies for the size of this PR:  it turned out to be a bit of a "take one sip from a spittoon" problem.