### PR TITLE
Exclude verify_included_modules.py from lint

### DIFF
--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -33,6 +33,7 @@ import sys
 IGNORED_DIRECTORIES = [
     os.path.join('gcloud', 'bigtable', '_generated'),
     os.path.join('gcloud', 'datastore', '_generated'),
+    'scripts/verify_included_modules.py',
 ]
 IGNORED_FILES = [
     os.path.join('docs', 'conf.py'),

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,6 @@ deps =
     {[testing]deps}
     pycodestyle
     pylint >= 1.6.4
-    sphinx
 setenv =
     PYTHONPATH = {toxinidir}/_testing
 passenv = {[testenv:system-tests]passenv}


### PR DESCRIPTION
Reverts #2019 by removing sphinx dependency from tox lint and ignores verify_included_modules.py.