### PR TITLE
Consolidate retry logic

### DIFF
--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 import sys
 
+from run_system_test import FailedSystemTestModule
 from run_system_test import run_module_tests
 
 
@@ -111,9 +112,14 @@ def prepare_to_run():
 def main():
     """Run all the system tests if necessary."""
     prepare_to_run()
+    failed_modules = 0
     for module in MODULES:
-        run_module_tests(module)
+        try:
+            run_module_tests(module)
+        except FailedSystemTestModule:
+            failed_modules += 1
 
+    sys.exit(failed_modules)
 
 if __name__ == '__main__':
     main()

--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -30,13 +30,13 @@ from run_system_test import run_module_tests
 
 
 MODULES = (
-    'bigquery',
     'datastore',
-    'logging',
-    'monitoring',
-    'pubsub',
     'storage',
+    'bigquery',
+    'pubsub',
+    'logging',
     'translate',
+    'monitoring',
 )
 if sys.version_info[:2] == (2, 7):
     MODULES += ('bigtable', 'bigtable-happybase')

--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -30,7 +30,7 @@ from run_system_test import FailedSystemTestModule
 from run_system_test import run_module_tests
 
 
-MODULES = (
+MODULES = (  # ordered from most to least stable
     'datastore',
     'storage',
     'bigquery',

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -22,7 +22,7 @@ from gcloud.environment_vars import TESTS_PROJECT
 from gcloud import bigquery
 from gcloud.exceptions import Forbidden
 
-from retry import Retry
+from retry import RetryErrors
 from system_test_utils import unique_resource_id
 
 
@@ -96,7 +96,7 @@ class TestBigQuery(unittest.TestCase):
         # We need to wait to stay within the rate limits.
         # The alternative outcome is a 403 Forbidden response from upstream.
         # See: https://cloud.google.com/bigquery/quota-policy
-        @Retry(Forbidden, tries=2, delay=30)
+        @RetryErrors(Forbidden, max_tries=2, delay=30)
         def update_dataset():
             dataset.update()
 
@@ -202,7 +202,7 @@ class TestBigQuery(unittest.TestCase):
         # We need to wait to stay within the rate limits.
         # The alternative outcome is a 403 Forbidden response from upstream.
         # See: https://cloud.google.com/bigquery/quota-policy
-        @Retry(Forbidden, tries=2, delay=30)
+        @RetryErrors(Forbidden, max_tries=2, delay=30)
         def create_dataset():
             dataset.create()
 

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -269,8 +269,8 @@ class TestBigQuery(unittest.TestCase):
 
         # Allow for 90 seconds of "warm up" before rows visible.  See:
         # https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability
-        # 7 tries -> 2**7 + 2**6 + ... 1 = 127 seconds.
-        retry = RetryResult(_has_rows, max_tries=7)
+        # 8 tries -> 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127 seconds
+        retry = RetryResult(_has_rows, max_tries=8)
         rows, _, _ = retry(table.fetch_data)()
 
         by_age = operator.itemgetter(1)
@@ -336,8 +336,8 @@ class TestBigQuery(unittest.TestCase):
 
         # Allow for 90 seconds of "warm up" before rows visible.  See:
         # https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability
-        # 7 tries -> 2**7 + 2**6 + ... 1 = 127 seconds.
-        retry = RetryInstanceState(_job_done, max_tries=7)
+        # 8 tries -> 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127 seconds
+        retry = RetryInstanceState(_job_done, max_tries=8)
         retry(job.reload)()
 
         self.assertTrue(job.state in ('DONE', 'done'))

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import operator
-import time
 
 import unittest
 
@@ -264,7 +263,6 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(len(errors), 0)
 
         rows = ()
-        counter = 9
 
         def _has_rows(result):
             return len(result[0]) > 0

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -33,6 +33,7 @@ from gcloud.bigtable.row_data import PartialRowData
 from gcloud.environment_vars import TESTS_PROJECT
 
 from retry import RetryErrors
+from retry import RetryResult
 from system_test_utils import unique_resource_id
 
 
@@ -76,14 +77,12 @@ def _operation_wait(operation, max_attempts=5):
     :rtype: bool
     :returns: Boolean indicating if the operation finished.
     """
-    total_sleep = 0
-    while not operation.finished():
-        if total_sleep > max_attempts:
-            return False
-        time.sleep(1)
-        total_sleep += 1
 
-    return True
+    def _operation_finished(result):
+        return result
+
+    retry = RetryResult(_operation_finished, max_tries=max_attempts)
+    return retry(operation.finished)()
 
 
 def _retry_on_unavailable(exc):

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -14,7 +14,6 @@
 
 import datetime
 import operator
-import time
 
 import unittest
 

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -32,6 +32,7 @@ from gcloud.bigtable.row_data import Cell
 from gcloud.bigtable.row_data import PartialRowData
 from gcloud.environment_vars import TESTS_PROJECT
 
+from retry import RetryErrors
 from system_test_utils import unique_resource_id
 
 
@@ -85,29 +86,20 @@ def _operation_wait(operation, max_attempts=5):
     return True
 
 
-def _retry_backoff(meth, *args, **kw):
+def _retry_on_unavailable(exc):
+    """Retry only AbortionErrors whose status code is 'UNAVAILABLE'."""
     from grpc.beta.interfaces import StatusCode
-    from grpc.framework.interfaces.face.face import AbortionError
-    backoff_intervals = [1, 2, 4, 8]
-    while True:
-        try:
-            return meth(*args, **kw)
-        except AbortionError as error:
-            if error.code != StatusCode.UNAVAILABLE:
-                raise
-            if backoff_intervals:
-                time.sleep(backoff_intervals.pop(0))
-            else:
-                raise
+    return exc.code == StatusCode.UNAVAILABLE
 
 
 def setUpModule():
+    from grpc.framework.interfaces.face.face import AbortionError
     _helpers.PROJECT = TESTS_PROJECT
     Config.CLIENT = Client(admin=True)
     Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID, LOCATION_ID)
     Config.CLIENT.start()
-    instances, failed_locations = _retry_backoff(
-        Config.CLIENT.list_instances)
+    retry = RetryErrors(AbortionError, error_predicate=_retry_on_unavailable)
+    instances, failed_locations = retry(Config.CLIENT.list_instances)()
 
     if len(failed_locations) != 0:
         raise ValueError('List instances failed in module set up.')

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 import unittest
 
 from gcloud import _helpers
@@ -188,10 +186,12 @@ class TestLogging(unittest.TestCase):
                          set([DEFAULT_METRIC_NAME]))
 
     def test_reload_metric(self):
+        from gcloud.exceptions import Conflict
+        retry = RetryErrors(Conflict)
         metric = Config.CLIENT.metric(
             DEFAULT_METRIC_NAME, DEFAULT_FILTER, DEFAULT_DESCRIPTION)
         self.assertFalse(metric.exists())
-        metric.create()
+        retry(metric.create)()
         self.to_delete.append(metric)
         metric.filter_ = 'logName:other'
         metric.description = 'local changes'
@@ -200,12 +200,14 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(metric.description, DEFAULT_DESCRIPTION)
 
     def test_update_metric(self):
+        from gcloud.exceptions import Conflict
+        retry = RetryErrors(Conflict)
         NEW_FILTER = 'logName:other'
         NEW_DESCRIPTION = 'updated'
         metric = Config.CLIENT.metric(
             DEFAULT_METRIC_NAME, DEFAULT_FILTER, DEFAULT_DESCRIPTION)
         self.assertFalse(metric.exists())
-        metric.create()
+        retry(metric.create)()
         self.to_delete.append(metric)
         metric.filter_ = NEW_FILTER
         metric.description = NEW_DESCRIPTION
@@ -307,10 +309,12 @@ class TestLogging(unittest.TestCase):
                          set([DEFAULT_SINK_NAME]))
 
     def test_reload_sink(self):
+        from gcloud.exceptions import Conflict
+        retry = RetryErrors(Conflict)
         uri = self._init_bigquery_dataset()
         sink = Config.CLIENT.sink(DEFAULT_SINK_NAME, DEFAULT_FILTER, uri)
         self.assertFalse(sink.exists())
-        sink.create()
+        retry(sink.create)()
         self.to_delete.append(sink)
         sink.filter_ = 'BOGUS FILTER'
         sink.destination = 'BOGUS DESTINATION'
@@ -319,13 +323,15 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(sink.destination, uri)
 
     def test_update_sink(self):
+        from gcloud.exceptions import Conflict
+        retry = RetryErrors(Conflict)
         bucket_uri = self._init_storage_bucket()
         dataset_uri = self._init_bigquery_dataset()
         UPDATED_FILTER = 'logName:syslog'
         sink = Config.CLIENT.sink(
             DEFAULT_SINK_NAME, DEFAULT_FILTER, bucket_uri)
         self.assertFalse(sink.exists())
-        sink.create()
+        retry(sink.create)()
         self.to_delete.append(sink)
         sink.filter_ = UPDATED_FILTER
         sink.destination = dataset_uri

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -81,17 +81,9 @@ class TestLogging(unittest.TestCase):
 
     def tearDown(self):
         from gcloud.exceptions import NotFound
+        retry = RetryErrors(NotFound)
         for doomed in self.to_delete:
-            backoff_intervals = [1, 2, 4, 8]
-            while True:
-                try:
-                    doomed.delete()
-                    break
-                except NotFound:
-                    if backoff_intervals:
-                        time.sleep(backoff_intervals.pop(0))
-                    else:
-                        raise
+            retry(doomed.delete)()
 
     @staticmethod
     def _logger_name():

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -267,7 +267,7 @@ class TestPubsub(unittest.TestCase):
         def _no_topic(instance):
             return instance.topic is None
 
-        retry = RetryInstanceState(_no_topic)
+        retry = RetryInstanceState(_no_topic, max_tries=6)
         retry(orphaned.reload)()
 
         self.assertTrue(orphaned.topic is None)

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -4,7 +4,7 @@ from functools import wraps
 import six
 
 
-def _retry_all(ignored):
+def _retry_all(_):
     """Retry all caught exceptions."""
     return True
 
@@ -160,6 +160,7 @@ class RetryInstanceState(RetryBase):
 
     def __call__(self, to_wrap):
         instance = to_wrap.__self__   # only instance methods allowed
+
         @wraps(to_wrap)
         def wrapped_function(*args, **kwargs):
             tries = 0

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -37,7 +37,7 @@ class RetryErrors(RetryBase):
 
     :type exception: Exception or tuple of Exceptions
     :param exception: The exception to check or may be a tuple of
-                        exceptions to check.
+                      exceptions to check.
 
     :type error_predicate: function, takes caught exception, returns bool
     :param error_predicate: Predicate evaluating whether to retry after a

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -3,6 +3,10 @@ from functools import wraps
 
 import six
 
+MAX_TRIES = 4
+DELAY = 1
+BACKOFF = 2
+
 
 def _retry_all(_):
     """Retry all caught exceptions."""
@@ -25,7 +29,8 @@ class RetryBase(object):
     :type logger: logging.Logger instance
     :param logger: Logger to use. If None, print.
     """
-    def __init__(self, max_tries=4, delay=1, backoff=2, logger=None):
+    def __init__(self, max_tries=MAX_TRIES, delay=DELAY, backoff=BACKOFF,
+                 logger=None):
         self.max_tries = max_tries
         self.delay = delay
         self.backoff = backoff
@@ -57,7 +62,8 @@ class RetryErrors(RetryBase):
     :param logger: Logger to use. If None, print.
     """
     def __init__(self, exception, error_predicate=_retry_all,
-                 max_tries=4, delay=1, backoff=2, logger=None):
+                 max_tries=MAX_TRIES, delay=DELAY, backoff=BACKOFF,
+                 logger=None):
         super(RetryErrors, self).__init__(max_tries, delay, backoff, logger)
         self.exception = exception
         self.error_predicate = error_predicate
@@ -107,7 +113,8 @@ class RetryResult(RetryBase):
     :param logger: Logger to use. If None, print.
     """
     def __init__(self, result_predicate,
-                 max_tries=4, delay=1, backoff=2, logger=None):
+                 max_tries=MAX_TRIES, delay=DELAY, backoff=BACKOFF,
+                 logger=None):
         super(RetryResult, self).__init__(max_tries, delay, backoff, logger)
         self.result_predicate = result_predicate
 
@@ -153,7 +160,8 @@ class RetryInstanceState(RetryBase):
     :param logger: Logger to use. If None, print.
     """
     def __init__(self, instance_predicate,
-                 max_tries=4, delay=1, backoff=2, logger=None):
+                 max_tries=MAX_TRIES, delay=DELAY, backoff=BACKOFF,
+                 logger=None):
         super(RetryInstanceState, self).__init__(
             max_tries, delay, backoff, logger)
         self.instance_predicate = instance_predicate

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -9,41 +9,58 @@ def _retry_all(ignored):
     return True
 
 
-class RetryErrors(object):
-    """Retry class for retrying given exceptions in testing."""
+class RetryBase(object):
+    """Base for retrying calling a decorated function w/ exponential backoff.
 
-    def __init__(self, exception, max_tries=4, delay=1, backoff=2,
-                 error_predicate=_retry_all, logger=None):
-        """Retry calling the decorated function using an exponential backoff.
+    :type max_tries: int
+    :param max_tries: Number of times to try (not retry) before giving up.
 
-        :type exception: Exception or tuple of Exceptions
-        :param exception: The exception to check or may be a tuple of
-                          exceptions to check.
+    :type delay: int
+    :param delay: Initial delay between retries in seconds.
 
-        :type max_tries: int
-        :param max_tries: Number of times to try (not retry) before giving up.
+    :type backoff: int
+    :param backoff: Backoff multiplier e.g. value of 2 will double the
+                    delay each retry.
 
-        :type delay: int
-        :param delay: Initial delay between retries in seconds.
-
-        :type backoff: int
-        :param backoff: Backoff multiplier e.g. value of 2 will double the
-                        delay each retry.
-
-        :type error_predicate: function, takes caught exception, returns bool
-        :param error_predicate: Predicate evaluating whether to retry after a
-                                caught exception.
-
-        :type logger: logging.Logger instance
-        :param logger: Logger to use. If None, print.
-        """
-
-        self.exception = exception
+    :type logger: logging.Logger instance
+    :param logger: Logger to use. If None, print.
+    """
+    def __init__(self, max_tries=4, delay=1, backoff=2, logger=None):
         self.max_tries = max_tries
         self.delay = delay
         self.backoff = backoff
-        self.error_predicate = error_predicate
         self.logger = logger.warning if logger else six.print_
+
+
+class RetryErrors(RetryBase):
+    """Decorator for retrying given exceptions in testing.
+
+    :type exception: Exception or tuple of Exceptions
+    :param exception: The exception to check or may be a tuple of
+                        exceptions to check.
+
+    :type error_predicate: function, takes caught exception, returns bool
+    :param error_predicate: Predicate evaluating whether to retry after a
+                            caught exception.
+
+    :type max_tries: int
+    :param max_tries: Number of times to try (not retry) before giving up.
+
+    :type delay: int
+    :param delay: Initial delay between retries in seconds.
+
+    :type backoff: int
+    :param backoff: Backoff multiplier e.g. value of 2 will double the
+                    delay each retry.
+
+    :type logger: logging.Logger instance
+    :param logger: Logger to use. If None, print.
+    """
+    def __init__(self, exception, error_predicate=_retry_all,
+                 max_tries=4, delay=1, backoff=2, logger=None):
+        super(RetryErrors, self).__init__(max_tries, delay, backoff, logger)
+        self.exception = exception
+        self.error_predicate = error_predicate
 
     def __call__(self, to_wrap):
         @wraps(to_wrap)
@@ -64,6 +81,52 @@ class RetryErrors(object):
 
                     time.sleep(delay)
                     tries += 1
+            return to_wrap(*args, **kwargs)
+
+        return wrapped_function
+
+
+class RetryResult(RetryBase):
+    """Decorator for retrying based on non-error result.
+
+    :type result_predicate: function, takes result, returns bool
+    :param result_predicate: Predicate evaluating whether to retry after a
+                             result is returned.
+
+    :type max_tries: int
+    :param max_tries: Number of times to try (not retry) before giving up.
+
+    :type delay: int
+    :param delay: Initial delay between retries in seconds.
+
+    :type backoff: int
+    :param backoff: Backoff multiplier e.g. value of 2 will double the
+                    delay each retry.
+
+    :type logger: logging.Logger instance
+    :param logger: Logger to use. If None, print.
+    """
+    def __init__(self, result_predicate,
+                 max_tries=4, delay=1, backoff=2, logger=None):
+        super(RetryResult, self).__init__(max_tries, delay, backoff, logger)
+        self.result_predicate = result_predicate
+
+    def __call__(self, to_wrap):
+        @wraps(to_wrap)
+        def wrapped_function(*args, **kwargs):
+            tries = 0
+            while tries < self.max_tries:
+                result = to_wrap(*args, **kwargs)
+                if self.result_predicate(result):
+                    return result
+
+                delay = self.delay * self.backoff**tries
+                msg = "%s. Trying again in %d seconds..." % (
+                    self.result_predicate.__name__, delay,)
+                self.logger(msg)
+
+                time.sleep(delay)
+                tries += 1
             return to_wrap(*args, **kwargs)
 
         return wrapped_function

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -4,11 +4,16 @@ from functools import wraps
 import six
 
 
+def _retry_all(ignored):
+    """Retry all caught exceptions."""
+    return True
+
+
 class RetryErrors(object):
     """Retry class for retrying given exceptions in testing."""
 
     def __init__(self, exception, max_tries=4, delay=1, backoff=2,
-                 logger=None):
+                 error_predicate=_retry_all, logger=None):
         """Retry calling the decorated function using an exponential backoff.
 
         :type exception: Exception or tuple of Exceptions
@@ -25,6 +30,10 @@ class RetryErrors(object):
         :param backoff: Backoff multiplier e.g. value of 2 will double the
                         delay each retry.
 
+        :type error_predicate: function, takes caught exception, returns bool
+        :param error_predicate: Predicate evaluating whether to retry after a
+                                caught exception.
+
         :type logger: logging.Logger instance
         :param logger: Logger to use. If None, print.
         """
@@ -33,6 +42,7 @@ class RetryErrors(object):
         self.max_tries = max_tries
         self.delay = delay
         self.backoff = backoff
+        self.error_predicate = error_predicate
         self.logger = logger.warning if logger else six.print_
 
     def __call__(self, to_wrap):
@@ -43,6 +53,10 @@ class RetryErrors(object):
                 try:
                     return to_wrap(*args, **kwargs)
                 except self.exception as caught_exception:
+
+                    if not self.error_predicate(caught_exception):
+                        raise
+
                     delay = self.delay * self.backoff**tries
                     msg = ("%s, Trying again in %d seconds..." %
                            (str(caught_exception), delay))

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -76,7 +76,7 @@ class RetryErrors(RetryBase):
 
                     delay = self.delay * self.backoff**tries
                     msg = ("%s, Trying again in %d seconds..." %
-                           (str(caught_exception), delay))
+                           (caught_exception, delay))
                     self.logger(msg)
 
                     time.sleep(delay)

--- a/system_tests/run_system_test.py
+++ b/system_tests/run_system_test.py
@@ -41,6 +41,10 @@ TEST_MODULES = {
 }
 
 
+class FailedSystemTestModule(Exception):
+    pass
+
+
 def get_parser():
     parser = argparse.ArgumentParser(
         description='GCloud test runner against actual project.')
@@ -68,14 +72,17 @@ def run_module_tests(module_name, ignore_requirements=False):
     test_result = unittest.TextTestRunner(verbosity=2).run(suite)
     # Exit if not successful.
     if not test_result.wasSuccessful():
-        sys.exit(1)
+        raise FailedSystemTestModule(module_name)
 
 
 def main():
     parser = get_parser()
     args = parser.parse_args()
-    run_module_tests(args.package,
-                     ignore_requirements=args.ignore_requirements)
+    try:
+        run_module_tests(args.package,
+                         ignore_requirements=args.ignore_requirements)
+    except FailedSystemTestModule:
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Toward #2042.

This PR tries to rationalize the retries in our system tests into three types:

- Retry methods which raise particular exceptions (the class @daspecster implemented already)
- Retry methods until the result passes a predicate (generalizing the backoff stuff in `logging_`).
- Retry methods until a predicate on the instance's `__self__` passes (e.g., until `job.state == "done"`).

The PR adds classes for each of these categories, and attempts to use them where appropriate, replacing manual `time.sleep()` calls and existing "backoff" functions / loops.

It also tweaks the `tox -e system-tests` runner to attempt all system test modules, even if one fails, and tries to run them in order from least to most flake.

BTW,  cannot figure out how to get the `translate` tests to run at all, and there is one of the `error_reporting` tests which blows up at me.