### PR TITLE
Regenerate from final Bigtable v2  v2 protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ scripts/pylintrc_reduced
 generated_python/
 cloud-bigtable-client/
 googleapis-pb/
+grpc_python_venv/

--- a/Makefile.bigtable_v1
+++ b/Makefile.bigtable_v1
@@ -1,11 +1,11 @@
+GRPCIO_VIRTUALENV=$(shell pwd)/grpc_python_venv
 GENERATED_DIR=$(shell pwd)/generated_python
 GENERATED_SUBDIR=_generated
 BIGTABLE_DIR=$(shell pwd)/gcloud/bigtable/$(GENERATED_SUBDIR)
-GRPC_PLUGIN=grpc_python_plugin
-PROTOC_CMD=protoc
-BIGTABLE_CHECKOUT_DIR=$(shell pwd)/cloud-bigtable-client
-BIGTABLE_PROTOS_DIR=$(BIGTABLE_CHECKOUT_DIR)/bigtable-protos/src/main/proto
+PROTOC_CMD=$(GRPCIO_VIRTUALENV)/bin/python -m grpc.tools.protoc
 GOOGLEAPIS_PROTOS_DIR=$(shell pwd)/googleapis-pb
+BIGTABLE_CHECKOUT_DIR=$(shell pwd)/cloud-bigtable-client
+BIGTABLE_PROTOS_DIR=$(BIGTABLE_CHECKOUT_DIR)/bigtable-client-core-parent/bigtable-protos/src/main/proto
 
 help:
 	@echo 'Makefile for gcloud-python Bigtable protos                      '
@@ -15,19 +15,22 @@ help:
 	@echo '   make clean                    Clean generated files          '
 
 generate:
+	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools
+	[ -d $(GRPCIO_VIRTUALENV) ] || python2.7 -m virtualenv $(GRPCIO_VIRTUALENV)
+	$(GRPCIO_VIRTUALENV)/bin/pip install --upgrade grpcio grpcio-tools
 	# Retrieve git repos that have our *.proto files.
 	[ -d $(BIGTABLE_CHECKOUT_DIR) ] || git clone https://github.com/GoogleCloudPlatform/cloud-bigtable-client --depth=1
 	cd $(BIGTABLE_CHECKOUT_DIR) && git pull origin master
-	[ -d googleapis-pb ] || git clone https://github.com/google/googleapis googleapis-pb --depth=1
-	cd googleapis-pb && git pull origin master
+	[ -d $(GOOGLEAPIS_PROTOS_DIR) ] || git clone https://github.com/google/googleapis googleapis-pb --depth=1
+	cd $(GOOGLEAPIS_PROTOS_DIR) && git pull origin master
 	# Make the directory where our *_pb2.py files will go.
 	mkdir -p $(GENERATED_DIR)
 	# Generate all *_pb2.py files that require gRPC.
 	$(PROTOC_CMD) \
 	    --proto_path=$(BIGTABLE_PROTOS_DIR) \
+	    --proto_path=$(GOOGLEAPIS_PROTOS_DIR) \
 	    --python_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    --grpc_out=$(GENERATED_DIR) \
+	    --grpc_python_out=$(GENERATED_DIR) \
 	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/v1/bigtable_service.proto \
 	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/cluster/v1/bigtable_cluster_service.proto \
 	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/table/v1/bigtable_table_service.proto
@@ -52,7 +55,7 @@ generate:
 	cp $(BIGTABLE_PROTOS_DIR)/google/bigtable/v1/*.proto $(BIGTABLE_DIR)
 	cp $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/cluster/v1/*.proto $(BIGTABLE_DIR)
 	cp $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/table/v1/*.proto $(BIGTABLE_DIR)
-	cp $(BIGTABLE_PROTOS_DIR)/google/longrunning/operations.proto $(BIGTABLE_DIR)
+	cp $(GOOGLEAPIS_PROTOS_DIR)/google/longrunning/operations.proto $(BIGTABLE_DIR)
 	# Rename all *.proto files in our library with an
 	# underscore and remove executable bit.
 	cd $(BIGTABLE_DIR) && \
@@ -63,8 +66,8 @@ generate:
 	# Separate the gRPC parts of the operations service from the
 	# non-gRPC parts so that the protos from `googleapis-common-protos`
 	# can be used without gRPC.
-	PROTOC_CMD=$(PROTOC_CMD) GRPC_PLUGIN=$(GRPC_PLUGIN) \
-		GENERATED_SUBDIR=$(GENERATED_SUBDIR) \
+	GRPCIO_VIRTUALENV="$(GRPCIO_VIRTUALENV)" \
+	GENERATED_SUBDIR=$(GENERATED_SUBDIR) \
 		python scripts/make_operations_grpc.py
 	# Rewrite the imports in the generated *_pb2.py files.
 	python scripts/rewrite_imports.py $(BIGTABLE_DIR)/*pb2.py
@@ -73,6 +76,6 @@ check_generate:
 	python scripts/check_generate.py
 
 clean:
-	rm -fr $(BIGTABLE_CHECKOUT_DIR) $(GOOGLEAPIS_PROTOS_DIR) $(GENERATED_DIR)
+	rm -fr $(GRPCIO_VIRTUALENV) $(GOOGLEAPIS_PROTOS_DIR) $(GENERATED_DIR)
 
 .PHONY: generate check_generate clean

--- a/Makefile.bigtable_v2
+++ b/Makefile.bigtable_v2
@@ -1,10 +1,8 @@
+GRPCIO_VIRTUALENV=$(shell pwd)/grpc_python_venv
 GENERATED_DIR=$(shell pwd)/generated_python
 GENERATED_SUBDIR=_generated_v2
 BIGTABLE_DIR=$(shell pwd)/gcloud/bigtable/$(GENERATED_SUBDIR)
-GRPC_PLUGIN=grpc_python_plugin
-PROTOC_CMD=protoc
-BIGTABLE_CHECKOUT_DIR=$(shell pwd)/cloud-bigtable-client
-BIGTABLE_PROTOS_DIR=$(BIGTABLE_CHECKOUT_DIR)/bigtable-protos/src/main/proto
+PROTOC_CMD=$(GRPCIO_VIRTUALENV)/bin/python -m grpc.tools.protoc
 GOOGLEAPIS_PROTOS_DIR=$(shell pwd)/googleapis-pb
 
 help:
@@ -15,31 +13,30 @@ help:
 	@echo '   make clean                    Clean generated files          '
 
 generate:
+	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools
+	[ -d $(GRPCIO_VIRTUALENV) ] || python2.7 -m virtualenv $(GRPCIO_VIRTUALENV)
+	$(GRPCIO_VIRTUALENV)/bin/pip install --upgrade grpcio grpcio-tools
 	# Retrieve git repos that have our *.proto files.
-	[ -d $(BIGTABLE_CHECKOUT_DIR) ] || git clone https://github.com/GoogleCloudPlatform/cloud-bigtable-client --depth=1
-	cd $(BIGTABLE_CHECKOUT_DIR) && git pull origin master
 	[ -d googleapis-pb ] || git clone https://github.com/google/googleapis googleapis-pb --depth=1
 	cd googleapis-pb && git pull origin master
 	# Make the directory where our *_pb2.py files will go.
 	mkdir -p $(GENERATED_DIR)
 	# Generate all *_pb2.py files that require gRPC.
 	$(PROTOC_CMD) \
-	    --proto_path=$(BIGTABLE_PROTOS_DIR) \
-	    --python_out=$(GENERATED_DIR) \
-	    --plugin=protoc-gen-grpc=$(GRPC_PLUGIN) \
-	    --grpc_out=$(GENERATED_DIR) \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/v2/bigtable.proto \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/bigtable_instance_admin.proto \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/bigtable_table_admin.proto
-	# Generate all *_pb2.py files that do not require gRPC.
-	$(PROTOC_CMD) \
-	    --proto_path=$(BIGTABLE_PROTOS_DIR) \
 	    --proto_path=$(GOOGLEAPIS_PROTOS_DIR) \
 	    --python_out=$(GENERATED_DIR) \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/v2/data.proto \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/common.proto \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/instance.proto \
-	    $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/table.proto \
+	    --grpc_python_out=$(GENERATED_DIR) \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/v2/bigtable.proto \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/bigtable_instance_admin.proto \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/bigtable_table_admin.proto
+	# Generate all *_pb2.py files that do not require gRPC.
+	$(PROTOC_CMD) \
+	    --proto_path=$(GOOGLEAPIS_PROTOS_DIR) \
+	    --python_out=$(GENERATED_DIR) \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/v2/data.proto \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/common.proto \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/instance.proto \
+	    $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/table.proto \
 	# Move the newly generated *_pb2.py files into our library.
 	cp $(GENERATED_DIR)/google/bigtable/v2/* $(BIGTABLE_DIR)
 	cp $(GENERATED_DIR)/google/bigtable/admin/v2/* $(BIGTABLE_DIR)
@@ -47,9 +44,9 @@ generate:
 	# Remove all existing *.proto files before we replace
 	rm -f $(BIGTABLE_DIR)/*.proto
 	# Copy over the *.proto files into our library.
-	cp $(BIGTABLE_PROTOS_DIR)/google/bigtable/v2/*.proto $(BIGTABLE_DIR)
-	cp $(BIGTABLE_PROTOS_DIR)/google/bigtable/admin/v2/*.proto $(BIGTABLE_DIR)
-	cp $(BIGTABLE_PROTOS_DIR)/google/longrunning/operations.proto $(BIGTABLE_DIR)
+	cp $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/v2/*.proto $(BIGTABLE_DIR)
+	cp $(GOOGLEAPIS_PROTOS_DIR)/google/bigtable/admin/v2/*.proto $(BIGTABLE_DIR)
+	cp $(GOOGLEAPIS_PROTOS_DIR)/google/longrunning/operations.proto $(BIGTABLE_DIR)
 	# Rename all *.proto files in our library with an
 	# underscore and remove executable bit.
 	cd $(BIGTABLE_DIR) && \
@@ -60,8 +57,8 @@ generate:
 	# Separate the gRPC parts of the operations service from the
 	# non-gRPC parts so that the protos from `googleapis-common-protos`
 	# can be used without gRPC.
-	PROTOC_CMD=$(PROTOC_CMD) GRPC_PLUGIN=$(GRPC_PLUGIN) \
-		GENERATED_SUBDIR=$(GENERATED_SUBDIR) \
+	GRPCIO_VIRTUALENV="$(GRPCIO_VIRTUALENV)" \
+	GENERATED_SUBDIR=$(GENERATED_SUBDIR) \
 		python scripts/make_operations_grpc.py
 	# Rewrite the imports in the generated *_pb2.py files.
 	python scripts/rewrite_imports.py $(BIGTABLE_DIR)/*pb2.py
@@ -70,6 +67,6 @@ check_generate:
 	python scripts/check_generate.py
 
 clean:
-	rm -fr $(BIGTABLE_CHECKOUT_DIR) $(GOOGLEAPIS_PROTOS_DIR) $(GENERATED_DIR)
+	rm -fr $(GRPCIO_VIRTUALENV) $(GOOGLEAPIS_PROTOS_DIR) $(GENERATED_DIR)
 
 .PHONY: generate check_generate clean

--- a/Makefile.bigtable_v2
+++ b/Makefile.bigtable_v2
@@ -40,7 +40,6 @@ generate:
 	# Move the newly generated *_pb2.py files into our library.
 	cp $(GENERATED_DIR)/google/bigtable/v2/* $(BIGTABLE_DIR)
 	cp $(GENERATED_DIR)/google/bigtable/admin/v2/* $(BIGTABLE_DIR)
-	cp $(GENERATED_DIR)/google/bigtable/admin/v2/* $(BIGTABLE_DIR)
 	# Remove all existing *.proto files before we replace
 	rm -f $(BIGTABLE_DIR)/*.proto
 	# Copy over the *.proto files into our library.

--- a/Makefile.datastore
+++ b/Makefile.datastore
@@ -1,7 +1,7 @@
+GRPCIO_VIRTUALENV=$(shell pwd)/grpc_python_venv
 GENERATED_DIR=$(shell pwd)/generated_python
 DATASTORE_DIR=$(shell pwd)/gcloud/datastore/_generated
-GRPC_PLUGIN=grpc_python_plugin
-PROTOC_CMD=protoc
+PROTOC_CMD=$(GRPCIO_VIRTUALENV)/bin/python -m grpc.tools.protoc
 GOOGLEAPIS_PROTOS_DIR=$(shell pwd)/googleapis-pb
 
 help:
@@ -12,6 +12,9 @@ help:
 	@echo '   make clean                    Clean generated files          '
 
 generate:
+	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools
+	[ -d $(GRPCIO_VIRTUALENV) ] || python2.7 -m virtualenv $(GRPCIO_VIRTUALENV)
+	$(GRPCIO_VIRTUALENV)/bin/pip install --upgrade grpcio grpcio-tools
 	# Retrieve git repos that have our *.proto files.
 	[ -d googleapis-pb ] || git clone https://github.com/google/googleapis googleapis-pb --depth=1
 	cd googleapis-pb && git pull origin master
@@ -39,7 +42,8 @@ generate:
 	    done
 	# Separate the gRPC parts of the datastore service from the
 	# non-gRPC parts so that the protos can be used without gRPC.
-	PROTOC_CMD=$(PROTOC_CMD) GRPC_PLUGIN=$(GRPC_PLUGIN) \
+	GRPCIO_VIRTUALENV="$(GRPCIO_VIRTUALENV)" \
+	GENERATED_SUBDIR=$(GENERATED_SUBDIR) \
 		python scripts/make_datastore_grpc.py
 	# Rewrite the imports in the generated *_pb2.py files.
 	python scripts/rewrite_imports.py $(DATASTORE_DIR)/*pb2.py

--- a/gcloud/bigtable/_generated_v2/_bigtable.proto
+++ b/gcloud/bigtable/_generated_v2/_bigtable.proto
@@ -27,18 +27,12 @@ option java_package = "com.google.bigtable.v2";
 
 
 // Service for reading from and writing to existing Bigtable tables.
-//
-// Caution: This service is experimental. The details can change and the rpcs
-// may or may not be active.
 service Bigtable {
   // Streams back the contents of all requested rows, optionally
   // applying the same Reader filter to each. Depending on their size,
   // rows and cells may be broken up across multiple responses, but
   // atomicity of each row will still be preserved. See the
   // ReadRowsResponse documentation for details.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc ReadRows(ReadRowsRequest) returns (stream ReadRowsResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:readRows" body: "*" };
   }
@@ -47,18 +41,12 @@ service Bigtable {
   // delimit contiguous sections of the table of approximately equal size,
   // which can be used to break up the data for distributed tasks like
   // mapreduces.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc SampleRowKeys(SampleRowKeysRequest) returns (stream SampleRowKeysResponse) {
     option (google.api.http) = { get: "/v2/{table_name=projects/*/instances/*/tables/*}:sampleRowKeys" };
   }
 
   // Mutates a row atomically. Cells already present in the row are left
-  // unchanged unless explicitly changed by 'mutation'.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
+  // unchanged unless explicitly changed by `mutation`.
   rpc MutateRow(MutateRowRequest) returns (MutateRowResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:mutateRow" body: "*" };
   }
@@ -66,28 +54,20 @@ service Bigtable {
   // Mutates multiple rows in a batch. Each individual row is mutated
   // atomically as in MutateRow, but the entire batch is not executed
   // atomically.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc MutateRows(MutateRowsRequest) returns (stream MutateRowsResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:mutateRows" body: "*" };
   }
 
   // Mutates a row atomically based on the output of a predicate Reader filter.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc CheckAndMutateRow(CheckAndMutateRowRequest) returns (CheckAndMutateRowResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:checkAndMutateRow" body: "*" };
   }
 
-  // Modifies a row atomically, reading the latest existing timestamp/value from
-  // the specified columns and writing a new value at
-  // max(existing timestamp, current server time) based on pre-defined
-  // read/modify/write rules. Returns the new contents of all modified cells.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
+  // Modifies a row atomically. The method reads the latest existing timestamp
+  // and value from the specified columns and writes a new entry based on
+  // pre-defined read/modify/write rules. The new value for the timestamp is the
+  // greater of the existing timestamp or the current server time. The method
+  // returns the new contents of all modified cells.
   rpc ReadModifyWriteRow(ReadModifyWriteRowRequest) returns (ReadModifyWriteRowResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:readModifyWriteRow" body: "*" };
   }
@@ -97,7 +77,7 @@ service Bigtable {
 message ReadRowsRequest {
   // The unique name of the table from which to read.
   // Values are of the form
-  // projects/<project>/instances/<instance>/tables/<table>
+  // projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;
   string table_name = 1;
 
   // The row keys and/or ranges to read. If not specified, reads from all rows.
@@ -128,22 +108,22 @@ message ReadRowsResponse {
     // family as the previous CellChunk.  The empty string can occur as a
     // column family name in a response so clients must check
     // explicitly for the presence of this message, not just for
-    // family_name.value being non-empty.
+    // `family_name.value` being non-empty.
     google.protobuf.StringValue family_name = 2;
 
     // The column qualifier for this chunk of data.  If this message
     // is not present, this CellChunk is a continuation of the same column
     // as the previous CellChunk.  Column qualifiers may be empty so
     // clients must check for the presence of this message, not just
-    // for qualifier.value being non-empty.
+    // for `qualifier.value` being non-empty.
     google.protobuf.BytesValue qualifier = 3;
 
     // The cell's stored timestamp, which also uniquely identifies it
     // within its column.  Values are always expressed in
     // microseconds, but individual tables may set a coarser
-    // "granularity" to further restrict the allowed values. For
+    // granularity to further restrict the allowed values. For
     // example, a table which specifies millisecond granularity will
-    // only allow values of "timestamp_micros" which are multiples of
+    // only allow values of `timestamp_micros` which are multiples of
     // 1000.  Timestamps are only set in the first CellChunk per cell
     // (for cells split into multiple chunks).
     int64 timestamp_micros = 4;
@@ -168,11 +148,11 @@ message ReadRowsResponse {
 
     oneof row_status {
       // Indicates that the client should drop all previous chunks for
-      // "row_key", as it will be re-read from the beginning.
+      // `row_key`, as it will be re-read from the beginning.
       bool reset_row = 8;
 
       // Indicates that the client can safely process all previous chunks for
-      // "row_key", as its data has been fully read.
+      // `row_key`, as its data has been fully read.
       bool commit_row = 9;
     }
   }
@@ -193,7 +173,7 @@ message ReadRowsResponse {
 message SampleRowKeysRequest {
   // The unique name of the table from which to sample row keys.
   // Values are of the form
-  // projects/<project>/instances/<instance>/tables/<table>
+  // projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;
   string table_name = 1;
 }
 
@@ -209,9 +189,9 @@ message SampleRowKeysResponse {
   bytes row_key = 1;
 
   // Approximate total storage space used by all rows in the table which precede
-  // "row_key". Buffering the contents of all rows between two subsequent
+  // `row_key`. Buffering the contents of all rows between two subsequent
   // samples would require space roughly equal to the difference in their
-  // "offset_bytes" fields.
+  // `offset_bytes` fields.
   int64 offset_bytes = 2;
 }
 
@@ -219,7 +199,7 @@ message SampleRowKeysResponse {
 message MutateRowRequest {
   // The unique name of the table to which the mutation should be applied.
   // Values are of the form
-  // projects/<project>/instances/<instance>/tables/<table>
+  // projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;
   string table_name = 1;
 
   // The key of the row to which the mutation should be applied.
@@ -245,17 +225,17 @@ message MutateRowsRequest {
     // Changes to be atomically applied to the specified row. Mutations are
     // applied in order, meaning that earlier mutations can be masked by
     // later ones.
-    // At least one mutation must be specified.
+    // You must specify at least one mutation.
     repeated Mutation mutations = 2;
   }
 
   // The unique name of the table to which the mutations should be applied.
   string table_name = 1;
 
-  // The row keys/mutations to be applied in bulk.
+  // The row keys and corresponding mutations to be applied in bulk.
   // Each entry is applied as an atomic mutation, but the entries may be
   // applied in arbitrary order (even between entries for the same row).
-  // At least one entry must be specified, and in total the entries may
+  // At least one entry must be specified, and in total the entries can
   // contain at most 100000 mutations.
   repeated Entry entries = 2;
 }
@@ -283,36 +263,36 @@ message CheckAndMutateRowRequest {
   // The unique name of the table to which the conditional mutation should be
   // applied.
   // Values are of the form
-  // projects/<project>/instances/<instance>/tables/<table>
+  // projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;
   string table_name = 1;
 
   // The key of the row to which the conditional mutation should be applied.
   bytes row_key = 2;
 
   // The filter to be applied to the contents of the specified row. Depending
-  // on whether or not any results are yielded, either "true_mutations" or
-  // "false_mutations" will be executed. If unset, checks that the row contains
+  // on whether or not any results are yielded, either `true_mutations` or
+  // `false_mutations` will be executed. If unset, checks that the row contains
   // any values at all.
   RowFilter predicate_filter = 6;
 
-  // Changes to be atomically applied to the specified row if "predicate_filter"
-  // yields at least one cell when applied to "row_key". Entries are applied in
+  // Changes to be atomically applied to the specified row if `predicate_filter`
+  // yields at least one cell when applied to `row_key`. Entries are applied in
   // order, meaning that earlier mutations can be masked by later ones.
-  // Must contain at least one entry if "false_mutations" is empty, and at most
+  // Must contain at least one entry if `false_mutations` is empty, and at most
   // 100000.
   repeated Mutation true_mutations = 4;
 
-  // Changes to be atomically applied to the specified row if "predicate_filter"
-  // does not yield any cells when applied to "row_key". Entries are applied in
+  // Changes to be atomically applied to the specified row if `predicate_filter`
+  // does not yield any cells when applied to `row_key`. Entries are applied in
   // order, meaning that earlier mutations can be masked by later ones.
-  // Must contain at least one entry if "true_mutations" is empty, and at most
+  // Must contain at least one entry if `true_mutations` is empty, and at most
   // 100000.
   repeated Mutation false_mutations = 5;
 }
 
 // Response message for Bigtable.CheckAndMutateRow.
 message CheckAndMutateRowResponse {
-  // Whether or not the request's "predicate_filter" yielded any results for
+  // Whether or not the request's `predicate_filter` yielded any results for
   // the specified row.
   bool predicate_matched = 1;
 }
@@ -322,7 +302,7 @@ message ReadModifyWriteRowRequest {
   // The unique name of the table to which the read/modify/write rules should be
   // applied.
   // Values are of the form
-  // projects/<project>/instances/<instance>/tables/<table>
+  // projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;
   string table_name = 1;
 
   // The key of the row to which the read/modify/write rules should be applied.

--- a/gcloud/bigtable/_generated_v2/_bigtable_instance_admin.proto
+++ b/gcloud/bigtable/_generated_v2/_bigtable_instance_admin.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package google.bigtable.admin.v2;
 
 import "google/api/annotations.proto";
-import "google/bigtable/admin/v2/common.proto";
 import "google/bigtable/admin/v2/instance.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
@@ -31,86 +30,53 @@ option java_package = "com.google.bigtable.admin.v2";
 // Service for creating, configuring, and deleting Cloud Bigtable Instances and
 // Clusters. Provides access to the Instance and Cluster schemas only, not the
 // tables metadata or data stored in those tables.
-//
-// Caution: This service is experimental. The details can change and the rpcs
-// may or may not be active.
 service BigtableInstanceAdmin {
   // Create an instance within a project.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc CreateInstance(CreateInstanceRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { post: "/v2/{name=projects/*}/instances" body: "*" };
+    option (google.api.http) = { post: "/v2/{parent=projects/*}/instances" body: "*" };
   }
 
   // Gets information about an instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc GetInstance(GetInstanceRequest) returns (Instance) {
     option (google.api.http) = { get: "/v2/{name=projects/*/instances/*}" };
   }
 
   // Lists information about instances in a project.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc ListInstances(ListInstancesRequest) returns (ListInstancesResponse) {
-    option (google.api.http) = { get: "/v2/{name=projects/*}/instances" };
+    option (google.api.http) = { get: "/v2/{parent=projects/*}/instances" };
   }
 
   // Updates an instance within a project.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc UpdateInstance(Instance) returns (Instance) {
     option (google.api.http) = { put: "/v2/{name=projects/*/instances/*}" body: "*" };
   }
 
   // Delete an instance from a project.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { delete: "/v2/{name=projects/*/instances/*}" };
   }
 
   // Creates a cluster within an instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc CreateCluster(CreateClusterRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { post: "/v2/{name=projects/*/instances/*}/clusters" body: "cluster" };
+    option (google.api.http) = { post: "/v2/{parent=projects/*/instances/*}/clusters" body: "cluster" };
   }
 
   // Gets information about a cluster.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc GetCluster(GetClusterRequest) returns (Cluster) {
     option (google.api.http) = { get: "/v2/{name=projects/*/instances/*/clusters/*}" };
   }
 
   // Lists information about clusters in an instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc ListClusters(ListClustersRequest) returns (ListClustersResponse) {
-    option (google.api.http) = { get: "/v2/{name=projects/*/instances/*}/clusters" };
+    option (google.api.http) = { get: "/v2/{parent=projects/*/instances/*}/clusters" };
   }
 
   // Updates a cluster within an instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc UpdateCluster(Cluster) returns (google.longrunning.Operation) {
     option (google.api.http) = { put: "/v2/{name=projects/*/instances/*/clusters/*}" body: "*" };
   }
 
   // Deletes a cluster from an instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc DeleteCluster(DeleteClusterRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { delete: "/v2/{name=projects/*/instances/*/clusters/*}" };
   }
@@ -118,23 +84,48 @@ service BigtableInstanceAdmin {
 
 // Request message for BigtableInstanceAdmin.CreateInstance.
 message CreateInstanceRequest {
-  string name = 1;
+  // The unique name of the project in which to create the new instance.
+  // Values are of the form projects/<project>
+  string parent = 1;
 
+  // The id to be used when referring to the new instance within its project,
+  // e.g. just the "myinstance" section of the full name
+  // "projects/myproject/instances/myinstance"
   string instance_id = 2;
 
+  // The instance to create.
+  // Fields marked "@OutputOnly" must be left blank.
   Instance instance = 3;
 
+  // The clusters to be created within the instance, mapped by desired
+  // cluster ID (e.g. just the "mycluster" part of the full name
+  // "projects/myproject/instances/myinstance/clusters/mycluster").
+  // Fields marked "@OutputOnly" must be left blank.
+  // Currently exactly one cluster must be specified.
   map<string, Cluster> clusters = 4;
 }
 
 // Request message for BigtableInstanceAdmin.GetInstance.
 message GetInstanceRequest {
+  // The unique name of the requested instance. Values are of the form
+  // projects/<project>/instances/<instance>
   string name = 1;
 }
 
 // Request message for BigtableInstanceAdmin.ListInstances.
 message ListInstancesRequest {
-  string name = 1;
+  // The unique name of the project for which a list of instances is requested.
+  // Values are of the form projects/<project>
+  string parent = 1;
+
+  // The value of `next_page_token` returned by a previous call.
+  string page_token = 2;
+}
+
+// Response message for BigtableInstanceAdmin.ListInstances.
+message ListInstancesResponse {
+  // The list of requested instances.
+  repeated Instance instances = 1;
 
   // Locations from which Instance information could not be retrieved,
   // due to an outage or some other transient condition.
@@ -143,47 +134,58 @@ message ListInstancesRequest {
   // Cluster in a failed location may only have partial information returned.
   repeated string failed_locations = 2;
 
-  string page_token = 3;
-}
-
-// Response message for BigtableInstanceAdmin.ListInstances.
-message ListInstancesResponse {
-  repeated Instance instances = 1;
-
-  string next_page_token = 2;
+  // Set if not all instances could be returned in a single response.
+  // Pass this value to `page_token` in another request to get the next
+  // page of results.
+  string next_page_token = 3;
 }
 
 // Request message for BigtableInstanceAdmin.DeleteInstance.
 message DeleteInstanceRequest {
+  // The unique name of the instance to be deleted.
+  // Values are of the form projects/<project>/instances/<instance>
   string name = 1;
 }
 
 // Request message for BigtableInstanceAdmin.CreateCluster.
 message CreateClusterRequest {
-  string name = 1;
+  // The unique name of the instance in which to create the new cluster.
+  // Values are of the form
+  // projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*
+  string parent = 1;
 
+  // The id to be used when referring to the new cluster within its instance,
+  // e.g. just the "mycluster" section of the full name
+  // "projects/myproject/instances/myinstance/clusters/mycluster"
   string cluster_id = 2;
 
+  // The cluster to be created.
+  // Fields marked "@OutputOnly" must be left blank.
   Cluster cluster = 3;
 }
 
 // Request message for BigtableInstanceAdmin.GetCluster.
 message GetClusterRequest {
+  // The unique name of the requested cluster. Values are of the form
+  // projects/<project>/instances/<instance>/clusters/<cluster>
   string name = 1;
 }
 
 // Request message for BigtableInstanceAdmin.ListClusters.
 message ListClustersRequest {
-  // Values are of the form projects/<project id>/instances/<instance id>
-  // Use <instance id> = '-' to list Clusters for all Instances in a project,
+  // The unique name of the instance for which a list of clusters is requested.
+  // Values are of the form projects/<project>/instances/<instance>
+  // Use <instance> = '-' to list Clusters for all Instances in a project,
   // for example "projects/myproject/instances/-"
-  string name = 1;
+  string parent = 1;
 
+  // The value of `next_page_token` returned by a previous call.
   string page_token = 2;
 }
 
 // Response message for BigtableInstanceAdmin.ListClusters.
 message ListClustersResponse {
+  // The list of requested clusters.
   repeated Cluster clusters = 1;
 
   // Locations from which Cluster information could not be retrieved,
@@ -192,11 +194,16 @@ message ListClustersResponse {
   // or may only have partial information returned.
   repeated string failed_locations = 2;
 
+  // Set if not all clusters could be returned in a single response.
+  // Pass this value to `page_token` in another request to get the next
+  // page of results.
   string next_page_token = 3;
 }
 
 // Request message for BigtableInstanceAdmin.DeleteCluster.
 message DeleteClusterRequest {
+  // The unique name of the cluster to be deleted. Values are of the form
+  // projects/<project>/instances/<instance>/clusters/<cluster>
   string name = 1;
 }
 
@@ -204,6 +211,18 @@ message DeleteClusterRequest {
 message CreateInstanceMetadata {
   // The request that prompted the initiation of this CreateInstance operation.
   CreateInstanceRequest original_request = 1;
+
+  // The time at which the original request was received.
+  google.protobuf.Timestamp request_time = 2;
+
+  // The time at which the operation failed or was completed successfully.
+  google.protobuf.Timestamp finish_time = 3;
+}
+
+// The metadata for the Operation returned by UpdateCluster.
+message UpdateClusterMetadata {
+  // The request that prompted the initiation of this UpdateCluster operation.
+  Cluster original_request = 1;
 
   // The time at which the original request was received.
   google.protobuf.Timestamp request_time = 2;

--- a/gcloud/bigtable/_generated_v2/_bigtable_table_admin.proto
+++ b/gcloud/bigtable/_generated_v2/_bigtable_table_admin.proto
@@ -28,49 +28,31 @@ option java_package = "com.google.bigtable.admin.v2";
 // Service for creating, configuring, and deleting Cloud Bigtable tables.
 // Provides access to the table schemas only, not the data stored within
 // the tables.
-//
-// Caution: This service is experimental. The details can change and the rpcs
-// may or may not be active.
 service BigtableTableAdmin {
   // Creates a new table in the specified instance.
   // The table can be created with a full set of initial column families,
   // specified in the request.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc CreateTable(CreateTableRequest) returns (Table) {
-    option (google.api.http) = { post: "/v2/{name=projects/*/instances/*}/tables" body: "*" };
+    option (google.api.http) = { post: "/v2/{parent=projects/*/instances/*}/tables" body: "*" };
   }
 
   // Lists all tables served from a specified instance.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc ListTables(ListTablesRequest) returns (ListTablesResponse) {
-    option (google.api.http) = { get: "/v2/{name=projects/*/instances/*}/tables" };
+    option (google.api.http) = { get: "/v2/{parent=projects/*/instances/*}/tables" };
   }
 
   // Gets metadata information about the specified table.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc GetTable(GetTableRequest) returns (Table) {
     option (google.api.http) = { get: "/v2/{name=projects/*/instances/*/tables/*}" };
   }
 
   // Permanently deletes a specified table and all of its data.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc DeleteTable(DeleteTableRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { delete: "/v2/{name=projects/*/instances/*/tables/*}" };
   }
 
   // Atomically performs a series of column family modifications
   // on the specified table.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc ModifyColumnFamilies(ModifyColumnFamiliesRequest) returns (Table) {
     option (google.api.http) = { post: "/v2/{name=projects/*/instances/*/tables/*}:modifyColumnFamilies" body: "*" };
   }
@@ -78,9 +60,6 @@ service BigtableTableAdmin {
   // Permanently drop/delete a row range from a specified table. The request can
   // specify whether to delete all rows in a table, or only those that match a
   // particular prefix.
-  //
-  // Caution: This rpc is experimental. The details can change and the rpc
-  // may or may not be active.
   rpc DropRowRange(DropRowRangeRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { post: "/v2/{name=projects/*/instances/*/tables/*}:dropRowRange" body: "*" };
   }
@@ -96,7 +75,7 @@ message CreateTableRequest {
 
   // The unique name of the instance in which to create the table.
   // Values are of the form projects/<project>/instances/<instance>
-  string name = 1;
+  string parent = 1;
 
   // The name by which the new table should be referred to within the parent
   // instance, e.g. "foobar" rather than "<parent>/tables/foobar".
@@ -143,13 +122,13 @@ message DropRowRangeRequest {
 message ListTablesRequest {
   // The unique name of the instance for which tables should be listed.
   // Values are of the form projects/<project>/instances/<instance>
-  string name = 1;
+  string parent = 1;
 
   // The view to be applied to the returned tables' fields.
   // Defaults to NAME_ONLY if unspecified (no others are currently supported).
   Table.View view = 2;
 
-  // Not yet supported.
+  // The value of `next_page_token` returned by a previous call.
   string page_token = 3;
 }
 
@@ -158,6 +137,9 @@ message ListTablesResponse {
   // The tables present in the requested cluster.
   repeated Table tables = 1;
 
+  // Set if not all tables could be returned in a single response.
+  // Pass this value to `page_token` in another request to get the next
+  // page of results.
   string next_page_token = 2;
 }
 

--- a/gcloud/bigtable/_generated_v2/_common.proto
+++ b/gcloud/bigtable/_generated_v2/_common.proto
@@ -24,10 +24,14 @@ option java_outer_classname = "CommonProto";
 option java_package = "com.google.bigtable.admin.v2";
 
 
+// Storage media types for persisting Bigtable data.
 enum StorageType {
+  // The user did not specify a storage type.
   STORAGE_TYPE_UNSPECIFIED = 0;
 
+  // Flash (SSD) storage should be used.
   SSD = 1;
 
+  // Magnetic drive (HDD) storage should be used.
   HDD = 2;
 }

--- a/gcloud/bigtable/_generated_v2/_data.proto
+++ b/gcloud/bigtable/_generated_v2/_data.proto
@@ -34,12 +34,13 @@ message Row {
   repeated Family families = 2;
 }
 
-// Specifies (some of) the contents of a single row/column family of a table.
+// Specifies (some of) the contents of a single row/column family intersection
+// of a table.
 message Family {
   // The unique key which identifies this family within its row. This is the
   // same key that's used to identify the family in, for example, a RowFilter
   // which sets its "family_name_regex_filter" field.
-  // Must match [-_.a-zA-Z0-9]+, except that AggregatingRowProcessors may
+  // Must match `[-_.a-zA-Z0-9]+`, except that AggregatingRowProcessors may
   // produce cells in a sentinel family with an empty name.
   // Must be no greater than 64 characters in length.
   string name = 1;
@@ -48,11 +49,12 @@ message Family {
   repeated Column columns = 2;
 }
 
-// Specifies (some of) the contents of a single row/column of a table.
+// Specifies (some of) the contents of a single row/column intersection of a
+// table.
 message Column {
   // The unique key which identifies this column within its family. This is the
   // same key that's used to identify the column in, for example, a RowFilter
-  // which sets its "column_qualifier_regex_filter" field.
+  // which sets its `column_qualifier_regex_filter` field.
   // May contain any byte string, including the empty string, up to 16kiB in
   // length.
   bytes qualifier = 1;
@@ -66,9 +68,9 @@ message Cell {
   // The cell's stored timestamp, which also uniquely identifies it within
   // its column.
   // Values are always expressed in microseconds, but individual tables may set
-  // a coarser "granularity" to further restrict the allowed values. For
+  // a coarser granularity to further restrict the allowed values. For
   // example, a table which specifies millisecond granularity will only allow
-  // values of "timestamp_micros" which are multiples of 1000.
+  // values of `timestamp_micros` which are multiples of 1000.
   int64 timestamp_micros = 1;
 
   // The value stored in the cell.
@@ -76,7 +78,7 @@ message Cell {
   // length.
   bytes value = 2;
 
-  // Labels applied to the cell by a [RowFilter][google.bigtable.v1.RowFilter].
+  // Labels applied to the cell by a [RowFilter][google.bigtable.v2.RowFilter].
   repeated string labels = 3;
 }
 
@@ -113,14 +115,14 @@ message RowSet {
 }
 
 // Specifies a contiguous range of columns within a single column family.
-// The range spans from <column_family>:<start_qualifier> to
-// <column_family>:<end_qualifier>, where both bounds can be either inclusive or
-// exclusive.
+// The range spans from &lt;column_family&gt;:&lt;start_qualifier&gt; to
+// &lt;column_family&gt;:&lt;end_qualifier&gt;, where both bounds can be either
+// inclusive or exclusive.
 message ColumnRange {
   // The name of the column family within which this range falls.
   string family_name = 1;
 
-  // The column qualifier at which to start the range (within 'column_family').
+  // The column qualifier at which to start the range (within `column_family`).
   // If neither field is set, interpreted as the empty string, inclusive.
   oneof start_qualifier {
     // Used when giving an inclusive lower bound for the range.
@@ -130,7 +132,7 @@ message ColumnRange {
     bytes start_qualifier_open = 3;
   }
 
-  // The column qualifier at which to end the range (within 'column_family').
+  // The column qualifier at which to end the range (within `column_family`).
   // If neither field is set, interpreted as the infinite string, exclusive.
   oneof end_qualifier {
     // Used when giving an inclusive upper bound for the range.
@@ -186,18 +188,18 @@ message ValueRange {
 // (chains and interleaves). They work as follows:
 //
 // * True filters alter the input row by excluding some of its cells wholesale
-// from the output row. An example of a true filter is the "value_regex_filter",
+// from the output row. An example of a true filter is the `value_regex_filter`,
 // which excludes cells whose values don't match the specified pattern. All
 // regex true filters use RE2 syntax (https://github.com/google/re2/wiki/Syntax)
 // in raw byte mode (RE2::Latin1), and are evaluated as full matches. An
-// important point to keep in mind is that RE2(.) is equivalent by default to
-// RE2([^\n]), meaning that it does not match newlines. When attempting to match
-// an arbitrary byte, you should therefore use the escape sequence '\C', which
-// may need to be further escaped as '\\C' in your client language.
+// important point to keep in mind is that `RE2(.)` is equivalent by default to
+// `RE2([^\n])`, meaning that it does not match newlines. When attempting to
+// match an arbitrary byte, you should therefore use the escape sequence `\C`,
+// which may need to be further escaped as `\\C` in your client language.
 //
 // * Transformers alter the input row by changing the values of some of its
 // cells in the output, without excluding them completely. Currently, the only
-// supported transformer is the "strip_value_transformer", which replaces every
+// supported transformer is the `strip_value_transformer`, which replaces every
 // cell's value with the empty string.
 //
 // * Chains and interleaves are described in more detail in the
@@ -224,23 +226,24 @@ message RowFilter {
     // they will all appear in the output row in an unspecified mutual order.
     // Consider the following example, with three filters:
     //
-    //                              input row
-    //                                  |
-    //        -----------------------------------------------------
-    //        |                         |                         |
-    //       f(0)                      f(1)                      f(2)
-    //        |                         |                         |
-    // 1: foo,bar,10,x             foo,bar,10,z              far,bar,7,a
-    // 2: foo,blah,11,z            far,blah,5,x              far,blah,5,x
-    //        |                         |                         |
-    //        -----------------------------------------------------
-    //                                  |
-    // 1:                        foo,bar,10,z     // could have switched with #2
-    // 2:                        foo,bar,10,x     // could have switched with #1
-    // 3:                        foo,blah,11,z
-    // 4:                        far,bar,7,a
-    // 5:                        far,blah,5,x     // identical to #6
-    // 6:                        far,blah,5,x     // identical to #5
+    //                                  input row
+    //                                      |
+    //            -----------------------------------------------------
+    //            |                         |                         |
+    //           f(0)                      f(1)                      f(2)
+    //            |                         |                         |
+    //     1: foo,bar,10,x             foo,bar,10,z              far,bar,7,a
+    //     2: foo,blah,11,z            far,blah,5,x              far,blah,5,x
+    //            |                         |                         |
+    //            -----------------------------------------------------
+    //                                      |
+    //     1:                      foo,bar,10,z   // could have switched with #2
+    //     2:                      foo,bar,10,x   // could have switched with #1
+    //     3:                      foo,blah,11,z
+    //     4:                      far,bar,7,a
+    //     5:                      far,blah,5,x   // identical to #6
+    //     6:                      far,blah,5,x   // identical to #5
+    //
     // All interleaved filters are executed atomically.
     repeated RowFilter filters = 1;
   }
@@ -253,15 +256,15 @@ message RowFilter {
   // results. Additionally, Condition filters have poor performance, especially
   // when filters are set for the false condition.
   message Condition {
-    // If "predicate_filter" outputs any cells, then "true_filter" will be
-    // evaluated on the input row. Otherwise, "false_filter" will be evaluated.
+    // If `predicate_filter` outputs any cells, then `true_filter` will be
+    // evaluated on the input row. Otherwise, `false_filter` will be evaluated.
     RowFilter predicate_filter = 1;
 
-    // The filter to apply to the input row if "predicate_filter" returns any
+    // The filter to apply to the input row if `predicate_filter` returns any
     // results. If not provided, no results will be returned in the true case.
     RowFilter true_filter = 2;
 
-    // The filter to apply to the input row if "predicate_filter" does not
+    // The filter to apply to the input row if `predicate_filter` does not
     // return any results. If not provided, no results will be returned in the
     // false case.
     RowFilter false_filter = 3;
@@ -287,14 +290,14 @@ message RowFilter {
     // the output of the read rather than to any parent filter. Consider the
     // following example:
     //
-    // Chain(
-    //   FamilyRegex("A"),
-    //   Interleave(
-    //     All(),
-    //     Chain(Label("foo"), Sink())
-    //   ),
-    //   QualifierRegex("B")
-    // )
+    //     Chain(
+    //       FamilyRegex("A"),
+    //       Interleave(
+    //         All(),
+    //         Chain(Label("foo"), Sink())
+    //       ),
+    //       QualifierRegex("B")
+    //     )
     //
     //                         A,A,1,w
     //                         A,B,2,x
@@ -332,7 +335,7 @@ message RowFilter {
     // Despite being excluded by the qualifier filter, a copy of every cell
     // that reaches the sink is present in the final result.
     //
-    // As with an [Interleave][google.bigtable.v1.RowFilter.Interleave],
+    // As with an [Interleave][google.bigtable.v2.RowFilter.Interleave],
     // duplicate cells are possible, and appear in an unspecified mutual order.
     // In this case we have a duplicate with column "A:B" and timestamp 2,
     // because one copy passed through the all filter while the other was
@@ -340,7 +343,7 @@ message RowFilter {
     // while the other does not.
     //
     // Cannot be used within the `predicate_filter`, `true_filter`, or
-    // `false_filter` of a [Condition][google.bigtable.v1.RowFilter.Condition].
+    // `false_filter` of a [Condition][google.bigtable.v2.RowFilter.Condition].
     bool sink = 16;
 
     // Matches all cells, regardless of input. Functionally equivalent to
@@ -354,9 +357,9 @@ message RowFilter {
     // Matches only cells from rows whose keys satisfy the given RE2 regex. In
     // other words, passes through the entire row when the key matches, and
     // otherwise produces an empty row.
-    // Note that, since row keys can contain arbitrary bytes, the '\C' escape
-    // sequence must be used if a true wildcard is desired. The '.' character
-    // will not match the new line character '\n', which may be present in a
+    // Note that, since row keys can contain arbitrary bytes, the `\C` escape
+    // sequence must be used if a true wildcard is desired. The `.` character
+    // will not match the new line character `\n`, which may be present in a
     // binary key.
     bytes row_key_regex_filter = 4;
 
@@ -365,18 +368,18 @@ message RowFilter {
     double row_sample_filter = 14;
 
     // Matches only cells from columns whose families satisfy the given RE2
-    // regex. For technical reasons, the regex must not contain the ':'
+    // regex. For technical reasons, the regex must not contain the `:`
     // character, even if it is not being used as a literal.
     // Note that, since column families cannot contain the new line character
-    // '\n', it is sufficient to use '.' as a full wildcard when matching
+    // `\n`, it is sufficient to use `.` as a full wildcard when matching
     // column family names.
     string family_name_regex_filter = 5;
 
     // Matches only cells from columns whose qualifiers satisfy the given RE2
     // regex.
-    // Note that, since column qualifiers can contain arbitrary bytes, the '\C'
-    // escape sequence must be used if a true wildcard is desired. The '.'
-    // character will not match the new line character '\n', which may be
+    // Note that, since column qualifiers can contain arbitrary bytes, the `\C`
+    // escape sequence must be used if a true wildcard is desired. The `.`
+    // character will not match the new line character `\n`, which may be
     // present in a binary qualifier.
     bytes column_qualifier_regex_filter = 6;
 
@@ -387,9 +390,9 @@ message RowFilter {
     TimestampRange timestamp_range_filter = 8;
 
     // Matches only cells with values that satisfy the given regular expression.
-    // Note that, since cell values can contain arbitrary bytes, the '\C' escape
-    // sequence must be used if a true wildcard is desired. The '.' character
-    // will not match the new line character '\n', which may be present in a
+    // Note that, since cell values can contain arbitrary bytes, the `\C` escape
+    // sequence must be used if a true wildcard is desired. The `.` character
+    // will not match the new line character `\n`, which may be present in a
     // binary value.
     bytes value_regex_filter = 9;
 
@@ -407,9 +410,9 @@ message RowFilter {
     int32 cells_per_row_limit_filter = 11;
 
     // Matches only the most recent N cells within each column. For example,
-    // if N=2, this filter would match column "foo:bar" at timestamps 10 and 9,
-    // skip all earlier cells in "foo:bar", and then begin matching again in
-    // column "foo:bar2".
+    // if N=2, this filter would match column `foo:bar` at timestamps 10 and 9,
+    // skip all earlier cells in `foo:bar`, and then begin matching again in
+    // column `foo:bar2`.
     // If duplicate cells are present, as is possible when using an Interleave,
     // each copy of the cell is counted separately.
     int32 cells_per_column_limit_filter = 12;
@@ -422,14 +425,14 @@ message RowFilter {
     // the filter.
     //
     // Values must be at most 15 characters in length, and match the RE2
-    // pattern [a-z0-9\\-]+
+    // pattern `[a-z0-9\\-]+`
     //
     // Due to a technical limitation, it is not currently possible to apply
     // multiple labels to a cell. As a result, a Chain may have no more than
-    // one sub-filter which contains a apply_label_transformer. It is okay for
-    // an Interleave to contain multiple apply_label_transformers, as they will
-    // be applied to separate copies of the input. This may be relaxed in the
-    // future.
+    // one sub-filter which contains a `apply_label_transformer`. It is okay for
+    // an Interleave to contain multiple `apply_label_transformers`, as they
+    // will be applied to separate copies of the input. This may be relaxed in
+    // the future.
     string apply_label_transformer = 19;
   }
 }
@@ -439,7 +442,7 @@ message Mutation {
   // A Mutation which sets the value of the specified cell.
   message SetCell {
     // The name of the family into which new data should be written.
-    // Must match [-_.a-zA-Z0-9]+
+    // Must match `[-_.a-zA-Z0-9]+`
     string family_name = 1;
 
     // The qualifier of the column into which new data should be written.
@@ -450,7 +453,7 @@ message Mutation {
     // Use -1 for current Bigtable server time.
     // Otherwise, the client should set this value itself, noting that the
     // default value is a timestamp of zero if the field is left unspecified.
-    // Values must match the "granularity" of the table (e.g. micros, millis).
+    // Values must match the granularity of the table (e.g. micros, millis).
     int64 timestamp_micros = 3;
 
     // The value to be written into the specified cell.
@@ -461,7 +464,7 @@ message Mutation {
   // restricting the deletions to a given timestamp range.
   message DeleteFromColumn {
     // The name of the family from which cells should be deleted.
-    // Must match [-_.a-zA-Z0-9]+
+    // Must match `[-_.a-zA-Z0-9]+`
     string family_name = 1;
 
     // The qualifier of the column from which cells should be deleted.
@@ -475,7 +478,7 @@ message Mutation {
   // A Mutation which deletes all cells from the specified column family.
   message DeleteFromFamily {
     // The name of the family from which cells should be deleted.
-    // Must match [-_.a-zA-Z0-9]+
+    // Must match `[-_.a-zA-Z0-9]+`
     string family_name = 1;
   }
 
@@ -504,7 +507,7 @@ message Mutation {
 // specified column.
 message ReadModifyWriteRule {
   // The name of the family to which the read/modify/write should be applied.
-  // Must match [-_.a-zA-Z0-9]+
+  // Must match `[-_.a-zA-Z0-9]+`
   string family_name = 1;
 
   // The qualifier of the column to which the read/modify/write should be
@@ -515,12 +518,12 @@ message ReadModifyWriteRule {
   // The rule used to determine the column's new latest value from its current
   // latest value.
   oneof rule {
-    // Rule specifying that "append_value" be appended to the existing value.
+    // Rule specifying that `append_value` be appended to the existing value.
     // If the targeted cell is unset, it will be treated as containing the
     // empty string.
     bytes append_value = 3;
 
-    // Rule specifying that "increment_amount" be added to the existing value.
+    // Rule specifying that `increment_amount` be added to the existing value.
     // If the targeted cell is unset, it will be treated as containing a zero.
     // Otherwise, the targeted cell must contain an 8-byte value (interpreted
     // as a 64-bit big-endian signed integer), or the entire request will fail.

--- a/gcloud/bigtable/_generated_v2/_instance.proto
+++ b/gcloud/bigtable/_generated_v2/_instance.proto
@@ -24,10 +24,18 @@ option java_outer_classname = "InstanceProto";
 option java_package = "com.google.bigtable.admin.v2";
 
 
+// A collection of Bigtable [Tables][google.bigtable.admin.v2.Table] and
+// the resources that serve them.
+// All tables in an instance are served from a single
+// [Cluster][google.bigtable.admin.v2.Cluster].
 message Instance {
+  // Possible states of an instance.
   enum State {
+    // The state of the instance could not be determined.
     STATE_NOT_KNOWN = 0;
 
+    // The instance has been successfully created and can serve requests
+    // to its tables.
     READY = 1;
 
     // The instance is currently being created, and may be destroyed
@@ -36,43 +44,70 @@ message Instance {
   }
 
   // @OutputOnly
+  // The unique name of the instance. Values are of the form
+  // projects/<project>/instances/[a-z][a-z0-9\\-]+[a-z0-9]
   string name = 1;
 
+  // The descriptive name for this instance as it appears in UIs.
+  // Can be changed at any time, but should be kept globally unique
+  // to avoid confusion.
   string display_name = 2;
 
-  // @OutputOnly
+  //
+  // The current state of the instance.
   State state = 3;
 }
 
+// A resizable group of nodes in a particular cloud location, capable
+// of serving all [Tables][google.bigtable.admin.v2.Table] in the parent
+// [Instance][google.bigtable.admin.v2.Instance].
 message Cluster {
+  // Possible states of a cluster.
   enum State {
+    // The state of the cluster could not be determined.
     STATE_NOT_KNOWN = 0;
 
+    // The cluster has been successfully created and is ready to serve requests.
     READY = 1;
 
     // The cluster is currently being created, and may be destroyed
     // if the creation process encounters an error.
+    // A cluster may not be able to serve requests while being created.
     CREATING = 2;
 
+    // The cluster is currently being resized, and may revert to its previous
+    // node count if the process encounters an error.
+    // A cluster is still capable of serving requests while being resized,
+    // but may exhibit performance as if its number of allocated nodes is
+    // between the starting and requested states.
     RESIZING = 3;
 
-    // The cluster has no backing nodes.  The data (tables) still
+    // The cluster has no backing nodes. The data (tables) still
     // exist, but no operations can be performed on the cluster.
     DISABLED = 4;
   }
 
   // @OutputOnly
+  // The unique name of the cluster. Values are of the form
+  // projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*
   string name = 1;
 
   // @CreationOnly
+  // The location where this cluster's nodes and storage reside. For best
+  // performance, clients should be located as close as possible to this cluster.
   // Currently only zones are supported, e.g. projects/*/locations/us-central1-b
   string location = 2;
 
   // @OutputOnly
+  // The current state of the cluster.
   State state = 3;
 
+  // The number of nodes allocated to this cluster. More nodes enable higher
+  // throughput and more consistent performance.
   int32 serve_nodes = 4;
 
   // @CreationOnly
+  // The type of storage used by this cluster to serve its
+  // parent instance's tables, unless explicitly overridden.
   StorageType default_storage_type = 5;
 }

--- a/gcloud/bigtable/_generated_v2/_table.proto
+++ b/gcloud/bigtable/_generated_v2/_table.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package google.bigtable.admin.v2;
 
+import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
 option java_multiple_files = true;
@@ -26,43 +27,14 @@ option java_package = "com.google.bigtable.admin.v2";
 // A collection of user data indexed by row, column, and timestamp.
 // Each table is served using the resources of its parent cluster.
 message Table {
-  // The state of a table's data in a particular cluster.
-  message ClusterState {
-    enum ReplicationState {
-      // The replication state of the table is unknown in this cluster.
-      STATE_NOT_KNOWN = 0;
-
-      // The cluster was recently created, and the table must finish copying
-      // over pre-existing data from other clusters before it can begin
-      // receiving live replication updates and serving
-      // [Data API][google.bigtable.v2.BigtableService] requests.
-      INITIALIZING = 1;
-
-      // The table is temporarily unable to serve
-      // [Data API][google.bigtable.v2.BigtableService] requests from this
-      // cluster due to planned internal maintenance.
-      PLANNED_MAINTENANCE = 2;
-
-      // The table is temporarily unable to serve
-      // [Data API][google.bigtable.v2.BigtableService] requests from this
-      // cluster due to unplanned or emergency maintenance.
-      UNPLANNED_MAINTENANCE = 3;
-
-      // The table can serve
-      // [Data API][google.bigtable.v2.BigtableService] requests from this
-      // cluster. Depending on replication delay, reads may not immediately
-      // reflect the state of the table in other clusters.
-      READY = 4;
-    }
-
-    // The state of replication for the table in this cluster.
-    // @OutputOnly
-    ReplicationState replication_state = 1;
-  }
-
+  // Possible timestamp granularities to use when keeping multiple versions
+  // of data in a table.
   enum TimestampGranularity {
+    // The user did not specify a granularity. Should not be returned.
+    // When specified during table creation, MILLIS will be used.
     TIMESTAMP_GRANULARITY_UNSPECIFIED = 0;
 
+    // The table keeps data versioned at a granularity of 1ms.
     MILLIS = 1;
   }
 
@@ -77,10 +49,6 @@ message Table {
     // Only populates `name` and fields related to the table's schema.
     SCHEMA_VIEW = 2;
 
-    // Only populates `name` and fields related to the table's
-    // replication state.
-    REPLICATION_VIEW = 3;
-
     // Populates all fields.
     FULL = 4;
   }
@@ -90,14 +58,6 @@ message Table {
   // Views: NAME_ONLY, SCHEMA_VIEW, REPLICATION_VIEW, FULL
   // @OutputOnly
   string name = 1;
-
-  // Map from cluster ID to per-cluster table state.
-  // If it could not be determined whether or not the table has data in a
-  // particular cluster (for example, if its zone is unavailable), then
-  // there will be an entry for the cluster with UNKNOWN `replication_status`.
-  // Views: REPLICATION_VIEW, FULL
-  // @OutputOnly
-  map<string, ClusterState> cluster_states = 2;
 
   // The column families configured for this table, mapped by column family ID.
   // Views: SCHEMA_VIEW, FULL

--- a/gcloud/bigtable/_generated_v2/bigtable_instance_admin_pb2.py
+++ b/gcloud/bigtable/_generated_v2/bigtable_instance_admin_pb2.py
@@ -14,7 +14,6 @@ _sym_db = _symbol_database.Default()
 
 
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
-from gcloud.bigtable._generated_v2 import common_pb2 as google_dot_bigtable_dot_admin_dot_v2_dot_common__pb2
 from gcloud.bigtable._generated_v2 import instance_pb2 as google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2
 from google.longrunning import operations_pb2 as google_dot_longrunning_dot_operations__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
@@ -25,9 +24,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/bigtable/admin/v2/bigtable_instance_admin.proto',
   package='google.bigtable.admin.v2',
   syntax='proto3',
-  serialized_pb=_b('\n6google/bigtable/admin/v2/bigtable_instance_admin.proto\x12\x18google.bigtable.admin.v2\x1a\x1cgoogle/api/annotations.proto\x1a%google/bigtable/admin/v2/common.proto\x1a\'google/bigtable/admin/v2/instance.proto\x1a#google/longrunning/operations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x95\x02\n\x15\x43reateInstanceRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0binstance_id\x18\x02 \x01(\t\x12\x34\n\x08instance\x18\x03 \x01(\x0b\x32\".google.bigtable.admin.v2.Instance\x12O\n\x08\x63lusters\x18\x04 \x03(\x0b\x32=.google.bigtable.admin.v2.CreateInstanceRequest.ClustersEntry\x1aR\n\rClustersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x30\n\x05value\x18\x02 \x01(\x0b\x32!.google.bigtable.admin.v2.Cluster:\x02\x38\x01\"\"\n\x12GetInstanceRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"R\n\x14ListInstancesRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x18\n\x10\x66\x61iled_locations\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\"g\n\x15ListInstancesResponse\x12\x35\n\tinstances\x18\x01 \x03(\x0b\x32\".google.bigtable.admin.v2.Instance\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"%\n\x15\x44\x65leteInstanceRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"l\n\x14\x43reateClusterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x12\n\ncluster_id\x18\x02 \x01(\t\x12\x32\n\x07\x63luster\x18\x03 \x01(\x0b\x32!.google.bigtable.admin.v2.Cluster\"!\n\x11GetClusterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"7\n\x13ListClustersRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\"~\n\x14ListClustersResponse\x12\x33\n\x08\x63lusters\x18\x01 \x03(\x0b\x32!.google.bigtable.admin.v2.Cluster\x12\x18\n\x10\x66\x61iled_locations\x18\x02 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t\"$\n\x14\x44\x65leteClusterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xc6\x01\n\x16\x43reateInstanceMetadata\x12I\n\x10original_request\x18\x01 \x01(\x0b\x32/.google.bigtable.admin.v2.CreateInstanceRequest\x12\x30\n\x0crequest_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inish_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp2\xd3\x0b\n\x15\x42igtableInstanceAdmin\x12\x8c\x01\n\x0e\x43reateInstance\x12/.google.bigtable.admin.v2.CreateInstanceRequest\x1a\x1d.google.longrunning.Operation\"*\x82\xd3\xe4\x93\x02$\"\x1f/v2/{name=projects/*}/instances:\x01*\x12\x8a\x01\n\x0bGetInstance\x12,.google.bigtable.admin.v2.GetInstanceRequest\x1a\".google.bigtable.admin.v2.Instance\")\x82\xd3\xe4\x93\x02#\x12!/v2/{name=projects/*/instances/*}\x12\x99\x01\n\rListInstances\x12..google.bigtable.admin.v2.ListInstancesRequest\x1a/.google.bigtable.admin.v2.ListInstancesResponse\"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v2/{name=projects/*}/instances\x12\x86\x01\n\x0eUpdateInstance\x12\".google.bigtable.admin.v2.Instance\x1a\".google.bigtable.admin.v2.Instance\",\x82\xd3\xe4\x93\x02&\x1a!/v2/{name=projects/*/instances/*}:\x01*\x12\x84\x01\n\x0e\x44\x65leteInstance\x12/.google.bigtable.admin.v2.DeleteInstanceRequest\x1a\x16.google.protobuf.Empty\")\x82\xd3\xe4\x93\x02#*!/v2/{name=projects/*/instances/*}\x12\x9b\x01\n\rCreateCluster\x12..google.bigtable.admin.v2.CreateClusterRequest\x1a\x1d.google.longrunning.Operation\";\x82\xd3\xe4\x93\x02\x35\"*/v2/{name=projects/*/instances/*}/clusters:\x07\x63luster\x12\x92\x01\n\nGetCluster\x12+.google.bigtable.admin.v2.GetClusterRequest\x1a!.google.bigtable.admin.v2.Cluster\"4\x82\xd3\xe4\x93\x02.\x12,/v2/{name=projects/*/instances/*/clusters/*}\x12\xa1\x01\n\x0cListClusters\x12-.google.bigtable.admin.v2.ListClustersRequest\x1a..google.bigtable.admin.v2.ListClustersResponse\"2\x82\xd3\xe4\x93\x02,\x12*/v2/{name=projects/*/instances/*}/clusters\x12\x8a\x01\n\rUpdateCluster\x12!.google.bigtable.admin.v2.Cluster\x1a\x1d.google.longrunning.Operation\"7\x82\xd3\xe4\x93\x02\x31\x1a,/v2/{name=projects/*/instances/*/clusters/*}:\x01*\x12\x8d\x01\n\rDeleteCluster\x12..google.bigtable.admin.v2.DeleteClusterRequest\x1a\x16.google.protobuf.Empty\"4\x82\xd3\xe4\x93\x02.*,/v2/{name=projects/*/instances/*/clusters/*}B<\n\x1c\x63om.google.bigtable.admin.v2B\x1a\x42igtableInstanceAdminProtoP\x01\x62\x06proto3')
+  serialized_pb=_b('\n6google/bigtable/admin/v2/bigtable_instance_admin.proto\x12\x18google.bigtable.admin.v2\x1a\x1cgoogle/api/annotations.proto\x1a\'google/bigtable/admin/v2/instance.proto\x1a#google/longrunning/operations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x97\x02\n\x15\x43reateInstanceRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x13\n\x0binstance_id\x18\x02 \x01(\t\x12\x34\n\x08instance\x18\x03 \x01(\x0b\x32\".google.bigtable.admin.v2.Instance\x12O\n\x08\x63lusters\x18\x04 \x03(\x0b\x32=.google.bigtable.admin.v2.CreateInstanceRequest.ClustersEntry\x1aR\n\rClustersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x30\n\x05value\x18\x02 \x01(\x0b\x32!.google.bigtable.admin.v2.Cluster:\x02\x38\x01\"\"\n\x12GetInstanceRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\":\n\x14ListInstancesRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\"\x81\x01\n\x15ListInstancesResponse\x12\x35\n\tinstances\x18\x01 \x03(\x0b\x32\".google.bigtable.admin.v2.Instance\x12\x18\n\x10\x66\x61iled_locations\x18\x02 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t\"%\n\x15\x44\x65leteInstanceRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"n\n\x14\x43reateClusterRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\ncluster_id\x18\x02 \x01(\t\x12\x32\n\x07\x63luster\x18\x03 \x01(\x0b\x32!.google.bigtable.admin.v2.Cluster\"!\n\x11GetClusterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"9\n\x13ListClustersRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x12\n\npage_token\x18\x02 \x01(\t\"~\n\x14ListClustersResponse\x12\x33\n\x08\x63lusters\x18\x01 \x03(\x0b\x32!.google.bigtable.admin.v2.Cluster\x12\x18\n\x10\x66\x61iled_locations\x18\x02 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t\"$\n\x14\x44\x65leteClusterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xc6\x01\n\x16\x43reateInstanceMetadata\x12I\n\x10original_request\x18\x01 \x01(\x0b\x32/.google.bigtable.admin.v2.CreateInstanceRequest\x12\x30\n\x0crequest_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inish_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xb7\x01\n\x15UpdateClusterMetadata\x12;\n\x10original_request\x18\x01 \x01(\x0b\x32!.google.bigtable.admin.v2.Cluster\x12\x30\n\x0crequest_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inish_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp2\xdb\x0b\n\x15\x42igtableInstanceAdmin\x12\x8e\x01\n\x0e\x43reateInstance\x12/.google.bigtable.admin.v2.CreateInstanceRequest\x1a\x1d.google.longrunning.Operation\",\x82\xd3\xe4\x93\x02&\"!/v2/{parent=projects/*}/instances:\x01*\x12\x8a\x01\n\x0bGetInstance\x12,.google.bigtable.admin.v2.GetInstanceRequest\x1a\".google.bigtable.admin.v2.Instance\")\x82\xd3\xe4\x93\x02#\x12!/v2/{name=projects/*/instances/*}\x12\x9b\x01\n\rListInstances\x12..google.bigtable.admin.v2.ListInstancesRequest\x1a/.google.bigtable.admin.v2.ListInstancesResponse\")\x82\xd3\xe4\x93\x02#\x12!/v2/{parent=projects/*}/instances\x12\x86\x01\n\x0eUpdateInstance\x12\".google.bigtable.admin.v2.Instance\x1a\".google.bigtable.admin.v2.Instance\",\x82\xd3\xe4\x93\x02&\x1a!/v2/{name=projects/*/instances/*}:\x01*\x12\x84\x01\n\x0e\x44\x65leteInstance\x12/.google.bigtable.admin.v2.DeleteInstanceRequest\x1a\x16.google.protobuf.Empty\")\x82\xd3\xe4\x93\x02#*!/v2/{name=projects/*/instances/*}\x12\x9d\x01\n\rCreateCluster\x12..google.bigtable.admin.v2.CreateClusterRequest\x1a\x1d.google.longrunning.Operation\"=\x82\xd3\xe4\x93\x02\x37\",/v2/{parent=projects/*/instances/*}/clusters:\x07\x63luster\x12\x92\x01\n\nGetCluster\x12+.google.bigtable.admin.v2.GetClusterRequest\x1a!.google.bigtable.admin.v2.Cluster\"4\x82\xd3\xe4\x93\x02.\x12,/v2/{name=projects/*/instances/*/clusters/*}\x12\xa3\x01\n\x0cListClusters\x12-.google.bigtable.admin.v2.ListClustersRequest\x1a..google.bigtable.admin.v2.ListClustersResponse\"4\x82\xd3\xe4\x93\x02.\x12,/v2/{parent=projects/*/instances/*}/clusters\x12\x8a\x01\n\rUpdateCluster\x12!.google.bigtable.admin.v2.Cluster\x1a\x1d.google.longrunning.Operation\"7\x82\xd3\xe4\x93\x02\x31\x1a,/v2/{name=projects/*/instances/*/clusters/*}:\x01*\x12\x8d\x01\n\rDeleteCluster\x12..google.bigtable.admin.v2.DeleteClusterRequest\x1a\x16.google.protobuf.Empty\"4\x82\xd3\xe4\x93\x02.*,/v2/{name=projects/*/instances/*/clusters/*}B<\n\x1c\x63om.google.bigtable.admin.v2B\x1a\x42igtableInstanceAdminProtoP\x01\x62\x06proto3')
   ,
-  dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_bigtable_dot_admin_dot_v2_dot_common__pb2.DESCRIPTOR,google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.DESCRIPTOR,google_dot_longrunning_dot_operations__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
+  dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.DESCRIPTOR,google_dot_longrunning_dot_operations__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
@@ -66,8 +65,8 @@ _CREATEINSTANCEREQUEST_CLUSTERSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=489,
-  serialized_end=571,
+  serialized_start=452,
+  serialized_end=534,
 )
 
 _CREATEINSTANCEREQUEST = _descriptor.Descriptor(
@@ -78,7 +77,7 @@ _CREATEINSTANCEREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.CreateInstanceRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.CreateInstanceRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -117,8 +116,8 @@ _CREATEINSTANCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=294,
-  serialized_end=571,
+  serialized_start=255,
+  serialized_end=534,
 )
 
 
@@ -148,8 +147,8 @@ _GETINSTANCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=573,
-  serialized_end=607,
+  serialized_start=536,
+  serialized_end=570,
 )
 
 
@@ -161,22 +160,15 @@ _LISTINSTANCESREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.ListInstancesRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.ListInstancesRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='failed_locations', full_name='google.bigtable.admin.v2.ListInstancesRequest.failed_locations', index=1,
-      number=2, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='page_token', full_name='google.bigtable.admin.v2.ListInstancesRequest.page_token', index=2,
-      number=3, type=9, cpp_type=9, label=1,
+      name='page_token', full_name='google.bigtable.admin.v2.ListInstancesRequest.page_token', index=1,
+      number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -193,8 +185,8 @@ _LISTINSTANCESREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=609,
-  serialized_end=691,
+  serialized_start=572,
+  serialized_end=630,
 )
 
 
@@ -213,8 +205,15 @@ _LISTINSTANCESRESPONSE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='next_page_token', full_name='google.bigtable.admin.v2.ListInstancesResponse.next_page_token', index=1,
-      number=2, type=9, cpp_type=9, label=1,
+      name='failed_locations', full_name='google.bigtable.admin.v2.ListInstancesResponse.failed_locations', index=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='next_page_token', full_name='google.bigtable.admin.v2.ListInstancesResponse.next_page_token', index=2,
+      number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -231,8 +230,8 @@ _LISTINSTANCESRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=693,
-  serialized_end=796,
+  serialized_start=633,
+  serialized_end=762,
 )
 
 
@@ -262,8 +261,8 @@ _DELETEINSTANCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=798,
-  serialized_end=835,
+  serialized_start=764,
+  serialized_end=801,
 )
 
 
@@ -275,7 +274,7 @@ _CREATECLUSTERREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.CreateClusterRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.CreateClusterRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -307,8 +306,8 @@ _CREATECLUSTERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=837,
-  serialized_end=945,
+  serialized_start=803,
+  serialized_end=913,
 )
 
 
@@ -338,8 +337,8 @@ _GETCLUSTERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=947,
-  serialized_end=980,
+  serialized_start=915,
+  serialized_end=948,
 )
 
 
@@ -351,7 +350,7 @@ _LISTCLUSTERSREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.ListClustersRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.ListClustersRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -376,8 +375,8 @@ _LISTCLUSTERSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=982,
-  serialized_end=1037,
+  serialized_start=950,
+  serialized_end=1007,
 )
 
 
@@ -421,8 +420,8 @@ _LISTCLUSTERSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1039,
-  serialized_end=1165,
+  serialized_start=1009,
+  serialized_end=1135,
 )
 
 
@@ -452,8 +451,8 @@ _DELETECLUSTERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1167,
-  serialized_end=1203,
+  serialized_start=1137,
+  serialized_end=1173,
 )
 
 
@@ -497,8 +496,53 @@ _CREATEINSTANCEMETADATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1206,
-  serialized_end=1404,
+  serialized_start=1176,
+  serialized_end=1374,
+)
+
+
+_UPDATECLUSTERMETADATA = _descriptor.Descriptor(
+  name='UpdateClusterMetadata',
+  full_name='google.bigtable.admin.v2.UpdateClusterMetadata',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='original_request', full_name='google.bigtable.admin.v2.UpdateClusterMetadata.original_request', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='request_time', full_name='google.bigtable.admin.v2.UpdateClusterMetadata.request_time', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='finish_time', full_name='google.bigtable.admin.v2.UpdateClusterMetadata.finish_time', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1377,
+  serialized_end=1560,
 )
 
 _CREATEINSTANCEREQUEST_CLUSTERSENTRY.fields_by_name['value'].message_type = google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2._CLUSTER
@@ -511,6 +555,9 @@ _LISTCLUSTERSRESPONSE.fields_by_name['clusters'].message_type = google_dot_bigta
 _CREATEINSTANCEMETADATA.fields_by_name['original_request'].message_type = _CREATEINSTANCEREQUEST
 _CREATEINSTANCEMETADATA.fields_by_name['request_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _CREATEINSTANCEMETADATA.fields_by_name['finish_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_UPDATECLUSTERMETADATA.fields_by_name['original_request'].message_type = google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2._CLUSTER
+_UPDATECLUSTERMETADATA.fields_by_name['request_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_UPDATECLUSTERMETADATA.fields_by_name['finish_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 DESCRIPTOR.message_types_by_name['CreateInstanceRequest'] = _CREATEINSTANCEREQUEST
 DESCRIPTOR.message_types_by_name['GetInstanceRequest'] = _GETINSTANCEREQUEST
 DESCRIPTOR.message_types_by_name['ListInstancesRequest'] = _LISTINSTANCESREQUEST
@@ -522,6 +569,7 @@ DESCRIPTOR.message_types_by_name['ListClustersRequest'] = _LISTCLUSTERSREQUEST
 DESCRIPTOR.message_types_by_name['ListClustersResponse'] = _LISTCLUSTERSRESPONSE
 DESCRIPTOR.message_types_by_name['DeleteClusterRequest'] = _DELETECLUSTERREQUEST
 DESCRIPTOR.message_types_by_name['CreateInstanceMetadata'] = _CREATEINSTANCEMETADATA
+DESCRIPTOR.message_types_by_name['UpdateClusterMetadata'] = _UPDATECLUSTERMETADATA
 
 CreateInstanceRequest = _reflection.GeneratedProtocolMessageType('CreateInstanceRequest', (_message.Message,), dict(
 
@@ -608,118 +656,352 @@ CreateInstanceMetadata = _reflection.GeneratedProtocolMessageType('CreateInstanc
   ))
 _sym_db.RegisterMessage(CreateInstanceMetadata)
 
+UpdateClusterMetadata = _reflection.GeneratedProtocolMessageType('UpdateClusterMetadata', (_message.Message,), dict(
+  DESCRIPTOR = _UPDATECLUSTERMETADATA,
+  __module__ = 'google.bigtable.admin.v2.bigtable_instance_admin_pb2'
+  # @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.UpdateClusterMetadata)
+  ))
+_sym_db.RegisterMessage(UpdateClusterMetadata)
+
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\034com.google.bigtable.admin.v2B\032BigtableInstanceAdminProtoP\001'))
 _CREATEINSTANCEREQUEST_CLUSTERSENTRY.has_options = True
 _CREATEINSTANCEREQUEST_CLUSTERSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-import abc
-import six
+
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality
 from grpc.framework.interfaces.face import utilities as face_utilities
 
-class BetaBigtableInstanceAdminServicer(object):
-  """<fill me in later!>"""
+
+class BigtableInstanceAdminStub(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable Instances and
+  Clusters. Provides access to the Instance and Cluster schemas only, not the
+  tables metadata or data stored in those tables.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.CreateInstance = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance',
+        request_serializer=CreateInstanceRequest.SerializeToString,
+        response_deserializer=google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+        )
+    self.GetInstance = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/GetInstance',
+        request_serializer=GetInstanceRequest.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
+        )
+    self.ListInstances = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/ListInstances',
+        request_serializer=ListInstancesRequest.SerializeToString,
+        response_deserializer=ListInstancesResponse.FromString,
+        )
+    self.UpdateInstance = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateInstance',
+        request_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
+        )
+    self.DeleteInstance = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteInstance',
+        request_serializer=DeleteInstanceRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+    self.CreateCluster = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateCluster',
+        request_serializer=CreateClusterRequest.SerializeToString,
+        response_deserializer=google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+        )
+    self.GetCluster = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/GetCluster',
+        request_serializer=GetClusterRequest.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.FromString,
+        )
+    self.ListClusters = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/ListClusters',
+        request_serializer=ListClustersRequest.SerializeToString,
+        response_deserializer=ListClustersResponse.FromString,
+        )
+    self.UpdateCluster = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateCluster',
+        request_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.SerializeToString,
+        response_deserializer=google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+        )
+    self.DeleteCluster = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteCluster',
+        request_serializer=DeleteClusterRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+
+
+class BigtableInstanceAdminServicer(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable Instances and
+  Clusters. Provides access to the Instance and Cluster schemas only, not the
+  tables metadata or data stored in those tables.
+  """
+
   def CreateInstance(self, request, context):
+    """Create an instance within a project.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetInstance(self, request, context):
+    """Gets information about an instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListInstances(self, request, context):
+    """Lists information about instances in a project.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def UpdateInstance(self, request, context):
+    """Updates an instance within a project.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteInstance(self, request, context):
+    """Delete an instance from a project.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CreateCluster(self, request, context):
+    """Creates a cluster within an instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetCluster(self, request, context):
+    """Gets information about a cluster.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListClusters(self, request, context):
+    """Lists information about clusters in an instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def UpdateCluster(self, request, context):
+    """Updates a cluster within an instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteCluster(self, request, context):
+    """Deletes a cluster from an instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_BigtableInstanceAdminServicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'CreateInstance': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateInstance,
+          request_deserializer=CreateInstanceRequest.FromString,
+          response_serializer=google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+      ),
+      'GetInstance': grpc.unary_unary_rpc_method_handler(
+          servicer.GetInstance,
+          request_deserializer=GetInstanceRequest.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
+      ),
+      'ListInstances': grpc.unary_unary_rpc_method_handler(
+          servicer.ListInstances,
+          request_deserializer=ListInstancesRequest.FromString,
+          response_serializer=ListInstancesResponse.SerializeToString,
+      ),
+      'UpdateInstance': grpc.unary_unary_rpc_method_handler(
+          servicer.UpdateInstance,
+          request_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
+      ),
+      'DeleteInstance': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteInstance,
+          request_deserializer=DeleteInstanceRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+      'CreateCluster': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateCluster,
+          request_deserializer=CreateClusterRequest.FromString,
+          response_serializer=google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+      ),
+      'GetCluster': grpc.unary_unary_rpc_method_handler(
+          servicer.GetCluster,
+          request_deserializer=GetClusterRequest.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.SerializeToString,
+      ),
+      'ListClusters': grpc.unary_unary_rpc_method_handler(
+          servicer.ListClusters,
+          request_deserializer=ListClustersRequest.FromString,
+          response_serializer=ListClustersResponse.SerializeToString,
+      ),
+      'UpdateCluster': grpc.unary_unary_rpc_method_handler(
+          servicer.UpdateCluster,
+          request_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.FromString,
+          response_serializer=google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+      ),
+      'DeleteCluster': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteCluster,
+          request_deserializer=DeleteClusterRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.bigtable.admin.v2.BigtableInstanceAdmin', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))
+
+
+class BetaBigtableInstanceAdminServicer(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable Instances and
+  Clusters. Provides access to the Instance and Cluster schemas only, not the
+  tables metadata or data stored in those tables.
+  """
+  def CreateInstance(self, request, context):
+    """Create an instance within a project.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def GetInstance(self, request, context):
+    """Gets information about an instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def ListInstances(self, request, context):
+    """Lists information about instances in a project.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def UpdateInstance(self, request, context):
+    """Updates an instance within a project.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def DeleteInstance(self, request, context):
+    """Delete an instance from a project.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def CreateCluster(self, request, context):
+    """Creates a cluster within an instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def GetCluster(self, request, context):
+    """Gets information about a cluster.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def ListClusters(self, request, context):
+    """Lists information about clusters in an instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def UpdateCluster(self, request, context):
+    """Updates a cluster within an instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def DeleteCluster(self, request, context):
+    """Deletes a cluster from an instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
+
 class BetaBigtableInstanceAdminStub(object):
-  """The interface to which stubs will conform."""
-  def CreateInstance(self, request, timeout):
+  """Service for creating, configuring, and deleting Cloud Bigtable Instances and
+  Clusters. Provides access to the Instance and Cluster schemas only, not the
+  tables metadata or data stored in those tables.
+  """
+  def CreateInstance(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Create an instance within a project.
+    """
     raise NotImplementedError()
   CreateInstance.future = None
-  def GetInstance(self, request, timeout):
+  def GetInstance(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Gets information about an instance.
+    """
     raise NotImplementedError()
   GetInstance.future = None
-  def ListInstances(self, request, timeout):
+  def ListInstances(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Lists information about instances in a project.
+    """
     raise NotImplementedError()
   ListInstances.future = None
-  def UpdateInstance(self, request, timeout):
+  def UpdateInstance(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Updates an instance within a project.
+    """
     raise NotImplementedError()
   UpdateInstance.future = None
-  def DeleteInstance(self, request, timeout):
+  def DeleteInstance(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Delete an instance from a project.
+    """
     raise NotImplementedError()
   DeleteInstance.future = None
-  def CreateCluster(self, request, timeout):
+  def CreateCluster(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Creates a cluster within an instance.
+    """
     raise NotImplementedError()
   CreateCluster.future = None
-  def GetCluster(self, request, timeout):
+  def GetCluster(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Gets information about a cluster.
+    """
     raise NotImplementedError()
   GetCluster.future = None
-  def ListClusters(self, request, timeout):
+  def ListClusters(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Lists information about clusters in an instance.
+    """
     raise NotImplementedError()
   ListClusters.future = None
-  def UpdateCluster(self, request, timeout):
+  def UpdateCluster(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Updates a cluster within an instance.
+    """
     raise NotImplementedError()
   UpdateCluster.future = None
-  def DeleteCluster(self, request, timeout):
+  def DeleteCluster(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Deletes a cluster from an instance.
+    """
     raise NotImplementedError()
   DeleteCluster.future = None
 
+
 def beta_create_BigtableInstanceAdmin_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.protobuf.empty_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.protobuf.empty_pb2
   request_deserializers = {
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.CreateClusterRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.CreateInstanceRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.DeleteClusterRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.DeleteInstanceRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.GetClusterRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.GetInstanceRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListClustersRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListInstancesRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google.bigtable.admin.v2.instance_pb2.Cluster.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google.bigtable.admin.v2.instance_pb2.Instance.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): CreateClusterRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): CreateInstanceRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): DeleteClusterRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): DeleteInstanceRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): GetClusterRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): GetInstanceRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): ListClustersRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): ListInstancesRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
   }
   response_serializers = {
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google.longrunning.operations_pb2.Operation.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google.longrunning.operations_pb2.Operation.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google.protobuf.empty_pb2.Empty.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google.protobuf.empty_pb2.Empty.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google.bigtable.admin.v2.instance_pb2.Cluster.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google.bigtable.admin.v2.instance_pb2.Instance.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListClustersResponse.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListInstancesResponse.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google.longrunning.operations_pb2.Operation.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google.bigtable.admin.v2.instance_pb2.Instance.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): ListClustersResponse.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): ListInstancesResponse.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google_dot_longrunning_dot_operations__pb2.Operation.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
   }
   method_implementations = {
     ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): face_utilities.unary_unary_inline(servicer.CreateCluster),
@@ -736,50 +1018,31 @@ def beta_create_BigtableInstanceAdmin_server(servicer, pool=None, pool_size=None
   server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
   return beta_implementations.server(method_implementations, options=server_options)
 
+
 def beta_create_BigtableInstanceAdmin_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.protobuf.empty_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.bigtable.admin.v2.instance_pb2
-  import google.longrunning.operations_pb2
-  import google.bigtable.admin.v2.bigtable_instance_admin_pb2
-  import google.protobuf.empty_pb2
   request_serializers = {
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.CreateClusterRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.CreateInstanceRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.DeleteClusterRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.DeleteInstanceRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.GetClusterRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.GetInstanceRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListClustersRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListInstancesRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google.bigtable.admin.v2.instance_pb2.Cluster.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google.bigtable.admin.v2.instance_pb2.Instance.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): CreateClusterRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): CreateInstanceRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): DeleteClusterRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): DeleteInstanceRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): GetClusterRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): GetInstanceRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): ListClustersRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): ListInstancesRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.SerializeToString,
   }
   response_deserializers = {
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google.longrunning.operations_pb2.Operation.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google.longrunning.operations_pb2.Operation.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google.protobuf.empty_pb2.Empty.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google.protobuf.empty_pb2.Empty.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google.bigtable.admin.v2.instance_pb2.Cluster.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google.bigtable.admin.v2.instance_pb2.Instance.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListClustersResponse.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): google.bigtable.admin.v2.bigtable_instance_admin_pb2.ListInstancesResponse.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google.longrunning.operations_pb2.Operation.FromString,
-    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google.bigtable.admin.v2.instance_pb2.Instance.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateCluster'): google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'CreateInstance'): google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteCluster'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'DeleteInstance'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetCluster'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Cluster.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'GetInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListClusters'): ListClustersResponse.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'ListInstances'): ListInstancesResponse.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateCluster'): google_dot_longrunning_dot_operations__pb2.Operation.FromString,
+    ('google.bigtable.admin.v2.BigtableInstanceAdmin', 'UpdateInstance'): google_dot_bigtable_dot_admin_dot_v2_dot_instance__pb2.Instance.FromString,
   }
   cardinalities = {
     'CreateCluster': cardinality.Cardinality.UNARY_UNARY,

--- a/gcloud/bigtable/_generated_v2/bigtable_pb2.py
+++ b/gcloud/bigtable/_generated_v2/bigtable_pb2.py
@@ -804,74 +804,259 @@ _sym_db.RegisterMessage(ReadModifyWriteRowResponse)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\026com.google.bigtable.v2B\rBigtableProtoP\001'))
-import abc
-import six
+
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality
 from grpc.framework.interfaces.face import utilities as face_utilities
 
-class BetaBigtableServicer(object):
-  """<fill me in later!>"""
+
+class BigtableStub(object):
+  """Service for reading from and writing to existing Bigtable tables.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.ReadRows = channel.unary_stream(
+        '/google.bigtable.v2.Bigtable/ReadRows',
+        request_serializer=ReadRowsRequest.SerializeToString,
+        response_deserializer=ReadRowsResponse.FromString,
+        )
+    self.SampleRowKeys = channel.unary_stream(
+        '/google.bigtable.v2.Bigtable/SampleRowKeys',
+        request_serializer=SampleRowKeysRequest.SerializeToString,
+        response_deserializer=SampleRowKeysResponse.FromString,
+        )
+    self.MutateRow = channel.unary_unary(
+        '/google.bigtable.v2.Bigtable/MutateRow',
+        request_serializer=MutateRowRequest.SerializeToString,
+        response_deserializer=MutateRowResponse.FromString,
+        )
+    self.MutateRows = channel.unary_stream(
+        '/google.bigtable.v2.Bigtable/MutateRows',
+        request_serializer=MutateRowsRequest.SerializeToString,
+        response_deserializer=MutateRowsResponse.FromString,
+        )
+    self.CheckAndMutateRow = channel.unary_unary(
+        '/google.bigtable.v2.Bigtable/CheckAndMutateRow',
+        request_serializer=CheckAndMutateRowRequest.SerializeToString,
+        response_deserializer=CheckAndMutateRowResponse.FromString,
+        )
+    self.ReadModifyWriteRow = channel.unary_unary(
+        '/google.bigtable.v2.Bigtable/ReadModifyWriteRow',
+        request_serializer=ReadModifyWriteRowRequest.SerializeToString,
+        response_deserializer=ReadModifyWriteRowResponse.FromString,
+        )
+
+
+class BigtableServicer(object):
+  """Service for reading from and writing to existing Bigtable tables.
+  """
+
   def ReadRows(self, request, context):
+    """Streams back the contents of all requested rows, optionally
+    applying the same Reader filter to each. Depending on their size,
+    rows and cells may be broken up across multiple responses, but
+    atomicity of each row will still be preserved. See the
+    ReadRowsResponse documentation for details.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def SampleRowKeys(self, request, context):
+    """Returns a sample of row keys in the table. The returned row keys will
+    delimit contiguous sections of the table of approximately equal size,
+    which can be used to break up the data for distributed tasks like
+    mapreduces.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def MutateRow(self, request, context):
+    """Mutates a row atomically. Cells already present in the row are left
+    unchanged unless explicitly changed by `mutation`.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def MutateRows(self, request, context):
+    """Mutates multiple rows in a batch. Each individual row is mutated
+    atomically as in MutateRow, but the entire batch is not executed
+    atomically.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CheckAndMutateRow(self, request, context):
+    """Mutates a row atomically based on the output of a predicate Reader filter.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ReadModifyWriteRow(self, request, context):
+    """Modifies a row atomically. The method reads the latest existing timestamp
+    and value from the specified columns and writes a new entry based on
+    pre-defined read/modify/write rules. The new value for the timestamp is the
+    greater of the existing timestamp or the current server time. The method
+    returns the new contents of all modified cells.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_BigtableServicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'ReadRows': grpc.unary_stream_rpc_method_handler(
+          servicer.ReadRows,
+          request_deserializer=ReadRowsRequest.FromString,
+          response_serializer=ReadRowsResponse.SerializeToString,
+      ),
+      'SampleRowKeys': grpc.unary_stream_rpc_method_handler(
+          servicer.SampleRowKeys,
+          request_deserializer=SampleRowKeysRequest.FromString,
+          response_serializer=SampleRowKeysResponse.SerializeToString,
+      ),
+      'MutateRow': grpc.unary_unary_rpc_method_handler(
+          servicer.MutateRow,
+          request_deserializer=MutateRowRequest.FromString,
+          response_serializer=MutateRowResponse.SerializeToString,
+      ),
+      'MutateRows': grpc.unary_stream_rpc_method_handler(
+          servicer.MutateRows,
+          request_deserializer=MutateRowsRequest.FromString,
+          response_serializer=MutateRowsResponse.SerializeToString,
+      ),
+      'CheckAndMutateRow': grpc.unary_unary_rpc_method_handler(
+          servicer.CheckAndMutateRow,
+          request_deserializer=CheckAndMutateRowRequest.FromString,
+          response_serializer=CheckAndMutateRowResponse.SerializeToString,
+      ),
+      'ReadModifyWriteRow': grpc.unary_unary_rpc_method_handler(
+          servicer.ReadModifyWriteRow,
+          request_deserializer=ReadModifyWriteRowRequest.FromString,
+          response_serializer=ReadModifyWriteRowResponse.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.bigtable.v2.Bigtable', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))
+
+
+class BetaBigtableServicer(object):
+  """Service for reading from and writing to existing Bigtable tables.
+  """
+  def ReadRows(self, request, context):
+    """Streams back the contents of all requested rows, optionally
+    applying the same Reader filter to each. Depending on their size,
+    rows and cells may be broken up across multiple responses, but
+    atomicity of each row will still be preserved. See the
+    ReadRowsResponse documentation for details.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def SampleRowKeys(self, request, context):
+    """Returns a sample of row keys in the table. The returned row keys will
+    delimit contiguous sections of the table of approximately equal size,
+    which can be used to break up the data for distributed tasks like
+    mapreduces.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def MutateRow(self, request, context):
+    """Mutates a row atomically. Cells already present in the row are left
+    unchanged unless explicitly changed by `mutation`.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def MutateRows(self, request, context):
+    """Mutates multiple rows in a batch. Each individual row is mutated
+    atomically as in MutateRow, but the entire batch is not executed
+    atomically.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def CheckAndMutateRow(self, request, context):
+    """Mutates a row atomically based on the output of a predicate Reader filter.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def ReadModifyWriteRow(self, request, context):
+    """Modifies a row atomically. The method reads the latest existing timestamp
+    and value from the specified columns and writes a new entry based on
+    pre-defined read/modify/write rules. The new value for the timestamp is the
+    greater of the existing timestamp or the current server time. The method
+    returns the new contents of all modified cells.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
+
 class BetaBigtableStub(object):
-  """The interface to which stubs will conform."""
-  def ReadRows(self, request, timeout):
+  """Service for reading from and writing to existing Bigtable tables.
+  """
+  def ReadRows(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Streams back the contents of all requested rows, optionally
+    applying the same Reader filter to each. Depending on their size,
+    rows and cells may be broken up across multiple responses, but
+    atomicity of each row will still be preserved. See the
+    ReadRowsResponse documentation for details.
+    """
     raise NotImplementedError()
-  def SampleRowKeys(self, request, timeout):
+  def SampleRowKeys(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Returns a sample of row keys in the table. The returned row keys will
+    delimit contiguous sections of the table of approximately equal size,
+    which can be used to break up the data for distributed tasks like
+    mapreduces.
+    """
     raise NotImplementedError()
-  def MutateRow(self, request, timeout):
+  def MutateRow(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Mutates a row atomically. Cells already present in the row are left
+    unchanged unless explicitly changed by `mutation`.
+    """
     raise NotImplementedError()
   MutateRow.future = None
-  def MutateRows(self, request, timeout):
+  def MutateRows(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Mutates multiple rows in a batch. Each individual row is mutated
+    atomically as in MutateRow, but the entire batch is not executed
+    atomically.
+    """
     raise NotImplementedError()
-  def CheckAndMutateRow(self, request, timeout):
+  def CheckAndMutateRow(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Mutates a row atomically based on the output of a predicate Reader filter.
+    """
     raise NotImplementedError()
   CheckAndMutateRow.future = None
-  def ReadModifyWriteRow(self, request, timeout):
+  def ReadModifyWriteRow(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Modifies a row atomically. The method reads the latest existing timestamp
+    and value from the specified columns and writes a new entry based on
+    pre-defined read/modify/write rules. The new value for the timestamp is the
+    greater of the existing timestamp or the current server time. The method
+    returns the new contents of all modified cells.
+    """
     raise NotImplementedError()
   ReadModifyWriteRow.future = None
 
+
 def beta_create_Bigtable_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
   request_deserializers = {
-    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): google.bigtable.v2.bigtable_pb2.CheckAndMutateRowRequest.FromString,
-    ('google.bigtable.v2.Bigtable', 'MutateRow'): google.bigtable.v2.bigtable_pb2.MutateRowRequest.FromString,
-    ('google.bigtable.v2.Bigtable', 'MutateRows'): google.bigtable.v2.bigtable_pb2.MutateRowsRequest.FromString,
-    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): google.bigtable.v2.bigtable_pb2.ReadModifyWriteRowRequest.FromString,
-    ('google.bigtable.v2.Bigtable', 'ReadRows'): google.bigtable.v2.bigtable_pb2.ReadRowsRequest.FromString,
-    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): google.bigtable.v2.bigtable_pb2.SampleRowKeysRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): CheckAndMutateRowRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'MutateRow'): MutateRowRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'MutateRows'): MutateRowsRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): ReadModifyWriteRowRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'ReadRows'): ReadRowsRequest.FromString,
+    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): SampleRowKeysRequest.FromString,
   }
   response_serializers = {
-    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): google.bigtable.v2.bigtable_pb2.CheckAndMutateRowResponse.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'MutateRow'): google.bigtable.v2.bigtable_pb2.MutateRowResponse.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'MutateRows'): google.bigtable.v2.bigtable_pb2.MutateRowsResponse.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): google.bigtable.v2.bigtable_pb2.ReadModifyWriteRowResponse.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'ReadRows'): google.bigtable.v2.bigtable_pb2.ReadRowsResponse.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): google.bigtable.v2.bigtable_pb2.SampleRowKeysResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): CheckAndMutateRowResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'MutateRow'): MutateRowResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'MutateRows'): MutateRowsResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): ReadModifyWriteRowResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'ReadRows'): ReadRowsResponse.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): SampleRowKeysResponse.SerializeToString,
   }
   method_implementations = {
     ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): face_utilities.unary_unary_inline(servicer.CheckAndMutateRow),
@@ -884,34 +1069,23 @@ def beta_create_Bigtable_server(servicer, pool=None, pool_size=None, default_tim
   server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
   return beta_implementations.server(method_implementations, options=server_options)
 
+
 def beta_create_Bigtable_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
-  import google.bigtable.v2.bigtable_pb2
   request_serializers = {
-    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): google.bigtable.v2.bigtable_pb2.CheckAndMutateRowRequest.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'MutateRow'): google.bigtable.v2.bigtable_pb2.MutateRowRequest.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'MutateRows'): google.bigtable.v2.bigtable_pb2.MutateRowsRequest.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): google.bigtable.v2.bigtable_pb2.ReadModifyWriteRowRequest.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'ReadRows'): google.bigtable.v2.bigtable_pb2.ReadRowsRequest.SerializeToString,
-    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): google.bigtable.v2.bigtable_pb2.SampleRowKeysRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): CheckAndMutateRowRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'MutateRow'): MutateRowRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'MutateRows'): MutateRowsRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): ReadModifyWriteRowRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'ReadRows'): ReadRowsRequest.SerializeToString,
+    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): SampleRowKeysRequest.SerializeToString,
   }
   response_deserializers = {
-    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): google.bigtable.v2.bigtable_pb2.CheckAndMutateRowResponse.FromString,
-    ('google.bigtable.v2.Bigtable', 'MutateRow'): google.bigtable.v2.bigtable_pb2.MutateRowResponse.FromString,
-    ('google.bigtable.v2.Bigtable', 'MutateRows'): google.bigtable.v2.bigtable_pb2.MutateRowsResponse.FromString,
-    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): google.bigtable.v2.bigtable_pb2.ReadModifyWriteRowResponse.FromString,
-    ('google.bigtable.v2.Bigtable', 'ReadRows'): google.bigtable.v2.bigtable_pb2.ReadRowsResponse.FromString,
-    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): google.bigtable.v2.bigtable_pb2.SampleRowKeysResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'CheckAndMutateRow'): CheckAndMutateRowResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'MutateRow'): MutateRowResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'MutateRows'): MutateRowsResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'ReadModifyWriteRow'): ReadModifyWriteRowResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'ReadRows'): ReadRowsResponse.FromString,
+    ('google.bigtable.v2.Bigtable', 'SampleRowKeys'): SampleRowKeysResponse.FromString,
   }
   cardinalities = {
     'CheckAndMutateRow': cardinality.Cardinality.UNARY_UNARY,

--- a/gcloud/bigtable/_generated_v2/bigtable_table_admin_pb2.py
+++ b/gcloud/bigtable/_generated_v2/bigtable_table_admin_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/bigtable/admin/v2/bigtable_table_admin.proto',
   package='google.bigtable.admin.v2',
   syntax='proto3',
-  serialized_pb=_b('\n3google/bigtable/admin/v2/bigtable_table_admin.proto\x12\x18google.bigtable.admin.v2\x1a\x1cgoogle/api/annotations.proto\x1a$google/bigtable/admin/v2/table.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xc6\x01\n\x12\x43reateTableRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08table_id\x18\x02 \x01(\t\x12.\n\x05table\x18\x03 \x01(\x0b\x32\x1f.google.bigtable.admin.v2.Table\x12J\n\x0einitial_splits\x18\x04 \x03(\x0b\x32\x32.google.bigtable.admin.v2.CreateTableRequest.Split\x1a\x14\n\x05Split\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"m\n\x13\x44ropRowRangeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x18\n\x0erow_key_prefix\x18\x02 \x01(\x0cH\x00\x12$\n\x1a\x64\x65lete_all_data_from_table\x18\x03 \x01(\x08H\x00\x42\x08\n\x06target\"i\n\x11ListTablesRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x32\n\x04view\x18\x02 \x01(\x0e\x32$.google.bigtable.admin.v2.Table.View\x12\x12\n\npage_token\x18\x03 \x01(\t\"^\n\x12ListTablesResponse\x12/\n\x06tables\x18\x01 \x03(\x0b\x32\x1f.google.bigtable.admin.v2.Table\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"S\n\x0fGetTableRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x32\n\x04view\x18\x02 \x01(\x0e\x32$.google.bigtable.admin.v2.Table.View\"\"\n\x12\x44\x65leteTableRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xae\x02\n\x1bModifyColumnFamiliesRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12Y\n\rmodifications\x18\x02 \x03(\x0b\x32\x42.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification\x1a\xa5\x01\n\x0cModification\x12\n\n\x02id\x18\x01 \x01(\t\x12\x38\n\x06\x63reate\x18\x02 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamilyH\x00\x12\x38\n\x06update\x18\x03 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamilyH\x00\x12\x0e\n\x04\x64rop\x18\x04 \x01(\x08H\x00\x42\x05\n\x03mod2\xb4\x07\n\x12\x42igtableTableAdmin\x12\x91\x01\n\x0b\x43reateTable\x12,.google.bigtable.admin.v2.CreateTableRequest\x1a\x1f.google.bigtable.admin.v2.Table\"3\x82\xd3\xe4\x93\x02-\"(/v2/{name=projects/*/instances/*}/tables:\x01*\x12\x99\x01\n\nListTables\x12+.google.bigtable.admin.v2.ListTablesRequest\x1a,.google.bigtable.admin.v2.ListTablesResponse\"0\x82\xd3\xe4\x93\x02*\x12(/v2/{name=projects/*/instances/*}/tables\x12\x8a\x01\n\x08GetTable\x12).google.bigtable.admin.v2.GetTableRequest\x1a\x1f.google.bigtable.admin.v2.Table\"2\x82\xd3\xe4\x93\x02,\x12*/v2/{name=projects/*/instances/*/tables/*}\x12\x87\x01\n\x0b\x44\x65leteTable\x12,.google.bigtable.admin.v2.DeleteTableRequest\x1a\x16.google.protobuf.Empty\"2\x82\xd3\xe4\x93\x02,**/v2/{name=projects/*/instances/*/tables/*}\x12\xba\x01\n\x14ModifyColumnFamilies\x12\x35.google.bigtable.admin.v2.ModifyColumnFamiliesRequest\x1a\x1f.google.bigtable.admin.v2.Table\"J\x82\xd3\xe4\x93\x02\x44\"?/v2/{name=projects/*/instances/*/tables/*}:modifyColumnFamilies:\x01*\x12\x99\x01\n\x0c\x44ropRowRange\x12-.google.bigtable.admin.v2.DropRowRangeRequest\x1a\x16.google.protobuf.Empty\"B\x82\xd3\xe4\x93\x02<\"7/v2/{name=projects/*/instances/*/tables/*}:dropRowRange:\x01*B9\n\x1c\x63om.google.bigtable.admin.v2B\x17\x42igtableTableAdminProtoP\x01\x62\x06proto3')
+  serialized_pb=_b('\n3google/bigtable/admin/v2/bigtable_table_admin.proto\x12\x18google.bigtable.admin.v2\x1a\x1cgoogle/api/annotations.proto\x1a$google/bigtable/admin/v2/table.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xc8\x01\n\x12\x43reateTableRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x10\n\x08table_id\x18\x02 \x01(\t\x12.\n\x05table\x18\x03 \x01(\x0b\x32\x1f.google.bigtable.admin.v2.Table\x12J\n\x0einitial_splits\x18\x04 \x03(\x0b\x32\x32.google.bigtable.admin.v2.CreateTableRequest.Split\x1a\x14\n\x05Split\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"m\n\x13\x44ropRowRangeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x18\n\x0erow_key_prefix\x18\x02 \x01(\x0cH\x00\x12$\n\x1a\x64\x65lete_all_data_from_table\x18\x03 \x01(\x08H\x00\x42\x08\n\x06target\"k\n\x11ListTablesRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x32\n\x04view\x18\x02 \x01(\x0e\x32$.google.bigtable.admin.v2.Table.View\x12\x12\n\npage_token\x18\x03 \x01(\t\"^\n\x12ListTablesResponse\x12/\n\x06tables\x18\x01 \x03(\x0b\x32\x1f.google.bigtable.admin.v2.Table\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"S\n\x0fGetTableRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x32\n\x04view\x18\x02 \x01(\x0e\x32$.google.bigtable.admin.v2.Table.View\"\"\n\x12\x44\x65leteTableRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xae\x02\n\x1bModifyColumnFamiliesRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12Y\n\rmodifications\x18\x02 \x03(\x0b\x32\x42.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification\x1a\xa5\x01\n\x0cModification\x12\n\n\x02id\x18\x01 \x01(\t\x12\x38\n\x06\x63reate\x18\x02 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamilyH\x00\x12\x38\n\x06update\x18\x03 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamilyH\x00\x12\x0e\n\x04\x64rop\x18\x04 \x01(\x08H\x00\x42\x05\n\x03mod2\xb8\x07\n\x12\x42igtableTableAdmin\x12\x93\x01\n\x0b\x43reateTable\x12,.google.bigtable.admin.v2.CreateTableRequest\x1a\x1f.google.bigtable.admin.v2.Table\"5\x82\xd3\xe4\x93\x02/\"*/v2/{parent=projects/*/instances/*}/tables:\x01*\x12\x9b\x01\n\nListTables\x12+.google.bigtable.admin.v2.ListTablesRequest\x1a,.google.bigtable.admin.v2.ListTablesResponse\"2\x82\xd3\xe4\x93\x02,\x12*/v2/{parent=projects/*/instances/*}/tables\x12\x8a\x01\n\x08GetTable\x12).google.bigtable.admin.v2.GetTableRequest\x1a\x1f.google.bigtable.admin.v2.Table\"2\x82\xd3\xe4\x93\x02,\x12*/v2/{name=projects/*/instances/*/tables/*}\x12\x87\x01\n\x0b\x44\x65leteTable\x12,.google.bigtable.admin.v2.DeleteTableRequest\x1a\x16.google.protobuf.Empty\"2\x82\xd3\xe4\x93\x02,**/v2/{name=projects/*/instances/*/tables/*}\x12\xba\x01\n\x14ModifyColumnFamilies\x12\x35.google.bigtable.admin.v2.ModifyColumnFamiliesRequest\x1a\x1f.google.bigtable.admin.v2.Table\"J\x82\xd3\xe4\x93\x02\x44\"?/v2/{name=projects/*/instances/*/tables/*}:modifyColumnFamilies:\x01*\x12\x99\x01\n\x0c\x44ropRowRange\x12-.google.bigtable.admin.v2.DropRowRangeRequest\x1a\x16.google.protobuf.Empty\"B\x82\xd3\xe4\x93\x02<\"7/v2/{name=projects/*/instances/*/tables/*}:dropRowRange:\x01*B9\n\x1c\x63om.google.bigtable.admin.v2B\x17\x42igtableTableAdminProtoP\x01\x62\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -56,8 +56,8 @@ _CREATETABLEREQUEST_SPLIT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=357,
-  serialized_end=377,
+  serialized_start=359,
+  serialized_end=379,
 )
 
 _CREATETABLEREQUEST = _descriptor.Descriptor(
@@ -68,7 +68,7 @@ _CREATETABLEREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.CreateTableRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.CreateTableRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -108,7 +108,7 @@ _CREATETABLEREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=179,
-  serialized_end=377,
+  serialized_end=379,
 )
 
 
@@ -155,8 +155,8 @@ _DROPROWRANGEREQUEST = _descriptor.Descriptor(
       name='target', full_name='google.bigtable.admin.v2.DropRowRangeRequest.target',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=379,
-  serialized_end=488,
+  serialized_start=381,
+  serialized_end=490,
 )
 
 
@@ -168,7 +168,7 @@ _LISTTABLESREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='google.bigtable.admin.v2.ListTablesRequest.name', index=0,
+      name='parent', full_name='google.bigtable.admin.v2.ListTablesRequest.parent', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -200,8 +200,8 @@ _LISTTABLESREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=490,
-  serialized_end=595,
+  serialized_start=492,
+  serialized_end=599,
 )
 
 
@@ -238,8 +238,8 @@ _LISTTABLESRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=597,
-  serialized_end=691,
+  serialized_start=601,
+  serialized_end=695,
 )
 
 
@@ -276,8 +276,8 @@ _GETTABLEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=693,
-  serialized_end=776,
+  serialized_start=697,
+  serialized_end=780,
 )
 
 
@@ -307,8 +307,8 @@ _DELETETABLEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=778,
-  serialized_end=812,
+  serialized_start=782,
+  serialized_end=816,
 )
 
 
@@ -362,8 +362,8 @@ _MODIFYCOLUMNFAMILIESREQUEST_MODIFICATION = _descriptor.Descriptor(
       name='mod', full_name='google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.mod',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=952,
-  serialized_end=1117,
+  serialized_start=956,
+  serialized_end=1121,
 )
 
 _MODIFYCOLUMNFAMILIESREQUEST = _descriptor.Descriptor(
@@ -399,8 +399,8 @@ _MODIFYCOLUMNFAMILIESREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=815,
-  serialized_end=1117,
+  serialized_start=819,
+  serialized_end=1121,
 )
 
 _CREATETABLEREQUEST_SPLIT.containing_type = _CREATETABLEREQUEST
@@ -504,77 +504,243 @@ _sym_db.RegisterMessage(ModifyColumnFamiliesRequest.Modification)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\034com.google.bigtable.admin.v2B\027BigtableTableAdminProtoP\001'))
-import abc
-import six
+
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality
 from grpc.framework.interfaces.face import utilities as face_utilities
 
-class BetaBigtableTableAdminServicer(object):
-  """<fill me in later!>"""
+
+class BigtableTableAdminStub(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable tables.
+  Provides access to the table schemas only, not the data stored within
+  the tables.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.CreateTable = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/CreateTable',
+        request_serializer=CreateTableRequest.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
+        )
+    self.ListTables = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/ListTables',
+        request_serializer=ListTablesRequest.SerializeToString,
+        response_deserializer=ListTablesResponse.FromString,
+        )
+    self.GetTable = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/GetTable',
+        request_serializer=GetTableRequest.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
+        )
+    self.DeleteTable = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/DeleteTable',
+        request_serializer=DeleteTableRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+    self.ModifyColumnFamilies = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/ModifyColumnFamilies',
+        request_serializer=ModifyColumnFamiliesRequest.SerializeToString,
+        response_deserializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
+        )
+    self.DropRowRange = channel.unary_unary(
+        '/google.bigtable.admin.v2.BigtableTableAdmin/DropRowRange',
+        request_serializer=DropRowRangeRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+
+
+class BigtableTableAdminServicer(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable tables.
+  Provides access to the table schemas only, not the data stored within
+  the tables.
+  """
+
   def CreateTable(self, request, context):
+    """Creates a new table in the specified instance.
+    The table can be created with a full set of initial column families,
+    specified in the request.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListTables(self, request, context):
+    """Lists all tables served from a specified instance.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetTable(self, request, context):
+    """Gets metadata information about the specified table.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteTable(self, request, context):
+    """Permanently deletes a specified table and all of its data.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ModifyColumnFamilies(self, request, context):
+    """Atomically performs a series of column family modifications
+    on the specified table.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DropRowRange(self, request, context):
+    """Permanently drop/delete a row range from a specified table. The request can
+    specify whether to delete all rows in a table, or only those that match a
+    particular prefix.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_BigtableTableAdminServicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'CreateTable': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateTable,
+          request_deserializer=CreateTableRequest.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
+      ),
+      'ListTables': grpc.unary_unary_rpc_method_handler(
+          servicer.ListTables,
+          request_deserializer=ListTablesRequest.FromString,
+          response_serializer=ListTablesResponse.SerializeToString,
+      ),
+      'GetTable': grpc.unary_unary_rpc_method_handler(
+          servicer.GetTable,
+          request_deserializer=GetTableRequest.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
+      ),
+      'DeleteTable': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteTable,
+          request_deserializer=DeleteTableRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+      'ModifyColumnFamilies': grpc.unary_unary_rpc_method_handler(
+          servicer.ModifyColumnFamilies,
+          request_deserializer=ModifyColumnFamiliesRequest.FromString,
+          response_serializer=google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
+      ),
+      'DropRowRange': grpc.unary_unary_rpc_method_handler(
+          servicer.DropRowRange,
+          request_deserializer=DropRowRangeRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.bigtable.admin.v2.BigtableTableAdmin', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))
+
+
+class BetaBigtableTableAdminServicer(object):
+  """Service for creating, configuring, and deleting Cloud Bigtable tables.
+  Provides access to the table schemas only, not the data stored within
+  the tables.
+  """
+  def CreateTable(self, request, context):
+    """Creates a new table in the specified instance.
+    The table can be created with a full set of initial column families,
+    specified in the request.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def ListTables(self, request, context):
+    """Lists all tables served from a specified instance.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def GetTable(self, request, context):
+    """Gets metadata information about the specified table.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def DeleteTable(self, request, context):
+    """Permanently deletes a specified table and all of its data.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def ModifyColumnFamilies(self, request, context):
+    """Atomically performs a series of column family modifications
+    on the specified table.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
   def DropRowRange(self, request, context):
+    """Permanently drop/delete a row range from a specified table. The request can
+    specify whether to delete all rows in a table, or only those that match a
+    particular prefix.
+    """
     context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
 
+
 class BetaBigtableTableAdminStub(object):
-  """The interface to which stubs will conform."""
-  def CreateTable(self, request, timeout):
+  """Service for creating, configuring, and deleting Cloud Bigtable tables.
+  Provides access to the table schemas only, not the data stored within
+  the tables.
+  """
+  def CreateTable(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Creates a new table in the specified instance.
+    The table can be created with a full set of initial column families,
+    specified in the request.
+    """
     raise NotImplementedError()
   CreateTable.future = None
-  def ListTables(self, request, timeout):
+  def ListTables(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Lists all tables served from a specified instance.
+    """
     raise NotImplementedError()
   ListTables.future = None
-  def GetTable(self, request, timeout):
+  def GetTable(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Gets metadata information about the specified table.
+    """
     raise NotImplementedError()
   GetTable.future = None
-  def DeleteTable(self, request, timeout):
+  def DeleteTable(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Permanently deletes a specified table and all of its data.
+    """
     raise NotImplementedError()
   DeleteTable.future = None
-  def ModifyColumnFamilies(self, request, timeout):
+  def ModifyColumnFamilies(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Atomically performs a series of column family modifications
+    on the specified table.
+    """
     raise NotImplementedError()
   ModifyColumnFamilies.future = None
-  def DropRowRange(self, request, timeout):
+  def DropRowRange(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Permanently drop/delete a row range from a specified table. The request can
+    specify whether to delete all rows in a table, or only those that match a
+    particular prefix.
+    """
     raise NotImplementedError()
   DropRowRange.future = None
 
+
 def beta_create_BigtableTableAdmin_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.protobuf.empty_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.protobuf.empty_pb2
   request_deserializers = {
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.CreateTableRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.DeleteTableRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google.bigtable.admin.v2.bigtable_table_admin_pb2.DropRowRangeRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.GetTableRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ListTablesRequest.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ModifyColumnFamiliesRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): CreateTableRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): DeleteTableRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): DropRowRangeRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): GetTableRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): ListTablesRequest.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): ModifyColumnFamiliesRequest.FromString,
   }
   response_serializers = {
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google.bigtable.admin.v2.table_pb2.Table.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google.protobuf.empty_pb2.Empty.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google.protobuf.empty_pb2.Empty.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google.bigtable.admin.v2.table_pb2.Table.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ListTablesResponse.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google.bigtable.admin.v2.table_pb2.Table.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): ListTablesResponse.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.SerializeToString,
   }
   method_implementations = {
     ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): face_utilities.unary_unary_inline(servicer.CreateTable),
@@ -587,34 +753,23 @@ def beta_create_BigtableTableAdmin_server(servicer, pool=None, pool_size=None, d
   server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
   return beta_implementations.server(method_implementations, options=server_options)
 
+
 def beta_create_BigtableTableAdmin_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.protobuf.empty_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.bigtable.admin.v2.table_pb2
-  import google.bigtable.admin.v2.bigtable_table_admin_pb2
-  import google.protobuf.empty_pb2
   request_serializers = {
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.CreateTableRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.DeleteTableRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google.bigtable.admin.v2.bigtable_table_admin_pb2.DropRowRangeRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google.bigtable.admin.v2.bigtable_table_admin_pb2.GetTableRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ListTablesRequest.SerializeToString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ModifyColumnFamiliesRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): CreateTableRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): DeleteTableRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): DropRowRangeRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): GetTableRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): ListTablesRequest.SerializeToString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): ModifyColumnFamiliesRequest.SerializeToString,
   }
   response_deserializers = {
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google.bigtable.admin.v2.table_pb2.Table.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google.protobuf.empty_pb2.Empty.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google.protobuf.empty_pb2.Empty.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google.bigtable.admin.v2.table_pb2.Table.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): google.bigtable.admin.v2.bigtable_table_admin_pb2.ListTablesResponse.FromString,
-    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google.bigtable.admin.v2.table_pb2.Table.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'CreateTable'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DeleteTable'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'DropRowRange'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'GetTable'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ListTables'): ListTablesResponse.FromString,
+    ('google.bigtable.admin.v2.BigtableTableAdmin', 'ModifyColumnFamilies'): google_dot_bigtable_dot_admin_dot_v2_dot_table__pb2.Table.FromString,
   }
   cardinalities = {
     'CreateTable': cardinality.Cardinality.UNARY_UNARY,

--- a/gcloud/bigtable/_generated_v2/operations_grpc_pb2.py
+++ b/gcloud/bigtable/_generated_v2/operations_grpc_pb2.py
@@ -1,0 +1,256 @@
+
+from grpc.beta import implementations as beta_implementations
+from grpc.beta import interfaces as beta_interfaces
+from grpc.framework.common import cardinality
+from grpc.framework.interfaces.face import utilities as face_utilities
+
+
+class OperationsStub(object):
+  """Manages long-running operations with an API service.
+
+  When an API method normally takes long time to complete, it can be designed
+  to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+  interface to receive the real response asynchronously by polling the
+  operation resource, or using `google.watcher.v1.Watcher` interface to watch
+  the response, or pass the operation resource to another API (such as Google
+  Cloud Pub/Sub API) to receive the response.  Any API service that returns
+  long-running operations should implement the `Operations` interface so
+  developers can have a consistent client experience.
+  """
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.GetOperation = channel.unary_unary(
+        '/google.longrunning.Operations/GetOperation',
+        request_serializer=GetOperationRequest.SerializeToString,
+        response_deserializer=Operation.FromString,
+        )
+    self.ListOperations = channel.unary_unary(
+        '/google.longrunning.Operations/ListOperations',
+        request_serializer=ListOperationsRequest.SerializeToString,
+        response_deserializer=ListOperationsResponse.FromString,
+        )
+    self.CancelOperation = channel.unary_unary(
+        '/google.longrunning.Operations/CancelOperation',
+        request_serializer=CancelOperationRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+    self.DeleteOperation = channel.unary_unary(
+        '/google.longrunning.Operations/DeleteOperation',
+        request_serializer=DeleteOperationRequest.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+
+
+class OperationsServicer(object):
+  """Manages long-running operations with an API service.
+
+  When an API method normally takes long time to complete, it can be designed
+  to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+  interface to receive the real response asynchronously by polling the
+  operation resource, or using `google.watcher.v1.Watcher` interface to watch
+  the response, or pass the operation resource to another API (such as Google
+  Cloud Pub/Sub API) to receive the response.  Any API service that returns
+  long-running operations should implement the `Operations` interface so
+  developers can have a consistent client experience.
+  """
+
+  def GetOperation(self, request, context):
+    """Gets the latest state of a long-running operation.  Clients may use this
+    method to poll the operation result at intervals as recommended by the API
+    service.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def ListOperations(self, request, context):
+    """Lists operations that match the specified filter in the request. If the
+    server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CancelOperation(self, request, context):
+    """Starts asynchronous cancellation on a long-running operation.  The server
+    makes a best effort to cancel the operation, but success is not
+    guaranteed.  If the server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+    [Operations.GetOperation] or other methods to check whether the
+    cancellation succeeded or the operation completed despite cancellation.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def DeleteOperation(self, request, context):
+    """Deletes a long-running operation.  It indicates the client is no longer
+    interested in the operation result. It does not cancel the operation.
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_OperationsServicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'GetOperation': grpc.unary_unary_rpc_method_handler(
+          servicer.GetOperation,
+          request_deserializer=GetOperationRequest.FromString,
+          response_serializer=Operation.SerializeToString,
+      ),
+      'ListOperations': grpc.unary_unary_rpc_method_handler(
+          servicer.ListOperations,
+          request_deserializer=ListOperationsRequest.FromString,
+          response_serializer=ListOperationsResponse.SerializeToString,
+      ),
+      'CancelOperation': grpc.unary_unary_rpc_method_handler(
+          servicer.CancelOperation,
+          request_deserializer=CancelOperationRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+      'DeleteOperation': grpc.unary_unary_rpc_method_handler(
+          servicer.DeleteOperation,
+          request_deserializer=DeleteOperationRequest.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'google.longrunning.Operations', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))
+
+
+class BetaOperationsServicer(object):
+  """Manages long-running operations with an API service.
+
+  When an API method normally takes long time to complete, it can be designed
+  to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+  interface to receive the real response asynchronously by polling the
+  operation resource, or using `google.watcher.v1.Watcher` interface to watch
+  the response, or pass the operation resource to another API (such as Google
+  Cloud Pub/Sub API) to receive the response.  Any API service that returns
+  long-running operations should implement the `Operations` interface so
+  developers can have a consistent client experience.
+  """
+  def GetOperation(self, request, context):
+    """Gets the latest state of a long-running operation.  Clients may use this
+    method to poll the operation result at intervals as recommended by the API
+    service.
+    """
+    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+  def ListOperations(self, request, context):
+    """Lists operations that match the specified filter in the request. If the
+    server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.
+    """
+    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+  def CancelOperation(self, request, context):
+    """Starts asynchronous cancellation on a long-running operation.  The server
+    makes a best effort to cancel the operation, but success is not
+    guaranteed.  If the server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+    [Operations.GetOperation] or other methods to check whether the
+    cancellation succeeded or the operation completed despite cancellation.
+    """
+    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+  def DeleteOperation(self, request, context):
+    """Deletes a long-running operation.  It indicates the client is no longer
+    interested in the operation result. It does not cancel the operation.
+    """
+    context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
+
+
+class BetaOperationsStub(object):
+  """Manages long-running operations with an API service.
+
+  When an API method normally takes long time to complete, it can be designed
+  to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+  interface to receive the real response asynchronously by polling the
+  operation resource, or using `google.watcher.v1.Watcher` interface to watch
+  the response, or pass the operation resource to another API (such as Google
+  Cloud Pub/Sub API) to receive the response.  Any API service that returns
+  long-running operations should implement the `Operations` interface so
+  developers can have a consistent client experience.
+  """
+  def GetOperation(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Gets the latest state of a long-running operation.  Clients may use this
+    method to poll the operation result at intervals as recommended by the API
+    service.
+    """
+    raise NotImplementedError()
+  GetOperation.future = None
+  def ListOperations(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Lists operations that match the specified filter in the request. If the
+    server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.
+    """
+    raise NotImplementedError()
+  ListOperations.future = None
+  def CancelOperation(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Starts asynchronous cancellation on a long-running operation.  The server
+    makes a best effort to cancel the operation, but success is not
+    guaranteed.  If the server doesn't support this method, it returns
+    `google.rpc.Code.UNIMPLEMENTED`.  Clients may use
+    [Operations.GetOperation] or other methods to check whether the
+    cancellation succeeded or the operation completed despite cancellation.
+    """
+    raise NotImplementedError()
+  CancelOperation.future = None
+  def DeleteOperation(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    """Deletes a long-running operation.  It indicates the client is no longer
+    interested in the operation result. It does not cancel the operation.
+    """
+    raise NotImplementedError()
+  DeleteOperation.future = None
+
+
+def beta_create_Operations_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
+  request_deserializers = {
+    ('google.longrunning.Operations', 'CancelOperation'): CancelOperationRequest.FromString,
+    ('google.longrunning.Operations', 'DeleteOperation'): DeleteOperationRequest.FromString,
+    ('google.longrunning.Operations', 'GetOperation'): GetOperationRequest.FromString,
+    ('google.longrunning.Operations', 'ListOperations'): ListOperationsRequest.FromString,
+  }
+  response_serializers = {
+    ('google.longrunning.Operations', 'CancelOperation'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.longrunning.Operations', 'DeleteOperation'): google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+    ('google.longrunning.Operations', 'GetOperation'): Operation.SerializeToString,
+    ('google.longrunning.Operations', 'ListOperations'): ListOperationsResponse.SerializeToString,
+  }
+  method_implementations = {
+    ('google.longrunning.Operations', 'CancelOperation'): face_utilities.unary_unary_inline(servicer.CancelOperation),
+    ('google.longrunning.Operations', 'DeleteOperation'): face_utilities.unary_unary_inline(servicer.DeleteOperation),
+    ('google.longrunning.Operations', 'GetOperation'): face_utilities.unary_unary_inline(servicer.GetOperation),
+    ('google.longrunning.Operations', 'ListOperations'): face_utilities.unary_unary_inline(servicer.ListOperations),
+  }
+  server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
+  return beta_implementations.server(method_implementations, options=server_options)
+
+
+def beta_create_Operations_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
+  request_serializers = {
+    ('google.longrunning.Operations', 'CancelOperation'): CancelOperationRequest.SerializeToString,
+    ('google.longrunning.Operations', 'DeleteOperation'): DeleteOperationRequest.SerializeToString,
+    ('google.longrunning.Operations', 'GetOperation'): GetOperationRequest.SerializeToString,
+    ('google.longrunning.Operations', 'ListOperations'): ListOperationsRequest.SerializeToString,
+  }
+  response_deserializers = {
+    ('google.longrunning.Operations', 'CancelOperation'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.longrunning.Operations', 'DeleteOperation'): google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+    ('google.longrunning.Operations', 'GetOperation'): Operation.FromString,
+    ('google.longrunning.Operations', 'ListOperations'): ListOperationsResponse.FromString,
+  }
+  cardinalities = {
+    'CancelOperation': cardinality.Cardinality.UNARY_UNARY,
+    'DeleteOperation': cardinality.Cardinality.UNARY_UNARY,
+    'GetOperation': cardinality.Cardinality.UNARY_UNARY,
+    'ListOperations': cardinality.Cardinality.UNARY_UNARY,
+  }
+  stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
+  return beta_implementations.dynamic_stub(channel, 'google.longrunning.Operations', cardinalities, options=stub_options)

--- a/gcloud/bigtable/_generated_v2/table_pb2.py
+++ b/gcloud/bigtable/_generated_v2/table_pb2.py
@@ -13,6 +13,7 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 
 
@@ -20,46 +21,12 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/bigtable/admin/v2/table.proto',
   package='google.bigtable.admin.v2',
   syntax='proto3',
-  serialized_pb=_b('\n$google/bigtable/admin/v2/table.proto\x12\x18google.bigtable.admin.v2\x1a\x1egoogle/protobuf/duration.proto\"\xcb\x06\n\x05Table\x12\x0c\n\x04name\x18\x01 \x01(\t\x12J\n\x0e\x63luster_states\x18\x02 \x03(\x0b\x32\x32.google.bigtable.admin.v2.Table.ClusterStatesEntry\x12L\n\x0f\x63olumn_families\x18\x03 \x03(\x0b\x32\x33.google.bigtable.admin.v2.Table.ColumnFamiliesEntry\x12I\n\x0bgranularity\x18\x04 \x01(\x0e\x32\x34.google.bigtable.admin.v2.Table.TimestampGranularity\x1a\xe2\x01\n\x0c\x43lusterState\x12X\n\x11replication_state\x18\x01 \x01(\x0e\x32=.google.bigtable.admin.v2.Table.ClusterState.ReplicationState\"x\n\x10ReplicationState\x12\x13\n\x0fSTATE_NOT_KNOWN\x10\x00\x12\x10\n\x0cINITIALIZING\x10\x01\x12\x17\n\x13PLANNED_MAINTENANCE\x10\x02\x12\x19\n\x15UNPLANNED_MAINTENANCE\x10\x03\x12\t\n\x05READY\x10\x04\x1a\x62\n\x12\x43lusterStatesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12;\n\x05value\x18\x02 \x01(\x0b\x32,.google.bigtable.admin.v2.Table.ClusterState:\x02\x38\x01\x1a]\n\x13\x43olumnFamiliesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x35\n\x05value\x18\x02 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamily:\x02\x38\x01\"I\n\x14TimestampGranularity\x12%\n!TIMESTAMP_GRANULARITY_UNSPECIFIED\x10\x00\x12\n\n\x06MILLIS\x10\x01\"\\\n\x04View\x12\x14\n\x10VIEW_UNSPECIFIED\x10\x00\x12\r\n\tNAME_ONLY\x10\x01\x12\x0f\n\x0bSCHEMA_VIEW\x10\x02\x12\x14\n\x10REPLICATION_VIEW\x10\x03\x12\x08\n\x04\x46ULL\x10\x04\"A\n\x0c\x43olumnFamily\x12\x31\n\x07gc_rule\x18\x01 \x01(\x0b\x32 .google.bigtable.admin.v2.GcRule\"\xd5\x02\n\x06GcRule\x12\x1a\n\x10max_num_versions\x18\x01 \x01(\x05H\x00\x12,\n\x07max_age\x18\x02 \x01(\x0b\x32\x19.google.protobuf.DurationH\x00\x12\x45\n\x0cintersection\x18\x03 \x01(\x0b\x32-.google.bigtable.admin.v2.GcRule.IntersectionH\x00\x12\x37\n\x05union\x18\x04 \x01(\x0b\x32&.google.bigtable.admin.v2.GcRule.UnionH\x00\x1a?\n\x0cIntersection\x12/\n\x05rules\x18\x01 \x03(\x0b\x32 .google.bigtable.admin.v2.GcRule\x1a\x38\n\x05Union\x12/\n\x05rules\x18\x01 \x03(\x0b\x32 .google.bigtable.admin.v2.GcRuleB\x06\n\x04ruleB,\n\x1c\x63om.google.bigtable.admin.v2B\nTableProtoP\x01\x62\x06proto3')
+  serialized_pb=_b('\n$google/bigtable/admin/v2/table.proto\x12\x18google.bigtable.admin.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\"\xa0\x03\n\x05Table\x12\x0c\n\x04name\x18\x01 \x01(\t\x12L\n\x0f\x63olumn_families\x18\x03 \x03(\x0b\x32\x33.google.bigtable.admin.v2.Table.ColumnFamiliesEntry\x12I\n\x0bgranularity\x18\x04 \x01(\x0e\x32\x34.google.bigtable.admin.v2.Table.TimestampGranularity\x1a]\n\x13\x43olumnFamiliesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x35\n\x05value\x18\x02 \x01(\x0b\x32&.google.bigtable.admin.v2.ColumnFamily:\x02\x38\x01\"I\n\x14TimestampGranularity\x12%\n!TIMESTAMP_GRANULARITY_UNSPECIFIED\x10\x00\x12\n\n\x06MILLIS\x10\x01\"F\n\x04View\x12\x14\n\x10VIEW_UNSPECIFIED\x10\x00\x12\r\n\tNAME_ONLY\x10\x01\x12\x0f\n\x0bSCHEMA_VIEW\x10\x02\x12\x08\n\x04\x46ULL\x10\x04\"A\n\x0c\x43olumnFamily\x12\x31\n\x07gc_rule\x18\x01 \x01(\x0b\x32 .google.bigtable.admin.v2.GcRule\"\xd5\x02\n\x06GcRule\x12\x1a\n\x10max_num_versions\x18\x01 \x01(\x05H\x00\x12,\n\x07max_age\x18\x02 \x01(\x0b\x32\x19.google.protobuf.DurationH\x00\x12\x45\n\x0cintersection\x18\x03 \x01(\x0b\x32-.google.bigtable.admin.v2.GcRule.IntersectionH\x00\x12\x37\n\x05union\x18\x04 \x01(\x0b\x32&.google.bigtable.admin.v2.GcRule.UnionH\x00\x1a?\n\x0cIntersection\x12/\n\x05rules\x18\x01 \x03(\x0b\x32 .google.bigtable.admin.v2.GcRule\x1a\x38\n\x05Union\x12/\n\x05rules\x18\x01 \x03(\x0b\x32 .google.bigtable.admin.v2.GcRuleB\x06\n\x04ruleB,\n\x1c\x63om.google.bigtable.admin.v2B\nTableProtoP\x01\x62\x06proto3')
   ,
-  dependencies=[google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,])
+  dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
-
-_TABLE_CLUSTERSTATE_REPLICATIONSTATE = _descriptor.EnumDescriptor(
-  name='ReplicationState',
-  full_name='google.bigtable.admin.v2.Table.ClusterState.ReplicationState',
-  filename=None,
-  file=DESCRIPTOR,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='STATE_NOT_KNOWN', index=0, number=0,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='INITIALIZING', index=1, number=1,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='PLANNED_MAINTENANCE', index=2, number=2,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='UNPLANNED_MAINTENANCE', index=3, number=3,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='READY', index=4, number=4,
-      options=None,
-      type=None),
-  ],
-  containing_type=None,
-  options=None,
-  serialized_start=458,
-  serialized_end=578,
-)
-_sym_db.RegisterEnumDescriptor(_TABLE_CLUSTERSTATE_REPLICATIONSTATE)
 
 _TABLE_TIMESTAMPGRANULARITY = _descriptor.EnumDescriptor(
   name='TimestampGranularity',
@@ -78,8 +45,8 @@ _TABLE_TIMESTAMPGRANULARITY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=775,
-  serialized_end=848,
+  serialized_start=400,
+  serialized_end=473,
 )
 _sym_db.RegisterEnumDescriptor(_TABLE_TIMESTAMPGRANULARITY)
 
@@ -102,89 +69,17 @@ _TABLE_VIEW = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='REPLICATION_VIEW', index=3, number=3,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='FULL', index=4, number=4,
+      name='FULL', index=3, number=4,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=850,
-  serialized_end=942,
+  serialized_start=475,
+  serialized_end=545,
 )
 _sym_db.RegisterEnumDescriptor(_TABLE_VIEW)
 
-
-_TABLE_CLUSTERSTATE = _descriptor.Descriptor(
-  name='ClusterState',
-  full_name='google.bigtable.admin.v2.Table.ClusterState',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='replication_state', full_name='google.bigtable.admin.v2.Table.ClusterState.replication_state', index=0,
-      number=1, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-    _TABLE_CLUSTERSTATE_REPLICATIONSTATE,
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=352,
-  serialized_end=578,
-)
-
-_TABLE_CLUSTERSTATESENTRY = _descriptor.Descriptor(
-  name='ClusterStatesEntry',
-  full_name='google.bigtable.admin.v2.Table.ClusterStatesEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='google.bigtable.admin.v2.Table.ClusterStatesEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='google.bigtable.admin.v2.Table.ClusterStatesEntry.value', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=580,
-  serialized_end=678,
-)
 
 _TABLE_COLUMNFAMILIESENTRY = _descriptor.Descriptor(
   name='ColumnFamiliesEntry',
@@ -219,8 +114,8 @@ _TABLE_COLUMNFAMILIESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=680,
-  serialized_end=773,
+  serialized_start=305,
+  serialized_end=398,
 )
 
 _TABLE = _descriptor.Descriptor(
@@ -238,21 +133,14 @@ _TABLE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='cluster_states', full_name='google.bigtable.admin.v2.Table.cluster_states', index=1,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='column_families', full_name='google.bigtable.admin.v2.Table.column_families', index=2,
+      name='column_families', full_name='google.bigtable.admin.v2.Table.column_families', index=1,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='granularity', full_name='google.bigtable.admin.v2.Table.granularity', index=3,
+      name='granularity', full_name='google.bigtable.admin.v2.Table.granularity', index=2,
       number=4, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -261,7 +149,7 @@ _TABLE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_TABLE_CLUSTERSTATE, _TABLE_CLUSTERSTATESENTRY, _TABLE_COLUMNFAMILIESENTRY, ],
+  nested_types=[_TABLE_COLUMNFAMILIESENTRY, ],
   enum_types=[
     _TABLE_TIMESTAMPGRANULARITY,
     _TABLE_VIEW,
@@ -272,8 +160,8 @@ _TABLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=99,
-  serialized_end=942,
+  serialized_start=129,
+  serialized_end=545,
 )
 
 
@@ -303,8 +191,8 @@ _COLUMNFAMILY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=944,
-  serialized_end=1009,
+  serialized_start=547,
+  serialized_end=612,
 )
 
 
@@ -334,8 +222,8 @@ _GCRULE_INTERSECTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1224,
-  serialized_end=1287,
+  serialized_start=827,
+  serialized_end=890,
 )
 
 _GCRULE_UNION = _descriptor.Descriptor(
@@ -364,8 +252,8 @@ _GCRULE_UNION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1289,
-  serialized_end=1345,
+  serialized_start=892,
+  serialized_end=948,
 )
 
 _GCRULE = _descriptor.Descriptor(
@@ -418,18 +306,12 @@ _GCRULE = _descriptor.Descriptor(
       name='rule', full_name='google.bigtable.admin.v2.GcRule.rule',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1012,
-  serialized_end=1353,
+  serialized_start=615,
+  serialized_end=956,
 )
 
-_TABLE_CLUSTERSTATE.fields_by_name['replication_state'].enum_type = _TABLE_CLUSTERSTATE_REPLICATIONSTATE
-_TABLE_CLUSTERSTATE.containing_type = _TABLE
-_TABLE_CLUSTERSTATE_REPLICATIONSTATE.containing_type = _TABLE_CLUSTERSTATE
-_TABLE_CLUSTERSTATESENTRY.fields_by_name['value'].message_type = _TABLE_CLUSTERSTATE
-_TABLE_CLUSTERSTATESENTRY.containing_type = _TABLE
 _TABLE_COLUMNFAMILIESENTRY.fields_by_name['value'].message_type = _COLUMNFAMILY
 _TABLE_COLUMNFAMILIESENTRY.containing_type = _TABLE
-_TABLE.fields_by_name['cluster_states'].message_type = _TABLE_CLUSTERSTATESENTRY
 _TABLE.fields_by_name['column_families'].message_type = _TABLE_COLUMNFAMILIESENTRY
 _TABLE.fields_by_name['granularity'].enum_type = _TABLE_TIMESTAMPGRANULARITY
 _TABLE_TIMESTAMPGRANULARITY.containing_type = _TABLE
@@ -460,20 +342,6 @@ DESCRIPTOR.message_types_by_name['GcRule'] = _GCRULE
 
 Table = _reflection.GeneratedProtocolMessageType('Table', (_message.Message,), dict(
 
-  ClusterState = _reflection.GeneratedProtocolMessageType('ClusterState', (_message.Message,), dict(
-    DESCRIPTOR = _TABLE_CLUSTERSTATE,
-    __module__ = 'google.bigtable.admin.v2.table_pb2'
-    # @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.Table.ClusterState)
-    ))
-  ,
-
-  ClusterStatesEntry = _reflection.GeneratedProtocolMessageType('ClusterStatesEntry', (_message.Message,), dict(
-    DESCRIPTOR = _TABLE_CLUSTERSTATESENTRY,
-    __module__ = 'google.bigtable.admin.v2.table_pb2'
-    # @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.Table.ClusterStatesEntry)
-    ))
-  ,
-
   ColumnFamiliesEntry = _reflection.GeneratedProtocolMessageType('ColumnFamiliesEntry', (_message.Message,), dict(
     DESCRIPTOR = _TABLE_COLUMNFAMILIESENTRY,
     __module__ = 'google.bigtable.admin.v2.table_pb2'
@@ -485,8 +353,6 @@ Table = _reflection.GeneratedProtocolMessageType('Table', (_message.Message,), d
   # @@protoc_insertion_point(class_scope:google.bigtable.admin.v2.Table)
   ))
 _sym_db.RegisterMessage(Table)
-_sym_db.RegisterMessage(Table.ClusterState)
-_sym_db.RegisterMessage(Table.ClusterStatesEntry)
 _sym_db.RegisterMessage(Table.ColumnFamiliesEntry)
 
 ColumnFamily = _reflection.GeneratedProtocolMessageType('ColumnFamily', (_message.Message,), dict(
@@ -522,8 +388,6 @@ _sym_db.RegisterMessage(GcRule.Union)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\034com.google.bigtable.admin.v2B\nTableProtoP\001'))
-_TABLE_CLUSTERSTATESENTRY.has_options = True
-_TABLE_CLUSTERSTATESENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 _TABLE_COLUMNFAMILIESENTRY.has_options = True
 _TABLE_COLUMNFAMILIESENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 # @@protoc_insertion_point(module_scope)

--- a/gcloud/bigtable/cluster.py
+++ b/gcloud/bigtable/cluster.py
@@ -50,7 +50,7 @@ def _prepare_create_request(cluster):
     :returns: The CreateCluster request object containing the cluster info.
     """
     return messages_v2_pb2.CreateClusterRequest(
-        name=cluster._instance.name,
+        parent=cluster._instance.name,
         cluster_id=cluster.cluster_id,
         cluster=data_v2_pb2.Cluster(
             serve_nodes=cluster.serve_nodes,

--- a/gcloud/bigtable/instance.py
+++ b/gcloud/bigtable/instance.py
@@ -54,7 +54,7 @@ def _prepare_create_request(instance):
     """
     parent_name = ('projects/' + instance._client.project)
     return messages_v2_pb2.CreateInstanceRequest(
-        name=parent_name,
+        parent=parent_name,
         instance_id=instance.instance_id,
         instance=data_v2_pb2.Instance(
             display_name=instance.display_name,
@@ -412,7 +412,7 @@ class Instance(object):
                   returned and the second is a list of strings (the failed
                   locations in the request).
         """
-        request_pb = messages_v2_pb2.ListClustersRequest(name=self.name)
+        request_pb = messages_v2_pb2.ListClustersRequest(parent=self.name)
         # We expect a `.cluster_messages_v1_pb2.ListClustersResponse`
         list_clusters_response = self._client._instance_stub.ListClusters(
             request_pb, self._client.timeout_seconds)
@@ -442,7 +442,7 @@ class Instance(object):
         :raises: :class:`ValueError <exceptions.ValueError>` if one of the
                  returned tables has a name that is not of the expected format.
         """
-        request_pb = table_messages_v2_pb2.ListTablesRequest(name=self.name)
+        request_pb = table_messages_v2_pb2.ListTablesRequest(parent=self.name)
         # We expect a `table_messages_v2_pb2.ListTablesResponse`
         table_list_pb = self._client._table_stub.ListTables(
             request_pb, self._client.timeout_seconds)

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -170,7 +170,7 @@ class Table(object):
                 split_pb(key=key) for key in initial_split_keys]
         request_pb = table_admin_messages_v2_pb2.CreateTableRequest(
             initial_splits=initial_split_keys or [],
-            name=self._instance.name,
+            parent=self._instance.name,
             table_id=self.table_id,
         )
         client = self._instance._client

--- a/gcloud/bigtable/test_cluster.py
+++ b/gcloud/bigtable/test_cluster.py
@@ -497,7 +497,7 @@ class Test__prepare_create_request(unittest2.TestCase):
         request_pb = self._callFUT(cluster)
 
         self.assertEqual(request_pb.cluster_id, CLUSTER_ID)
-        self.assertEqual(request_pb.name, instance.name)
+        self.assertEqual(request_pb.parent, instance.name)
         self.assertEqual(request_pb.cluster.serve_nodes, SERVE_NODES)
 
 

--- a/gcloud/bigtable/test_instance.py
+++ b/gcloud/bigtable/test_instance.py
@@ -471,7 +471,7 @@ class TestInstance(unittest2.TestCase):
         CLUSTER_NAME2 = (instance.name + '/clusters/' + CLUSTER_ID2)
         # Create request_pb
         request_pb = messages_v2_pb2.ListClustersRequest(
-            name=instance.name,
+            parent=instance.name,
         )
 
         # Create response_pb
@@ -520,7 +520,7 @@ class TestInstance(unittest2.TestCase):
 
         # Create request_
         request_pb = table_messages_v1_pb2.ListTablesRequest(
-            name=self.INSTANCE_NAME)
+            parent=self.INSTANCE_NAME)
 
         # Create response_pb
         if table_name is None:
@@ -588,7 +588,7 @@ class Test__prepare_create_request(unittest2.TestCase):
         self.assertTrue(isinstance(request_pb,
                                    messages_v2_pb.CreateInstanceRequest))
         self.assertEqual(request_pb.instance_id, INSTANCE_ID)
-        self.assertEqual(request_pb.name,
+        self.assertEqual(request_pb.parent,
                          'projects/' + PROJECT)
         self.assertTrue(isinstance(request_pb.instance, data_v2_pb2.Instance))
         self.assertEqual(request_pb.instance.display_name, DISPLAY_NAME)
@@ -637,7 +637,7 @@ class Test__parse_pb_any_to_native(unittest2.TestCase):
             request_time=Timestamp(seconds=1, nanos=1234),
             finish_time=Timestamp(seconds=10, nanos=891011),
             original_request=messages_v2_pb.CreateInstanceRequest(
-                name='foo',
+                parent='foo',
                 instance_id='bar',
                 instance=data_v2_pb2.Instance(
                     display_name='quux',

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -147,7 +147,7 @@ class TestTable(unittest2.TestCase):
             for key in initial_split_keys or ()]
         request_pb = _CreateTableRequestPB(
             initial_splits=splits_pb,
-            name=self.INSTANCE_NAME,
+            parent=self.INSTANCE_NAME,
             table_id=self.TABLE_ID,
         )
 

--- a/scripts/make_datastore_grpc.py
+++ b/scripts/make_datastore_grpc.py
@@ -28,8 +28,7 @@ PROTO_PATH = os.path.join(PROTOS_DIR, 'google', 'datastore',
                           'v1beta3', 'datastore.proto')
 GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'gcloud', 'datastore',
                               '_generated', 'datastore_grpc_pb2.py')
-PROTOC_CMD = os.environ.get('PROTOC_CMD', 'protoc')
-GRPC_PLUGIN = os.environ.get('GRPC_PLUGIN', 'grpc_python_plugin')
+GRPCIO_VIRTUALENV = os.environ.get('GRPCIO_VIRTUALENV', 'protoc')
 
 
 def get_pb2_contents_with_grpc():
@@ -43,14 +42,14 @@ def get_pb2_contents_with_grpc():
                                   'v1beta3', 'datastore_pb2.py')
     try:
         return_code = subprocess.call([
-            PROTOC_CMD,
+            '%s/bin/python' % GRPCIO_VIRTUALENV,
+            '-m',
+            'grpc.tools.protoc',
             '--proto_path',
             PROTOS_DIR,
             '--python_out',
             temp_dir,
-            '--plugin',
-            'protoc-gen-grpc=' + GRPC_PLUGIN,
-            '--grpc_out',
+            '--grpc_python_out',
             temp_dir,
             PROTO_PATH,
         ])
@@ -73,7 +72,9 @@ def get_pb2_contents_without_grpc():
                                   'v1beta3', 'datastore_pb2.py')
     try:
         return_code = subprocess.call([
-            PROTOC_CMD,
+            '%s/bin/python' % GRPCIO_VIRTUALENV,
+            '-m',
+            'grpc.tools.protoc',
             '--proto_path',
             PROTOS_DIR,
             '--python_out',

--- a/scripts/make_operations_grpc.py
+++ b/scripts/make_operations_grpc.py
@@ -23,15 +23,13 @@ import tempfile
 
 ROOT_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..'))
-PROTOS_DIR = os.path.join(ROOT_DIR, 'cloud-bigtable-client',
-                          'bigtable-protos', 'src', 'main', 'proto')
+PROTOS_DIR = os.path.join(ROOT_DIR, 'googleapis-pb')
 PROTO_PATH = os.path.join(PROTOS_DIR, 'google', 'longrunning',
                           'operations.proto')
 GENERATED_SUBDIR = os.environ.get('GENERATED_SUBDIR', '_generated')
 GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'gcloud', 'bigtable',
                               GENERATED_SUBDIR, 'operations_grpc_pb2.py')
-PROTOC_CMD = os.environ.get('PROTOC_CMD', 'protoc')
-GRPC_PLUGIN = os.environ.get('GRPC_PLUGIN', 'grpc_python_plugin')
+GRPCIO_VIRTUALENV = os.environ.get('GRPCIO_VIRTUALENV', 'protoc')
 
 
 def get_pb2_contents_with_grpc():
@@ -45,14 +43,14 @@ def get_pb2_contents_with_grpc():
                                   'operations_pb2.py')
     try:
         return_code = subprocess.call([
-            PROTOC_CMD,
+            '%s/bin/python' % GRPCIO_VIRTUALENV,
+            '-m',
+            'grpc.tools.protoc',
             '--proto_path',
             PROTOS_DIR,
             '--python_out',
             temp_dir,
-            '--plugin',
-            'protoc-gen-grpc=' + GRPC_PLUGIN,
-            '--grpc_out',
+            '--grpc_python_out',
             temp_dir,
             PROTO_PATH,
         ])
@@ -75,7 +73,9 @@ def get_pb2_contents_without_grpc():
                                   'operations_pb2.py')
     try:
         return_code = subprocess.call([
-            PROTOC_CMD,
+            '%s/bin/python' % GRPCIO_VIRTUALENV,
+            '-m',
+            'grpc.tools.protoc',
             '--proto_path',
             PROTOS_DIR,
             '--python_out',

--- a/scripts/rewrite_imports.py
+++ b/scripts/rewrite_imports.py
@@ -112,6 +112,10 @@ def transform_line(line):
     :rtype: str
     :returns: The transformed line.
     """
+    # Work around https://github.com/grpc/grpc/issues/7101
+    if line == 'import ':
+        return ''
+
     for old_module, new_module in REPLACEMENTS.iteritems():
         result = transform_old_to_new(line, old_module, new_module)
         if result is not None:


### PR DESCRIPTION
See #1918.

In order to make the generation process repeatable, I updated the makefiles to create a virtualenv and install the latest `grpcio` / `grpcio-tools`:  the latter can then be used to generate gRPC-aware stubs from protos, without relying on any other `protoc` compiler.

Note that I don't actually update the generated code for `datastore` or `bigtable` V1 protos: although they do generate cleanly, examinig the diffs closely is off my radar for now.