### PR TITLE
Add Sphinx as a dependency for linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,7 @@ deps =
     {[testing]deps}
     pycodestyle
     pylint >= 1.6.4
+    sphinx
 setenv =
     PYTHONPATH = {toxinidir}/_testing
 passenv = {[testenv:system-tests]passenv}


### PR DESCRIPTION
First seen https://github.com/GoogleCloudPlatform/gcloud-python/pull/1946#issuecomment-234667091

![screen shot 2016-07-22 at 6 10 03 pm](https://cloud.githubusercontent.com/assets/192456/17072591/8c63abea-5037-11e6-9040-e3904b5ec480.png)

Not sure how this got through?