### PR TITLE
Install gRPC et al for testing except py26/lint/docs-rtd

### DIFF
--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -218,14 +218,14 @@ class Test_PublisherAPI(_Base, unittest2.TestCase):
         topic_path, message_pbs, options = gax_api._publish_called_with
         self.assertEqual(topic_path, self.TOPIC_PATH)
         message_pb, = message_pbs
-        self.assertEqual(message_pb.data, B64)
+        self.assertEqual(message_pb.data.decode('ascii'), B64)
         self.assertEqual(message_pb.attributes, {})
         self.assertEqual(options.is_bundling, False)
 
     def test_topic_publish_miss_w_attrs_w_bytes_payload(self):
         import base64
         from gcloud.exceptions import NotFound
-        PAYLOAD = u'This is the message text'
+        PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD)
         MESSAGE = {'data': B64, 'attributes': {'foo': 'bar'}}
         gax_api = _GAXPublisherAPI()
@@ -256,7 +256,7 @@ class Test_PublisherAPI(_Base, unittest2.TestCase):
         topic_path, message_pbs, options = gax_api._publish_called_with
         self.assertEqual(topic_path, self.TOPIC_PATH)
         message_pb, = message_pbs
-        self.assertEqual(message_pb.data, B64)
+        self.assertEqual(message_pb.data.decode('ascii'), B64)
         self.assertEqual(message_pb.attributes, {})
         self.assertEqual(options.is_bundling, False)
 

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,12 @@ REQUIREMENTS = [
 ]
 
 GRPC_EXTRAS = [
-    'grpcio >= 0.14.0',
-    'google-gax >= 0.12.1',
-    'gax-google-pubsub-v1 >= 0.7.10',
-    'gax-google-logging-v2 >= 0.7.10',
+    'grpcio >= 1.0rc1',
+    'google-gax >= 0.12.3, < 0.13dev',
+    'gax-google-pubsub-v1 >= 0.7.12, < 0.8dev',
+    'grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev',
+    'gax-google-logging-v2 >= 0.7.12, < 0.8dev',
+    'grpc-google-logging-v2 >= 0.7.12, < 0.8dev',
 ]
 
 if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,11 @@
 envlist =
     py27,py34,py35,cover,docs,lint
 
-[testenv]
-commands =
-    nosetests
+[testing]
 deps =
     nose
     nose-exclude
     unittest2
-setenv =
-    PYTHONPATH = {toxinidir}/_testing
 covercmd =
     nosetests \
       --exclude-dir=system_tests \
@@ -28,24 +24,30 @@ deps =
     gax-google-pubsub-v1 >= 0.7.10
     gax-google-logging-v2 >= 0.7.10
 
-[testenv:py27]
-basepython =
-    python2.7
+[docs]
+deps =
+    {[testenv]deps}
+    Sphinx
+    sphinx_rtd_theme
+
+[testenv]
 commands =
     nosetests
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     {[grpc]deps}
+
+[testenv:py26]
+basepython =
+    python2.6
+deps =
+    {[testing]deps}
 setenv =
-    PYTHONPATH =
+    PYTHONPATH = {toxinidir}/_testing
 
 [testenv:py27-pandas]
 basepython =
     python2.7
-commands =
-    {[testenv:py27]commands}
-setenv =
-    {[testenv:py27]setenv}
 deps =
     {[testenv]deps}
     pandas
@@ -54,25 +56,19 @@ deps =
 basepython =
     python2.7
 commands =
-    {[testenv]covercmd} --cover-min-percentage=100
+    {[testing]covercmd} --cover-min-percentage=100
 deps =
     {[testenv]deps}
-    {[grpc]deps}
     coverage
-setenv =
-    PYTHONPATH =
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}
 commands =
-    pip install gcloud[grpc]
-    {[testenv]covercmd}
+    {[testing]covercmd}
     coveralls
 deps =
     {[testenv:cover]deps}
     coveralls
-setenv =
-    PYTHONPATH =
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:codecov]
@@ -105,20 +101,22 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
     python {toxinidir}/scripts/verify_included_modules.py
 deps =
-    Sphinx
-    sphinx_rtd_theme
+    {[testenv]deps}
+    {[docs]deps}
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS LOCAL_RTD
 
 [testenv:docs-rtd]
-setenv =
-    PYTHONPATH = {toxinidir}/_testing
-    LOCAL_RTD = True
 basepython = {[testenv:docs]basepython}
 commands =
     python -c "import shutil; shutil.rmtree('docs/_build_rtd', ignore_errors=True)"
     sphinx-build -W -b html -d docs/_build_rtd/doctrees docs docs/_build_rtd/html
     python {toxinidir}/scripts/verify_included_modules.py
-deps = {[testenv:docs]deps}
+deps =
+    {[testing]deps}
+    {[docs]deps}
+setenv =
+    PYTHONPATH = {toxinidir}/_testing
+    LOCAL_RTD = True
 passenv = {[testenv:docs]passenv}
 
 [pep8]
@@ -132,13 +130,11 @@ commands =
     python {toxinidir}/scripts/pycodestyle_on_repo.py
     python {toxinidir}/scripts/run_pylint.py
 deps =
+    {[testing]deps}
     pycodestyle
     pylint >= 1.6.4
-    unittest2
-    psutil
-    Sphinx
 setenv =
-    PYTHONPATH =
+    PYTHONPATH = {toxinidir}/_testing
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:system-tests]
@@ -146,11 +142,6 @@ basepython =
     python2.7
 commands =
     python {toxinidir}/system_tests/attempt_system_tests.py
-setenv =
-    PYTHONPATH =
-deps =
-    {[testenv]deps}
-    {[grpc]deps}
 passenv = GOOGLE_* GCLOUD_* TRAVIS* encrypted_*
 
 [testenv:system-tests3]

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,12 @@ covercmd =
 
 [grpc]
 deps =
-    grpcio >= 0.14.0
-    google-gax >= 0.12.1
-    gax-google-pubsub-v1 >= 0.7.10
-    gax-google-logging-v2 >= 0.7.10
+    grpcio >= 1.0rc1
+    google-gax >= 0.12.3, < 0.13dev
+    gax-google-pubsub-v1 >= 0.7.12, < 0.8dev
+    grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev
+    gax-google-logging-v2 >= 0.7.12, < 0.8dev
+    grpc-google-logging-v2 >= 0.7.12, < 0.8dev
 
 [docs]
 deps =


### PR DESCRIPTION
Rationalize tox vs. gRPC:

- Install `grpcio` and related deps by default, and omit adding `_testing` to PYTHONPATH.

- For Python 2.6, and lint, RTD, suppress installing gRPC-related deps, and add `_testing` to PYTHONPATH.

Bump minimum version for `grpcio` to 0.15.0.

Fix up Py3k failures with `grpcio` installed.

@daspecster, @dhermes Maybe this should land before 0.17.0?