### PR TITLE
Update the helper _datetime_to_rfc3339 to handle time zones.

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -409,15 +409,23 @@ def _rfc3339_nanos_to_datetime(dt_str):
     return bare_seconds.replace(microsecond=micros, tzinfo=UTC)
 
 
-def _datetime_to_rfc3339(value):
-    """Convert a native timestamp to a string.
+def _datetime_to_rfc3339(value, ignore_zone=True):
+    """Convert a timestamp to a string.
 
     :type value: :class:`datetime.datetime`
     :param value: The datetime object to be converted to a string.
 
+    :type ignore_zone: boolean
+    :param ignore_zone: If True, then the timezone (if any) of the datetime
+                        object is ignored.
+
     :rtype: str
     :returns: The string representing the datetime stamp.
     """
+    if not(ignore_zone or value.tzinfo is None):
+        # Convert to UTC and remove the time zone info.
+        value = value.replace(tzinfo=None) - value.utcoffset()
+
     return value.strftime(_RFC3339_MICROS)
 
 

--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -422,7 +422,7 @@ def _datetime_to_rfc3339(value, ignore_zone=True):
     :rtype: str
     :returns: The string representing the datetime stamp.
     """
-    if not(ignore_zone or value.tzinfo is None):
+    if not ignore_zone and value.tzinfo is not None:
         # Convert to UTC and remove the time zone info.
         value = value.replace(tzinfo=None) - value.utcoffset()
 

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -25,6 +25,7 @@ import itertools
 
 import six
 
+from gcloud._helpers import _datetime_to_rfc3339
 from gcloud.monitoring._dataframe import _build_dataframe
 from gcloud.monitoring.timeseries import TimeSeries
 
@@ -498,9 +499,12 @@ class Query(object):
         """
         yield 'filter', self.filter
 
-        yield 'interval.endTime', _format_timestamp(self._end_time)
+        yield 'interval.endTime', _datetime_to_rfc3339(
+            self._end_time, ignore_zone=False)
+
         if self._start_time is not None:
-            yield 'interval.startTime', _format_timestamp(self._start_time)
+            yield 'interval.startTime', _datetime_to_rfc3339(
+                self._start_time, ignore_zone=False)
 
         if self._per_series_aligner is not None:
             yield 'aggregation.perSeriesAligner', self._per_series_aligner
@@ -651,20 +655,3 @@ def _build_label_filter(category, *args, **kwargs):
         terms.append(term.format(key=key, value=value))
 
     return ' AND '.join(sorted(terms))
-
-
-def _format_timestamp(timestamp):
-    """Convert a datetime object to a string as required by the API.
-
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp: A datetime object.
-
-    :rtype: string
-    :returns: The formatted timestamp. For example:
-        ``"2016-02-17T19:18:01.763000Z"``
-    """
-    if timestamp.tzinfo is not None:
-        # Convert to UTC and remove the time zone info.
-        timestamp = timestamp.replace(tzinfo=None) - timestamp.utcoffset()
-
-    return timestamp.isoformat() + 'Z'

--- a/gcloud/monitoring/test_client.py
+++ b/gcloud/monitoring/test_client.py
@@ -28,6 +28,7 @@ class TestClient(unittest2.TestCase):
 
     def test_query(self):
         import datetime
+        from gcloud._helpers import _datetime_to_rfc3339
         from gcloud.exceptions import NotFound
 
         START_TIME = datetime.datetime(2016, 4, 6, 22, 5, 0)
@@ -119,8 +120,8 @@ class TestClient(unittest2.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', END_TIME.isoformat() + 'Z'),
-                ('interval.startTime', START_TIME.isoformat() + 'Z'),
+                ('interval.endTime', _datetime_to_rfc3339(END_TIME)),
+                ('interval.startTime', _datetime_to_rfc3339(START_TIME)),
             ],
         }
 

--- a/gcloud/monitoring/test_query.py
+++ b/gcloud/monitoring/test_query.py
@@ -80,6 +80,11 @@ class TestQuery(unittest2.TestCase):
     def _makeOne(self, *args, **kwargs):
         return self._getTargetClass()(*args, **kwargs)
 
+    @staticmethod
+    def _make_timestamp(value):
+        from gcloud._helpers import _datetime_to_rfc3339
+        return _datetime_to_rfc3339(value)
+
     def test_constructor_minimal(self):
         client = _Client(project=PROJECT, connection=_Connection())
         query = self._makeOne(client)
@@ -217,7 +222,7 @@ class TestQuery(unittest2.TestCase):
         actual = list(query._build_query_params())
         expected = [
             ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-            ('interval.endTime', T1.isoformat() + 'Z'),
+            ('interval.endTime', self._make_timestamp(T1)),
         ]
         self.assertEqual(actual, expected)
 
@@ -246,8 +251,8 @@ class TestQuery(unittest2.TestCase):
                                                 page_token=PAGE_TOKEN))
         expected = [
             ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-            ('interval.endTime', T1.isoformat() + 'Z'),
-            ('interval.startTime', T0.isoformat() + 'Z'),
+            ('interval.endTime', self._make_timestamp(T1)),
+            ('interval.startTime', self._make_timestamp(T0)),
             ('aggregation.perSeriesAligner', ALIGNER),
             ('aggregation.alignmentPeriod', PERIOD),
             ('aggregation.crossSeriesReducer', REDUCER),
@@ -318,8 +323,8 @@ class TestQuery(unittest2.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', T1.isoformat() + 'Z'),
-                ('interval.startTime', T0.isoformat() + 'Z'),
+                ('interval.endTime', self._make_timestamp(T1)),
+                ('interval.startTime', self._make_timestamp(T0)),
             ],
         }
 
@@ -398,8 +403,8 @@ class TestQuery(unittest2.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', T1.isoformat() + 'Z'),
-                ('interval.startTime', T0.isoformat() + 'Z'),
+                ('interval.endTime', self._make_timestamp(T1)),
+                ('interval.startTime', self._make_timestamp(T0)),
             ],
         }
 
@@ -432,8 +437,8 @@ class TestQuery(unittest2.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', T1.isoformat() + 'Z'),
-                ('interval.startTime', T0.isoformat() + 'Z'),
+                ('interval.endTime', self._make_timestamp(T1)),
+                ('interval.startTime', self._make_timestamp(T0)),
             ],
         }
         request, = connection._requested
@@ -482,8 +487,8 @@ class TestQuery(unittest2.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', T1.isoformat() + 'Z'),
-                ('interval.startTime', T0.isoformat() + 'Z'),
+                ('interval.endTime', self._make_timestamp(T1)),
+                ('interval.startTime', self._make_timestamp(T0)),
                 ('view', 'HEADERS'),
             ],
         }
@@ -594,26 +599,6 @@ class Test__build_label_filter(unittest2.TestCase):
         actual = self._callFUT('resource', resource_type_suffix='-foo')
         expected = 'resource.type = ends_with("-foo")'
         self.assertEqual(actual, expected)
-
-
-class Test__format_timestamp(unittest2.TestCase):
-
-    def _callFUT(self, timestamp):
-        from gcloud.monitoring.query import _format_timestamp
-        return _format_timestamp(timestamp)
-
-    def test_naive(self):
-        from datetime import datetime
-        TIMESTAMP = datetime(2016, 4, 5, 13, 30, 0)
-        timestamp = self._callFUT(TIMESTAMP)
-        self.assertEqual(timestamp, '2016-04-05T13:30:00Z')
-
-    def test_with_timezone(self):
-        from datetime import datetime
-        from gcloud._helpers import UTC
-        TIMESTAMP = datetime(2016, 4, 5, 13, 30, 0, tzinfo=UTC)
-        timestamp = self._callFUT(TIMESTAMP)
-        self.assertEqual(timestamp, '2016-04-05T13:30:00Z')
 
 
 class _Connection(object):


### PR DESCRIPTION
The helper function _format_timestamp in gcloud.monitoring.query is
superseded by this updated helper function.