### PR TITLE
Fix branch coverage miss in 'gcloud.streaming.transfer'.

### DIFF
--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -66,7 +66,7 @@ TEST_RC_ADDITIONS = {
 }
 TEST_RC_REPLACEMENTS = {
     'FORMAT': {
-        'max-module-lines': 1900,
+        'max-module-lines': 1950,
     },
 }
 


### PR DESCRIPTION
Introduced in PR #1914.

Bump pylint's max line count for test modules accordingly.