### PR TITLE
Fix datastore __init__ docstring.

### DIFF
--- a/gcloud/datastore/__init__.py
+++ b/gcloud/datastore/__init__.py
@@ -14,14 +14,14 @@
 
 """Shortcut methods for getting set up with Google Cloud Datastore.
 
-You'll typically use these to get started with the API:
+You'll typically use these to get started with the API::
 
->>> from gcloud import datastore
->>>
->>> client = datastore.Client()
->>> key = client.key('EntityKind', 1234)
->>> entity = datastore.Entity(key)
->>> query = client.query(kind='EntityKind')
+    >>> from gcloud import datastore
+    >>>
+    >>> client = datastore.Client()
+    >>> key = client.key('EntityKind', 1234)
+    >>> entity = datastore.Entity(key)
+    >>> query = client.query(kind='EntityKind')
 
 The main concepts with this API are:
 


### PR DESCRIPTION
This fixes the issue with datastore index doc not rendering the examples.

![screen shot 2016-07-20 at 12 02 25 am](https://cloud.githubusercontent.com/assets/192456/16974711/4906721e-4e0d-11e6-9880-95210770e92b.png)

http://daspecster.github.io/gcloud-python/#/docs/master/gcloud/datastore

@dhermes, one small step closer but far far from perfect. I need to detect lists so that renders better.