### PR TITLE
Pylint 1.6.3 compatibility

### DIFF
--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -898,7 +898,8 @@ class _GAXBaseAPI(object):
             code = status_code
 
             def __init__(self):
-                pass
+                super(_DummyException, self).__init__(
+                    None, None, self.code, None)
 
         return _DummyException()
 

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -749,7 +749,8 @@ class _GaxAPIBase(object):
             code = status_code
 
             def __init__(self):
-                pass
+                super(_DummyException, self).__init__(
+                    None, None, self.code, None)
 
         return _DummyException()
 

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -37,10 +37,6 @@ IGNORED_DIRECTORIES = [
 ]
 IGNORED_FILES = [
     os.path.join('docs', 'conf.py'),
-    # Both these files cause pylint 1.6 to barf.  See:
-    # https://github.com/PyCQA/pylint/issues/998
-    os.path.join('gcloud', 'bigtable', 'happybase', 'connection.py'),
-    os.path.join('gcloud', 'streaming', 'http_wrapper.py'),
     'setup.py',
 ]
 SCRIPTS_DIR = os.path.abspath(os.path.dirname(__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -133,10 +133,12 @@ commands =
     python {toxinidir}/scripts/run_pylint.py
 deps =
     pep8
-    pylint
+    pylint >= 1.6.3
     unittest2
     psutil
     Sphinx
+setenv =
+    PYTHONPATH =
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:system-tests]


### PR DESCRIPTION
Fixes in [pylint 1.6.2 and 1.6.3](https://github.com/PyCQA/pylint/issues/998) mean we can test the files that caused it to barf in 1.6.0.