### PR TITLE
Attempt to un-break Appveyor:

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,10 +30,14 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "32"
+      # Use mocked-up GRPC for now
+      GRPC_PATH: "_testing"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "64"
+      # Use mocked-up GRPC for now
+      GRPC_PATH: "_testing"
 
     # Python 3.5.1 is the latest Python 3.5 with a Windows installer
     # Python 3.5.1 is the overall latest
@@ -41,10 +45,14 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
+      # Use mocked-up GRPC for now
+      GRPC_PATH: "_testing"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "64"
+      # Use mocked-up GRPC for now
+      GRPC_PATH: "_testing"
 
 install:
   - ECHO "Filesystem root:"
@@ -78,10 +86,12 @@ install:
 
 build_script:
   # Build the compiled extension
-  - "%CMD_IN_ENV% python setup.py build"
+  #- "%CMD_IN_ENV% python setup.py build"
+  - "%CMD_IN_ENV% python setup.py develop"
+  - "%CMD_IN_ENV% pip list"
 
 test_script:
-  - "set PYTHONPATH=_testing"
+  - "set PYTHONPATH=%GRPC_PATH%"
   # Run the project tests
   - "%CMD_IN_ENV% python setup.py nosetests"
 


### PR DESCRIPTION
- Put `_testing` on PYTHONPATH only for Py3k (debug grpico-on-Py3k issues later).
- Use `setup.py develop` rather than `setup.py build` to get dependencies installed.
- Run `pip list` afterwards to show what got installed.

Toward #1863.