### PR TITLE
Fix GAX logging system tests

### DIFF
--- a/gcloud/logging/_gax.py
+++ b/gcloud/logging/_gax.py
@@ -154,7 +154,8 @@ class _SinksAPI(object):
                   with another call (pass that value as ``page_token``).
         """
         options = _build_paging_options(page_token)
-        page_iter = self._gax_api.list_sinks(project, page_size, options)
+        path = 'projects/%s' % (project,)
+        page_iter = self._gax_api.list_sinks(path, page_size, options)
         sinks = [_log_sink_pb_to_mapping(log_sink_pb)
                  for log_sink_pb in page_iter.next()]
         token = page_iter.page_token or None
@@ -289,7 +290,8 @@ class _MetricsAPI(object):
                   with another call (pass that value as ``page_token``).
         """
         options = _build_paging_options(page_token)
-        page_iter = self._gax_api.list_log_metrics(project, page_size, options)
+        path = 'projects/%s' % (project,)
+        page_iter = self._gax_api.list_log_metrics(path, page_size, options)
         metrics = [_log_metric_pb_to_mapping(log_metric_pb)
                    for log_metric_pb in page_iter.next()]
         token = page_iter.page_token or None

--- a/gcloud/logging/_gax.py
+++ b/gcloud/logging/_gax.py
@@ -463,7 +463,7 @@ def _log_entry_pb_to_mapping(entry_pb):
     mapping = {
         'logName': entry_pb.log_name,
         'resource': _mon_resource_pb_to_mapping(entry_pb.resource),
-        'severity': entry_pb.severity,
+        'severity': LogSeverity.Name(entry_pb.severity),
         'insertId': entry_pb.insert_id,
         'timestamp': _pb_timestamp_to_rfc3339(entry_pb.timestamp),
         'labels': entry_pb.labels,

--- a/gcloud/logging/_gax.py
+++ b/gcloud/logging/_gax.py
@@ -440,15 +440,15 @@ def _log_entry_pb_to_mapping(entry_pb):
     if entry_pb.http_request:
         request = entry_pb.http_request
         mapping['httpRequest'] = {
-            'request_method': request.request_method,
-            'request_url': request.request_url,
+            'requestMethod': request.request_method,
+            'requestUrl': request.request_url,
             'status': request.status,
             'referer': request.referer,
-            'user_agent': request.user_agent,
-            'cache_hit': request.cache_hit,
-            'request_size': request.request_size,
-            'response_size': request.response_size,
-            'remote_ip': request.remote_ip,
+            'userAgent': request.user_agent,
+            'cacheHit': request.cache_hit,
+            'requestSize': request.request_size,
+            'responseSize': request.response_size,
+            'remoteIp': request.remote_ip,
         }
 
     if entry_pb.operation:

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -439,7 +439,7 @@ class Test_SinksAPI(_Base, unittest2.TestCase):
         self.assertEqual(token, TOKEN)
 
         project, page_size, options = gax_api._list_sinks_called_with
-        self.assertEqual(project, self.PROJECT)
+        self.assertEqual(project, self.PROJECT_PATH)
         self.assertEqual(page_size, 0)
         self.assertEqual(options.page_token, INITIAL_PAGE)
 
@@ -465,7 +465,7 @@ class Test_SinksAPI(_Base, unittest2.TestCase):
         self.assertEqual(token, None)
 
         project, page_size, options = gax_api._list_sinks_called_with
-        self.assertEqual(project, self.PROJECT)
+        self.assertEqual(project, self.PROJECT_PATH)
         self.assertEqual(page_size, PAGE_SIZE)
         self.assertEqual(options.page_token, TOKEN)
 
@@ -643,7 +643,7 @@ class Test_MetricsAPI(_Base, unittest2.TestCase):
         self.assertEqual(token, TOKEN)
 
         project, page_size, options = gax_api._list_log_metrics_called_with
-        self.assertEqual(project, self.PROJECT)
+        self.assertEqual(project, self.PROJECT_PATH)
         self.assertEqual(page_size, 0)
         self.assertEqual(options.page_token, INITIAL_PAGE)
 
@@ -669,7 +669,7 @@ class Test_MetricsAPI(_Base, unittest2.TestCase):
         self.assertEqual(token, None)
 
         project, page_size, options = gax_api._list_log_metrics_called_with
-        self.assertEqual(project, self.PROJECT)
+        self.assertEqual(project, self.PROJECT_PATH)
         self.assertEqual(page_size, PAGE_SIZE)
         self.assertEqual(options.page_token, TOKEN)
 

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -154,15 +154,15 @@ class Test_LoggingAPI(_Base, unittest2.TestCase):
         self.assertEqual(entry['insertId'], IID)
         self.assertEqual(entry['timestamp'], _datetime_to_rfc3339(NOW))
         EXPECTED_REQUEST = {
-            'request_method': request.request_method,
-            'request_url': request.request_url,
+            'requestMethod': request.request_method,
+            'requestUrl': request.request_url,
             'status': request.status,
-            'request_size': request.request_size,
-            'response_size': request.response_size,
+            'requestSize': request.request_size,
+            'responseSize': request.response_size,
             'referer': request.referer,
-            'user_agent': request.user_agent,
-            'remote_ip': request.remote_ip,
-            'cache_hit': request.cache_hit,
+            'userAgent': request.user_agent,
+            'remoteIp': request.remote_ip,
+            'cacheHit': request.cache_hit,
         }
         self.assertEqual(entry['httpRequest'], EXPECTED_REQUEST)
         EXPECTED_OPERATION = {

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -112,6 +112,7 @@ class Test_LoggingAPI(_Base, unittest2.TestCase):
 
     def test_list_entries_with_extra_properties(self):
         from datetime import datetime
+        from google.logging.type.log_severity_pb2 import WARNING
         from gcloud._testing import _GAXPageIterator
         from gcloud._helpers import UTC
         from gcloud._helpers import _datetime_to_rfc3339
@@ -129,7 +130,7 @@ class Test_LoggingAPI(_Base, unittest2.TestCase):
         request = _HTTPRequestPB()
         operation = _LogEntryOperationPB()
         EXTRAS = {
-            'severity': SEVERITY,
+            'severity': WARNING,
             'labels': LABELS,
             'insert_id': IID,
             'http_request': request,
@@ -1054,7 +1055,7 @@ class _StructPB(object):
 
 class _LogEntryPB(object):
 
-    severity = 'DEFAULT'
+    severity = 0
     http_request = operation = insert_id = None
     text_payload = json_payload = proto_payload = None
 

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -45,6 +45,7 @@ def _retry_backoff(result_predicate, meth, *args, **kw):
                 raise
             if backoff_intervals:
                 time.sleep(backoff_intervals.pop(0))
+                continue
             else:
                 raise
         if result_predicate(result):


### PR DESCRIPTION
Logging system tests now pass both **with** `GCLOUD_ENABLE_GAX` **and** without it.

The `_retry_backoff` function added in  3a3613e may help toward #1619.