### PR TITLE
Change error for generating signed URL

### DIFF
--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -95,10 +95,20 @@ def _get_signed_query_params(credentials, expiration, string_to_sign):
     :type string_to_sign: string
     :param string_to_sign: The string to be signed by the credentials.
 
+    :raises AttributeError: If :meth: sign_blob is unavailable.
+
     :rtype: dict
     :returns: Query parameters matching the signing credentials with a
               signed payload.
     """
+    if not hasattr(credentials, 'sign_blob'):
+        raise AttributeError('you need a private key to sign credentials.'
+                             'the credentials you are currently using %s '
+                             'just contains a token. see https://googlecloud'
+                             'platform.github.io/gcloud-python/stable/gcloud-'
+                             'auth.html#setting-up-a-service-account for more '
+                             'details.' % type(credentials))
+
     _, signature_bytes = credentials.sign_blob(string_to_sign)
     signature = base64.b64encode(signature_bytes)
     service_account_name = credentials.service_account_email
@@ -114,6 +124,8 @@ def _get_expiration_seconds(expiration):
 
     :type expiration: int, long, datetime.datetime, datetime.timedelta
     :param expiration: When the signed URL should expire.
+
+    :raises TypeError: When expiration is not an integer.
 
     :rtype: int
     :returns: a timestamp as an absolute number of seconds.

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -101,6 +101,18 @@ class Test_generate_signed_url(unittest2.TestCase):
                               generation=generation)
 
 
+class Test_generate_signed_url_exception(unittest2.TestCase):
+    def test_with_google_credentials(self):
+        import time
+        from gcloud.credentials import generate_signed_url
+        RESOURCE = '/name/path'
+
+        credentials = _GoogleCredentials()
+        expiration = int(time.time() + 5)
+        self.assertRaises(AttributeError, generate_signed_url, credentials,
+                          resource=RESOURCE, expiration=expiration)
+
+
 class Test__get_signed_query_params(unittest2.TestCase):
 
     def _callFUT(self, credentials, expiration, string_to_sign):
@@ -110,8 +122,6 @@ class Test__get_signed_query_params(unittest2.TestCase):
 
     def test_it(self):
         import base64
-        from gcloud._testing import _Monkey
-        from gcloud import credentials as MUT
 
         SIG_BYTES = b'DEADBEEF'
         ACCOUNT_NAME = object()
@@ -224,6 +234,12 @@ class _Credentials(object):
     def sign_blob(self, bytes_to_sign):
         self._signed.append(bytes_to_sign)
         return None, self._sign_result
+
+
+class _GoogleCredentials(object):
+
+    def __init__(self, service_account_email='testing@example.com'):
+        self.service_account_email = service_account_email
 
 
 class _Client(object):


### PR DESCRIPTION
Change message when calling `generate_signed_url` on Blob if credentials with insufficient parameters are used.

See: #1964

The tests should actually be failing here. I'm still looking into why they aren't.