### PR TITLE
Fix pubsub context manager exit error

### DIFF
--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -228,6 +228,18 @@ class TestTopic(unittest2.TestCase):
         self.assertEqual(api._topic_published,
                          (self.TOPIC_PATH, [MESSAGE1, MESSAGE2]))
 
+    def test_publish_w_no_messages(self):
+        client = _Client(project=self.PROJECT)
+        api = client.publisher_api = _FauxPublisherAPI()
+        api._topic_publish_response = []
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
+
+        with topic.batch() as batch:
+            pass
+
+        self.assertEqual(list(batch.messages), [])
+        self.assertEqual(api._api_called, 0)
+
     def test_publish_multiple_w_alternate_client(self):
         import base64
         PAYLOAD1 = b'This is the first message text'
@@ -716,6 +728,7 @@ class TestBatch(unittest2.TestCase):
 
 
 class _FauxPublisherAPI(object):
+    _api_called = 0
 
     def topic_create(self, topic_path):
         self._topic_created = topic_path
@@ -735,6 +748,7 @@ class _FauxPublisherAPI(object):
 
     def topic_publish(self, topic_path, messages):
         self._topic_published = topic_path, messages
+        self._api_called += 1
         return self._topic_publish_response
 
     def topic_list_subscriptions(self, topic_path, page_size=None,

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -416,7 +416,7 @@ class Batch(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None and len(self.messages):
+        if exc_type is None:
             self.commit()
 
     def __iter__(self):
@@ -443,6 +443,9 @@ class Batch(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current batch.
         """
+        if not self.messages:
+            return
+
         if client is None:
             client = self.client
         api = client.publisher_api

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -416,7 +416,7 @@ class Batch(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
+        if exc_type is None and len(self.messages):
             self.commit()
 
     def __iter__(self):


### PR DESCRIPTION
Possible fix for #1955, checking the length of `self.messages` before `__exit__`.