### PR TITLE
Disable pylint 1.6 warnings / work around breakage

### DIFF
--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -636,8 +636,6 @@ class TestDataset(unittest2.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_tables_empty(self):
-        from gcloud.bigquery.table import Table
-
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = self._makeOne(self.DS_NAME, client=client)

--- a/gcloud/bigquery/test_query.py
+++ b/gcloud/bigquery/test_query.py
@@ -323,8 +323,6 @@ class _Connection(object):
         self._requested = []
 
     def api_request(self, **kw):
-        from gcloud.exceptions import NotFound
         self._requested.append(kw)
-
         response, self._responses = self._responses[0], self._responses[1:]
         return response

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -834,7 +834,6 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         import datetime
         from gcloud._helpers import UTC
         from gcloud._helpers import _millis
-        from gcloud.bigquery.table import SchemaField
 
         PATH = 'projects/%s/datasets/%s/tables/%s' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)

--- a/gcloud/dns/test_changes.py
+++ b/gcloud/dns/test_changes.py
@@ -56,7 +56,6 @@ class TestChanges(unittest2.TestCase):
 
     def _verifyResourceProperties(self, changes, resource, zone):
         from gcloud._helpers import _rfc3339_to_datetime
-        from gcloud._helpers import UTC
         self.assertEqual(changes.name, resource['id'])
         started = _rfc3339_to_datetime(resource['startTime'])
         self.assertEqual(changes.started, started)

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -800,7 +800,6 @@ class _Connection(object):
         self._deleted = []
 
     def api_request(self, **kw):
-        from gcloud.exceptions import NotFound
         self._requested.append(kw)
         response, self._responses = self._responses[0], self._responses[1:]
         return response

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -90,6 +90,13 @@ load-plugins=pylint.extensions.check_docs
 # - no-name-in-module: Error gives a lot of false positives for names which
 #                      are defined dynamically. Also, any truly missing names
 #                      will be detected by our 100% code coverage.
+#
+# New opinions in pylint 1.6, enforcing PEP 257.  #1968 for eventual fixes
+# - catching-non-exception
+# - missing-raises-doc
+# - missing-returns-doc
+# - redundant-returns-doc
+# - ungrouped-imports
 disable =
     maybe-no-member,
     no-member,
@@ -99,6 +106,11 @@ disable =
     redefined-variable-type,
     wrong-import-position,
     no-name-in-module,
+    catching-non-exception,
+    missing-raises-doc,
+    missing-returns-doc,
+    redundant-returns-doc,
+    ungrouped-imports
 
 
 [REPORTS]

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -51,8 +51,6 @@ TEST_DISABLED_MESSAGES = [
     'import-error',
     'invalid-name',
     'missing-docstring',
-    'missing-raises-doc',
-    'missing-returns-doc',
     'no-init',
     'no-self-use',
     'superfluous-parens',

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -37,6 +37,9 @@ IGNORED_DIRECTORIES = [
 ]
 IGNORED_FILES = [
     os.path.join('docs', 'conf.py'),
+    # Both these files cause pylint 1.6 to barf.  See:
+    # https://github.com/PyCQA/pylint/issues/998
+    os.path.join('gcloud', 'bigtable', 'happybase', 'connection.py'),
     os.path.join('gcloud', 'streaming', 'http_wrapper.py'),
     'setup.py',
 ]

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -37,6 +37,7 @@ IGNORED_DIRECTORIES = [
 ]
 IGNORED_FILES = [
     os.path.join('docs', 'conf.py'),
+    os.path.join('gcloud', 'streaming', 'http_wrapper.py'),
     'setup.py',
 ]
 SCRIPTS_DIR = os.path.abspath(os.path.dirname(__file__))

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -226,13 +226,17 @@ def lint_fileset(filenames, rcfile, description):
                  if os.path.exists(filename)]
     if filenames:
         rc_flag = '--rcfile=%s' % (rcfile,)
-        pylint_shell_command = ['pylint', rc_flag] + filenames
-        status_code = subprocess.call(pylint_shell_command)
-        if status_code != 0:
-            error_message = ('Pylint failed on %s with '
-                             'status %d.' % (description, status_code))
-            print(error_message, file=sys.stderr)
-            sys.exit(status_code)
+        pylint_shell_command = ['pylint', rc_flag]
+        errors = {}  # filename -> status_code
+        for filename in filenames:
+            cmd = pylint_shell_command + [filename]
+            status_code = subprocess.call(cmd)
+            if status_code != 0:
+                errors[filename] = status_code
+        if errors:
+            for filename, status_code in sorted(errors.items()):
+                print('%-30s: %d' % (filename, status_code), file=sys.stderr)
+            sys.exit(len(errors))
     else:
         print('Skipping %s, no files to lint.' % (description,))
 


### PR DESCRIPTION
Work around https://github.com/PyCQA/pylint/issues/998

Globally disable new warnings (rather than just for tests, as in #1967).

Run pylint a single file at a time:  if any exits with a non-zero status, record the name and status and continue (this helped debug the issue above).