### PR TITLE
Adding UDF Resources to Queries

### DIFF
--- a/gcloud/bigquery/job.py~
+++ b/gcloud/bigquery/job.py~
@@ -927,7 +927,7 @@ class QueryJob(_AsyncJob):
 
     :type udf_resources: tuple
     :param udf_resources: An iterable of
-                        :class:`gcloud.bigquery.job.UDFResource`
+                        :class:`gcloud.bigquery.query.UDFResource`
                         (empty by default)
     """
     _JOB_TYPE = 'query'

--- a/gcloud/bigquery/query.py~
+++ b/gcloud/bigquery/query.py~
@@ -51,7 +51,7 @@ class QueryResults(object):
 
     :type udf_resources: tuple
     :param udf_resources: An iterable of
-                        :class:`gcloud.bigquery.job.UDFResource`
+                        :class:`gcloud.bigquery.query.UDFResource`
                         (empty by default)
     """
 

--- a/gcloud/bigquery/test_job.py
+++ b/gcloud/bigquery/test_job.py
@@ -1384,7 +1384,7 @@ class TestQueryJob(unittest2.TestCase, _Base):
         job = self._makeOne(self.JOB_NAME, self.QUERY, client)
 
         job.begin()
-
+        self.assertEqual(job.udf_resources, [])
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
@@ -1396,7 +1396,7 @@ class TestQueryJob(unittest2.TestCase, _Base):
             },
             'configuration': {
                 'query': {
-                    'query': self.QUERY,
+                    'query': self.QUERY
                 },
             },
         }
@@ -1467,6 +1467,62 @@ class TestQueryJob(unittest2.TestCase, _Base):
         }
         self.assertEqual(req['data'], SENT)
         self._verifyResourceProperties(job, RESOURCE)
+
+    def test_begin_w_bound_client_and_udf(self):
+        from gcloud.bigquery.job import UDFResource
+        RESOURCE_URI = 'gs://some-bucket/js/lib.js'
+        PATH = 'projects/%s/jobs' % self.PROJECT
+        RESOURCE = self._makeResource()
+        # Ensure None for missing server-set props
+        del RESOURCE['statistics']['creationTime']
+        del RESOURCE['etag']
+        del RESOURCE['selfLink']
+        del RESOURCE['user_email']
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        job = self._makeOne(self.JOB_NAME, self.QUERY, client,
+                            udf_resources=[
+                                UDFResource("resourceUri", RESOURCE_URI)
+                            ])
+
+        job.begin()
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(job.udf_resources,
+                         [UDFResource("resourceUri", RESOURCE_URI)])
+        SENT = {
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': self.JOB_NAME,
+            },
+            'configuration': {
+                'query': {
+                    'query': self.QUERY,
+                    'userDefinedFunctionResources':
+                        [{'resourceUri': RESOURCE_URI}]
+                },
+            },
+        }
+        self.assertEqual(req['data'], SENT)
+        self._verifyResourceProperties(job, RESOURCE)
+
+    def test_begin_w_bad_udf(self):
+        RESOURCE = self._makeResource()
+        # Ensure None for missing server-set props
+        del RESOURCE['statistics']['creationTime']
+        del RESOURCE['etag']
+        del RESOURCE['selfLink']
+        del RESOURCE['user_email']
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        job = self._makeOne(self.JOB_NAME, self.QUERY, client)
+
+        with self.assertRaises(ValueError):
+            job.udf_resources = ["foo"]
+        self.assertEqual(job.udf_resources, [])
 
     def test_exists_miss_w_bound_client(self):
         PATH = 'projects/%s/jobs/%s' % (self.PROJECT, self.JOB_NAME)

--- a/gcloud/bigquery/test_query.py
+++ b/gcloud/bigquery/test_query.py
@@ -181,7 +181,7 @@ class TestQueryResults(unittest2.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         query = self._makeOne(self.QUERY, client)
-
+        self.assertEqual(query.udf_resources, [])
         query.run()
 
         self.assertEqual(len(conn._requested), 1)
@@ -232,6 +232,88 @@ class TestQueryResults(unittest2.TestCase):
         }
         self.assertEqual(req['data'], SENT)
         self._verifyResourceProperties(query, RESOURCE)
+
+    def test_run_w_inline_udf(self):
+        from gcloud.bigquery.query import UDFResource
+        INLINE_UDF_CODE = 'var someCode = "here";'
+        PATH = 'projects/%s/queries' % self.PROJECT
+        RESOURCE = self._makeResource(complete=False)
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        query = self._makeOne(self.QUERY, client)
+        query.udf_resources = [UDFResource("inlineCode", INLINE_UDF_CODE)]
+
+        query.run()
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        SENT = {'query': self.QUERY,
+                'userDefinedFunctionResources':
+                [{'inlineCode': INLINE_UDF_CODE}]}
+        self.assertEqual(req['data'], SENT)
+        self._verifyResourceProperties(query, RESOURCE)
+
+    def test_run_w_udf_resource_uri(self):
+        from gcloud.bigquery.job import UDFResource
+        RESOURCE_URI = 'gs://some-bucket/js/lib.js'
+        PATH = 'projects/%s/queries' % self.PROJECT
+        RESOURCE = self._makeResource(complete=False)
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        query = self._makeOne(self.QUERY, client)
+        query.udf_resources = [UDFResource("resourceUri", RESOURCE_URI)]
+
+        query.run()
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        SENT = {'query': self.QUERY,
+                'userDefinedFunctionResources':
+                [{'resourceUri': RESOURCE_URI}]}
+        self.assertEqual(req['data'], SENT)
+        self._verifyResourceProperties(query, RESOURCE)
+
+    def test_run_w_mixed_udfs(self):
+        from gcloud.bigquery.job import UDFResource
+        RESOURCE_URI = 'gs://some-bucket/js/lib.js'
+        INLINE_UDF_CODE = 'var someCode = "here";'
+        PATH = 'projects/%s/queries' % self.PROJECT
+        RESOURCE = self._makeResource(complete=False)
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        query = self._makeOne(self.QUERY, client)
+        query.udf_resources = [UDFResource("resourceUri", RESOURCE_URI),
+                               UDFResource("inlineCode", INLINE_UDF_CODE)]
+
+        query.run()
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        self.assertEqual(query.udf_resources,
+                         [UDFResource("resourceUri", RESOURCE_URI),
+                          UDFResource("inlineCode", INLINE_UDF_CODE)])
+        SENT = {'query': self.QUERY,
+                'userDefinedFunctionResources': [
+                    {'resourceUri': RESOURCE_URI},
+                    {"inlineCode": INLINE_UDF_CODE}]}
+        self.assertEqual(req['data'], SENT)
+        self._verifyResourceProperties(query, RESOURCE)
+
+    def test_run_w_bad_udfs(self):
+        RESOURCE = self._makeResource(complete=False)
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        query = self._makeOne(self.QUERY, client)
+
+        with self.assertRaises(ValueError):
+            query.udf_resources = ["foo"]
+        self.assertEqual(query.udf_resources, [])
 
     def test_fetch_data_query_not_yet_run(self):
         conn = _Connection()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,cover,docs,lint
+    py26,py27,py34,py35,cover,docs,lint
 
 [testing]
 deps =
@@ -44,6 +44,7 @@ basepython =
     python2.6
 deps =
     {[testing]deps}
+	ordereddict
 setenv =
     PYTHONPATH = {toxinidir}/_testing
 


### PR DESCRIPTION
The BigQuery client doesn't currently support adding UDF resources.  This pull request adds a UDFResources object, and properties to set these resources on queries and QueryJobs.