### PR TITLE
Resolve issues with GAE and os.path.expanduser()

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -191,10 +191,9 @@ def _default_service_project_id():
     search_paths = []
     # Workaround for GAE not supporting pwd which is used by expanduser.
     try:
-        full_config_path = os.path.expanduser(DEFAULT_CONFIGURATION_PATH)
-        search_paths.append(full_config_path)
+        search_paths.append(os.path.expanduser(DEFAULT_CONFIGURATION_PATH))
     except ImportError:
-        full_config_path = ''
+        pass
     win32_config_path = os.path.join(os.getenv('APPDATA', ''),
                                      'gcloud', 'configurations',
                                      'config_default')

--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -188,12 +188,19 @@ def _default_service_project_id():
     :rtype: str or ``NoneType``
     :returns: Project-ID from default configuration file else ``None``
     """
-    full_config_path = os.path.expanduser(DEFAULT_CONFIGURATION_PATH)
+    search_paths = []
+    # Workaround for GAE not supporting pwd which is used by expanduser.
+    try:
+        full_config_path = os.path.expanduser(DEFAULT_CONFIGURATION_PATH)
+        search_paths.append(full_config_path)
+    except ImportError:
+        full_config_path = ''
     win32_config_path = os.path.join(os.getenv('APPDATA', ''),
                                      'gcloud', 'configurations',
                                      'config_default')
+    search_paths.append(win32_config_path)
     config = configparser.RawConfigParser()
-    config.read([full_config_path, win32_config_path])
+    config.read(search_paths)
 
     if config.has_section('core'):
         return config.get('core', 'project')

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -224,12 +224,12 @@ class Test__get_default_service_project_id(unittest2.TestCase):
 
     def test_gae_without_expanduser(self):
         import sys
-        import pwd
-        del pwd
-        sys.modules['pwd'] = None  # Blocks pwd from being imported.
-        project_id = self.callFUT('test-project-id')
-        self.assertEqual(None, project_id)
-        del sys.modules['pwd']  # Unblocks importing of pwd.
+        try:
+            sys.modules['pwd'] = None  # Blocks pwd from being imported.
+            project_id = self.callFUT('test-project-id')
+            self.assertEqual(None, project_id)
+        finally:
+            del sys.modules['pwd']  # Unblocks importing of pwd.
 
     def test_info_value_not_present(self):
         project_id = self.callFUT()

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -211,6 +211,7 @@ class Test__get_default_service_project_id(unittest2.TestCase):
 
         def mock_expanduser(path=''):
             if project_id and path.startswith('~'):
+                __import__('pwd')  # Simulate actual expanduser imports.
                 return self.temp_config_file
             return ''
 
@@ -220,6 +221,15 @@ class Test__get_default_service_project_id(unittest2.TestCase):
     def test_read_from_cli_info(self):
         project_id = self.callFUT('test-project-id')
         self.assertEqual('test-project-id', project_id)
+
+    def test_gae_without_expanduser(self):
+        import sys
+        import pwd
+        del pwd
+        sys.modules['pwd'] = None  # Blocks pwd from being imported.
+        project_id = self.callFUT('test-project-id')
+        self.assertEqual(None, project_id)
+        del sys.modules['pwd']  # Unblocks importing of pwd.
 
     def test_info_value_not_present(self):
         project_id = self.callFUT()


### PR DESCRIPTION
`os.path.expanduser` imports the `pwd` module which is [not supported by GAE](https://cloud.google.com/appengine/kb/?csw=1#libraries).

This should resolve #1922.