### PR TITLE
Drop 'unittest2' dependency.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install wheel nose nose-exclude unittest2 cryptography grpcio"
+  - "%CMD_IN_ENV% pip install wheel nose nose-exclude cryptography grpcio"
   # Install sometimes-problemaatic gRPC-related dependencies
   - "%CMD_IN_ENV% pip install grpcio gax-google-pubsub-v1 gax-google-logging-v2"
 

--- a/gcloud/bigquery/test__helpers.py
+++ b/gcloud/bigquery/test__helpers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_ConfigurationProperty(unittest2.TestCase):
+class Test_ConfigurationProperty(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery._helpers import _ConfigurationProperty
@@ -50,7 +50,7 @@ class Test_ConfigurationProperty(unittest2.TestCase):
         self.assertEqual(wrapper._configuration._attr, None)
 
 
-class Test_TypedProperty(unittest2.TestCase):
+class Test_TypedProperty(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery._helpers import _TypedProperty
@@ -83,7 +83,7 @@ class Test_TypedProperty(unittest2.TestCase):
         self.assertEqual(wrapper._configuration._attr, None)
 
 
-class Test_EnumProperty(unittest2.TestCase):
+class Test_EnumProperty(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery._helpers import _EnumProperty

--- a/gcloud/bigquery/test_client.py
+++ b/gcloud/bigquery/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.client import Client

--- a/gcloud/bigquery/test_connection.py
+++ b/gcloud/bigquery/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.connection import Connection

--- a/gcloud/bigquery/test_dataset.py
+++ b/gcloud/bigquery/test_dataset.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestAccessGrant(unittest2.TestCase):
+class TestAccessGrant(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.dataset import AccessGrant
@@ -76,7 +76,7 @@ class TestAccessGrant(unittest2.TestCase):
         self.assertEqual(grant, other)
 
 
-class TestDataset(unittest2.TestCase):
+class TestDataset(unittest.TestCase):
     PROJECT = 'project'
     DS_NAME = 'dataset-name'
 

--- a/gcloud/bigquery/test_job.py
+++ b/gcloud/bigquery/test_job.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_UDFResourcesProperty(unittest2.TestCase):
+class Test_UDFResourcesProperty(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.job import UDFResourcesProperty
@@ -189,7 +189,7 @@ class _Base(object):
             self.assertEqual(job.user_email, None)
 
 
-class TestLoadTableFromStorageJob(unittest2.TestCase, _Base):
+class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
     JOB_TYPE = 'load'
 
     def _getTargetClass(self):
@@ -695,7 +695,7 @@ class TestLoadTableFromStorageJob(unittest2.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
-class TestCopyJob(unittest2.TestCase, _Base):
+class TestCopyJob(unittest.TestCase, _Base):
     JOB_TYPE = 'copy'
     SOURCE_TABLE = 'source_table'
     DESTINATION_TABLE = 'destination_table'
@@ -992,7 +992,7 @@ class TestCopyJob(unittest2.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
-class TestExtractTableToStorageJob(unittest2.TestCase, _Base):
+class TestExtractTableToStorageJob(unittest.TestCase, _Base):
     JOB_TYPE = 'extract'
     SOURCE_TABLE = 'source_table'
     DESTINATION_URI = 'gs://bucket_name/object_name'
@@ -1285,7 +1285,7 @@ class TestExtractTableToStorageJob(unittest2.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
-class TestQueryJob(unittest2.TestCase, _Base):
+class TestQueryJob(unittest.TestCase, _Base):
     JOB_TYPE = 'query'
     QUERY = 'select count(*) from persons'
     DESTINATION_TABLE = 'destination_table'

--- a/gcloud/bigquery/test_query.py
+++ b/gcloud/bigquery/test_query.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestQueryResults(unittest2.TestCase):
+class TestQueryResults(unittest.TestCase):
     PROJECT = 'project'
     JOB_NAME = 'job_name'
     JOB_NAME = 'test-synchronous-query'

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestSchemaField(unittest2.TestCase):
+class TestSchemaField(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigquery.table import SchemaField
@@ -125,7 +125,7 @@ class _SchemaBase(object):
             self._verify_field(field, r_field)
 
 
-class TestTable(unittest2.TestCase, _SchemaBase):
+class TestTable(unittest.TestCase, _SchemaBase):
     PROJECT = 'project'
     DS_NAME = 'dataset-name'
     TABLE_NAME = 'table-name'
@@ -1552,7 +1552,7 @@ class TestTable(unittest2.TestCase, _SchemaBase):
     # pylint: enable=too-many-statements
 
 
-class Test_parse_schema_resource(unittest2.TestCase, _SchemaBase):
+class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
 
     def _callFUT(self, resource):
         from gcloud.bigquery.table import _parse_schema_resource
@@ -1596,7 +1596,7 @@ class Test_parse_schema_resource(unittest2.TestCase, _SchemaBase):
         self._verifySchema(schema, RESOURCE)
 
 
-class Test_build_schema_resource(unittest2.TestCase, _SchemaBase):
+class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
 
     def _callFUT(self, resource):
         from gcloud.bigquery.table import _build_schema_resource

--- a/gcloud/bigtable/happybase/test_batch.py
+++ b/gcloud/bigtable/happybase/test_batch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
 class _SendMixin(object):
@@ -24,7 +24,7 @@ class _SendMixin(object):
         self._send_called = True
 
 
-class TestBatch(unittest2.TestCase):
+class TestBatch(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.happybase.batch import Batch
@@ -474,7 +474,7 @@ class TestBatch(unittest2.TestCase):
         self.assertTrue(batch._send_called)
 
 
-class Test__get_column_pairs(unittest2.TestCase):
+class Test__get_column_pairs(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.batch import _get_column_pairs

--- a/gcloud/bigtable/happybase/test_connection.py
+++ b/gcloud/bigtable/happybase/test_connection.py
@@ -15,10 +15,10 @@
 
 import sys
 
-import unittest2
+import unittest
 
 
-class Test__get_instance(unittest2.TestCase):
+class Test__get_instance(unittest.TestCase):
 
     def _callFUT(self, timeout=None):
         from gcloud.bigtable.happybase.connection import _get_instance
@@ -72,7 +72,7 @@ class Test__get_instance(unittest2.TestCase):
                          failed_locations=[failed_location])
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.happybase.connection import Connection
@@ -418,8 +418,8 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(len(tables_created), 1)
         self.assertEqual(tables_created[0].create_calls, 1)
 
-    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
-                          'gRPC only in Python 2.7')
+    @unittest.skipUnless(sys.version_info[:2] == (2, 7),
+                         'gRPC only in Python 2.7')
     def test_create_table_already_exists(self):
         from grpc.beta import interfaces
         from grpc.framework.interfaces.face import face
@@ -429,8 +429,8 @@ class TestConnection(unittest2.TestCase):
                                     interfaces.StatusCode.ALREADY_EXISTS, None)
         self._create_table_error_helper(err_val, AlreadyExists)
 
-    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
-                          'gRPC only in Python 2.7')
+    @unittest.skipUnless(sys.version_info[:2] == (2, 7),
+                         'gRPC only in Python 2.7')
     def test_create_table_connection_error(self):
         from grpc.beta import interfaces
         from grpc.framework.interfaces.face import face
@@ -438,8 +438,8 @@ class TestConnection(unittest2.TestCase):
                                     interfaces.StatusCode.INTERNAL, None)
         self._create_table_error_helper(err_val, face.NetworkError)
 
-    @unittest2.skipUnless(sys.version_info[:2] == (2, 7),
-                          'gRPC only in Python 2.7')
+    @unittest.skipUnless(sys.version_info[:2] == (2, 7),
+                         'gRPC only in Python 2.7')
     def test_create_table_other_error(self):
         self._create_table_error_helper(RuntimeError, RuntimeError)
 
@@ -562,7 +562,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(warned, [MUT._COMPACT_TMPL % (name, False)])
 
 
-class Test__parse_family_option(unittest2.TestCase):
+class Test__parse_family_option(unittest.TestCase):
 
     def _callFUT(self, option):
         from gcloud.bigtable.happybase.connection import _parse_family_option

--- a/gcloud/bigtable/happybase/test_pool.py
+++ b/gcloud/bigtable/happybase/test_pool.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestConnectionPool(unittest2.TestCase):
+class TestConnectionPool(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.happybase.pool import ConnectionPool

--- a/gcloud/bigtable/happybase/test_table.py
+++ b/gcloud/bigtable/happybase/test_table.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_make_row(unittest2.TestCase):
+class Test_make_row(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import make_row
@@ -26,7 +26,7 @@ class Test_make_row(unittest2.TestCase):
             self._callFUT({}, False)
 
 
-class Test_make_ordered_row(unittest2.TestCase):
+class Test_make_ordered_row(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import make_ordered_row
@@ -37,7 +37,7 @@ class Test_make_ordered_row(unittest2.TestCase):
             self._callFUT([], False)
 
 
-class TestTable(unittest2.TestCase):
+class TestTable(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.happybase.table import Table
@@ -1013,7 +1013,7 @@ class TestTable(unittest2.TestCase):
             self._counter_inc_helper(row, column, value, commit_result)
 
 
-class Test__gc_rule_to_dict(unittest2.TestCase):
+class Test__gc_rule_to_dict(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _gc_rule_to_dict
@@ -1102,7 +1102,7 @@ class Test__gc_rule_to_dict(unittest2.TestCase):
         self.assertTrue(result is gc_rule)
 
 
-class Test__string_successor(unittest2.TestCase):
+class Test__string_successor(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _string_successor
@@ -1125,7 +1125,7 @@ class Test__string_successor(unittest2.TestCase):
         self.assertEqual(self._callFUT(u'boa'), b'bob')
 
 
-class Test__convert_to_time_range(unittest2.TestCase):
+class Test__convert_to_time_range(unittest.TestCase):
 
     def _callFUT(self, timestamp=None):
         from gcloud.bigtable.happybase.table import _convert_to_time_range
@@ -1153,7 +1153,7 @@ class Test__convert_to_time_range(unittest2.TestCase):
         self.assertEqual(result.end, ts_dt)
 
 
-class Test__cells_to_pairs(unittest2.TestCase):
+class Test__cells_to_pairs(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _cells_to_pairs
@@ -1189,7 +1189,7 @@ class Test__cells_to_pairs(unittest2.TestCase):
                          [(value1, ts1_millis), (value2, ts2_millis)])
 
 
-class Test__partial_row_to_dict(unittest2.TestCase):
+class Test__partial_row_to_dict(unittest.TestCase):
 
     def _callFUT(self, partial_row_data, include_timestamp=False):
         from gcloud.bigtable.happybase.table import _partial_row_to_dict
@@ -1238,7 +1238,7 @@ class Test__partial_row_to_dict(unittest2.TestCase):
         self.assertEqual(result, expected_result)
 
 
-class Test__filter_chain_helper(unittest2.TestCase):
+class Test__filter_chain_helper(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _filter_chain_helper
@@ -1348,7 +1348,7 @@ class Test__filter_chain_helper(unittest2.TestCase):
                             timestamp=timestamp)
 
 
-class Test__columns_filter_helper(unittest2.TestCase):
+class Test__columns_filter_helper(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _columns_filter_helper
@@ -1396,7 +1396,7 @@ class Test__columns_filter_helper(unittest2.TestCase):
         self.assertEqual(filter2b.regex, col_qual2.encode('utf-8'))
 
 
-class Test__row_keys_filter_helper(unittest2.TestCase):
+class Test__row_keys_filter_helper(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.happybase.table import _row_keys_filter_helper

--- a/gcloud/bigtable/test_client.py
+++ b/gcloud/bigtable/test_client.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     INSTANCE_ID = 'instance-id'
@@ -636,7 +636,7 @@ class TestClient(unittest2.TestCase):
         )])
 
 
-class Test_MetadataPlugin(unittest2.TestCase):
+class Test_MetadataPlugin(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.client import _MetadataPlugin
@@ -685,7 +685,7 @@ class Test_MetadataPlugin(unittest2.TestCase):
         self.assertEqual(len(credentials._tokens), 1)
 
 
-class Test__make_stub(unittest2.TestCase):
+class Test__make_stub(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.client import _make_stub

--- a/gcloud/bigtable/test_cluster.py
+++ b/gcloud/bigtable/test_cluster.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestOperation(unittest2.TestCase):
+class TestOperation(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.cluster import Operation
@@ -130,7 +130,7 @@ class TestOperation(unittest2.TestCase):
         self._finished_helper(done=False)
 
 
-class TestCluster(unittest2.TestCase):
+class TestCluster(unittest.TestCase):
 
     PROJECT = 'project'
     INSTANCE_ID = 'instance-id'
@@ -475,7 +475,7 @@ class TestCluster(unittest2.TestCase):
         )])
 
 
-class Test__prepare_create_request(unittest2.TestCase):
+class Test__prepare_create_request(unittest.TestCase):
 
     def _callFUT(self, cluster):
         from gcloud.bigtable.cluster import _prepare_create_request
@@ -501,7 +501,7 @@ class Test__prepare_create_request(unittest2.TestCase):
         self.assertEqual(request_pb.cluster.serve_nodes, SERVE_NODES)
 
 
-class Test__parse_pb_any_to_native(unittest2.TestCase):
+class Test__parse_pb_any_to_native(unittest.TestCase):
 
     def _callFUT(self, any_val, expected_type=None):
         from gcloud.bigtable.cluster import _parse_pb_any_to_native
@@ -554,7 +554,7 @@ class Test__parse_pb_any_to_native(unittest2.TestCase):
                 self._callFUT(any_val, expected_type=type_url1)
 
 
-class Test__process_operation(unittest2.TestCase):
+class Test__process_operation(unittest.TestCase):
 
     def _callFUT(self, operation_pb):
         from gcloud.bigtable.cluster import _process_operation

--- a/gcloud/bigtable/test_column_family.py
+++ b/gcloud/bigtable/test_column_family.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class Test__timedelta_to_duration_pb(unittest2.TestCase):
+class Test__timedelta_to_duration_pb(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.column_family import _timedelta_to_duration_pb
@@ -61,7 +61,7 @@ class Test__timedelta_to_duration_pb(unittest2.TestCase):
         self.assertEqual(result.nanos, -(10**9 - 1000 * microseconds))
 
 
-class Test__duration_pb_to_timedelta(unittest2.TestCase):
+class Test__duration_pb_to_timedelta(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.column_family import _duration_pb_to_timedelta
@@ -81,7 +81,7 @@ class Test__duration_pb_to_timedelta(unittest2.TestCase):
         self.assertEqual(result, timedelta_val)
 
 
-class TestMaxVersionsGCRule(unittest2.TestCase):
+class TestMaxVersionsGCRule(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.column_family import MaxVersionsGCRule
@@ -114,7 +114,7 @@ class TestMaxVersionsGCRule(unittest2.TestCase):
         self.assertEqual(pb_val, expected)
 
 
-class TestMaxAgeGCRule(unittest2.TestCase):
+class TestMaxAgeGCRule(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.column_family import MaxAgeGCRule
@@ -153,7 +153,7 @@ class TestMaxAgeGCRule(unittest2.TestCase):
         self.assertEqual(pb_val, _GcRulePB(max_age=duration))
 
 
-class TestGCRuleUnion(unittest2.TestCase):
+class TestGCRuleUnion(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.column_family import GCRuleUnion
@@ -239,7 +239,7 @@ class TestGCRuleUnion(unittest2.TestCase):
         self.assertEqual(gc_rule_pb, pb_rule5)
 
 
-class TestGCRuleIntersection(unittest2.TestCase):
+class TestGCRuleIntersection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.column_family import GCRuleIntersection
@@ -328,7 +328,7 @@ class TestGCRuleIntersection(unittest2.TestCase):
         self.assertEqual(gc_rule_pb, pb_rule5)
 
 
-class TestColumnFamily(unittest2.TestCase):
+class TestColumnFamily(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.column_family import ColumnFamily
@@ -569,7 +569,7 @@ class TestColumnFamily(unittest2.TestCase):
         )])
 
 
-class Test__gc_rule_from_pb(unittest2.TestCase):
+class Test__gc_rule_from_pb(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.bigtable.column_family import _gc_rule_from_pb

--- a/gcloud/bigtable/test_instance.py
+++ b/gcloud/bigtable/test_instance.py
@@ -14,10 +14,10 @@
 
 
 import datetime
-import unittest2
+import unittest
 
 
-class TestOperation(unittest2.TestCase):
+class TestOperation(unittest.TestCase):
 
     OP_TYPE = 'fake-op'
     OP_ID = 8915
@@ -140,7 +140,7 @@ class TestOperation(unittest2.TestCase):
         self._finished_helper(done=False)
 
 
-class TestInstance(unittest2.TestCase):
+class TestInstance(unittest.TestCase):
 
     PROJECT = 'project'
     INSTANCE_ID = 'instance-id'
@@ -637,7 +637,7 @@ class TestInstance(unittest2.TestCase):
             self._list_tables_helper(table_name=BAD_TABLE_NAME)
 
 
-class Test__prepare_create_request(unittest2.TestCase):
+class Test__prepare_create_request(unittest.TestCase):
     PROJECT = 'PROJECT'
     PARENT = 'projects/' + PROJECT
     LOCATION_ID = 'locname'
@@ -706,7 +706,7 @@ class Test__prepare_create_request(unittest2.TestCase):
         self.assertEqual(cluster.serve_nodes, SERVE_NODES)
 
 
-class Test__parse_pb_any_to_native(unittest2.TestCase):
+class Test__parse_pb_any_to_native(unittest.TestCase):
 
     def _callFUT(self, any_val, expected_type=None):
         from gcloud.bigtable.instance import _parse_pb_any_to_native
@@ -789,7 +789,7 @@ class Test__parse_pb_any_to_native(unittest2.TestCase):
                 self._callFUT(any_val, expected_type=TYPE_URL1)
 
 
-class Test__process_operation(unittest2.TestCase):
+class Test__process_operation(unittest.TestCase):
 
     def _callFUT(self, operation_pb):
         from gcloud.bigtable.instance import _process_operation

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class Test_SetDeleteRow(unittest2.TestCase):
+class Test_SetDeleteRow(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row import _SetDeleteRow
@@ -31,7 +31,7 @@ class Test_SetDeleteRow(unittest2.TestCase):
             row._get_mutations(None)
 
 
-class TestDirectRow(unittest2.TestCase):
+class TestDirectRow(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row import DirectRow
@@ -375,7 +375,7 @@ class TestDirectRow(unittest2.TestCase):
         self.assertEqual(stub.method_calls, [])
 
 
-class TestConditionalRow(unittest2.TestCase):
+class TestConditionalRow(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row import ConditionalRow
@@ -517,7 +517,7 @@ class TestConditionalRow(unittest2.TestCase):
         self.assertEqual(stub.method_calls, [])
 
 
-class TestAppendRow(unittest2.TestCase):
+class TestAppendRow(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row import AppendRow
@@ -662,7 +662,7 @@ class TestAppendRow(unittest2.TestCase):
                 row.commit()
 
 
-class Test__parse_rmw_row_response(unittest2.TestCase):
+class Test__parse_rmw_row_response(unittest.TestCase):
 
     def _callFUT(self, row_response):
         from gcloud.bigtable.row import _parse_rmw_row_response
@@ -747,7 +747,7 @@ class Test__parse_rmw_row_response(unittest2.TestCase):
         self.assertEqual(expected_output, self._callFUT(sample_input))
 
 
-class Test__parse_family_pb(unittest2.TestCase):
+class Test__parse_family_pb(unittest.TestCase):
 
     def _callFUT(self, family_pb):
         from gcloud.bigtable.row import _parse_family_pb

--- a/gcloud/bigtable/test_row_data.py
+++ b/gcloud/bigtable/test_row_data.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestCell(unittest2.TestCase):
+class TestCell(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_data import Cell
@@ -91,7 +91,7 @@ class TestCell(unittest2.TestCase):
         self.assertNotEqual(cell1, cell2)
 
 
-class TestPartialRowData(unittest2.TestCase):
+class TestPartialRowData(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_data import PartialRowData
@@ -182,7 +182,7 @@ class TestPartialRowData(unittest2.TestCase):
         self.assertTrue(partial_row_data.row_key is row_key)
 
 
-class TestPartialRowsData(unittest2.TestCase):
+class TestPartialRowsData(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_data import PartialRowsData
@@ -422,7 +422,7 @@ class TestPartialRowsData(unittest2.TestCase):
             prd.consume_next()
 
 
-class TestPartialRowsData_JSON_acceptance_tests(unittest2.TestCase):
+class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
 
     _json_tests = None
 

--- a/gcloud/bigtable/test_row_filters.py
+++ b/gcloud/bigtable/test_row_filters.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class Test_BoolFilter(unittest2.TestCase):
+class Test_BoolFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import _BoolFilter
@@ -50,7 +50,7 @@ class Test_BoolFilter(unittest2.TestCase):
         self.assertFalse(comparison_val)
 
 
-class TestSinkFilter(unittest2.TestCase):
+class TestSinkFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import SinkFilter
@@ -67,7 +67,7 @@ class TestSinkFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestPassAllFilter(unittest2.TestCase):
+class TestPassAllFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import PassAllFilter
@@ -84,7 +84,7 @@ class TestPassAllFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestBlockAllFilter(unittest2.TestCase):
+class TestBlockAllFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import BlockAllFilter
@@ -101,7 +101,7 @@ class TestBlockAllFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class Test_RegexFilter(unittest2.TestCase):
+class Test_RegexFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import _RegexFilter
@@ -140,7 +140,7 @@ class Test_RegexFilter(unittest2.TestCase):
         self.assertFalse(comparison_val)
 
 
-class TestRowKeyRegexFilter(unittest2.TestCase):
+class TestRowKeyRegexFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import RowKeyRegexFilter
@@ -157,7 +157,7 @@ class TestRowKeyRegexFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestRowSampleFilter(unittest2.TestCase):
+class TestRowSampleFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import RowSampleFilter
@@ -191,7 +191,7 @@ class TestRowSampleFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestFamilyNameRegexFilter(unittest2.TestCase):
+class TestFamilyNameRegexFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import FamilyNameRegexFilter
@@ -208,7 +208,7 @@ class TestFamilyNameRegexFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestColumnQualifierRegexFilter(unittest2.TestCase):
+class TestColumnQualifierRegexFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ColumnQualifierRegexFilter
@@ -226,7 +226,7 @@ class TestColumnQualifierRegexFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestTimestampRange(unittest2.TestCase):
+class TestTimestampRange(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import TimestampRange
@@ -300,7 +300,7 @@ class TestTimestampRange(unittest2.TestCase):
         self._to_pb_helper(end_micros=end_micros)
 
 
-class TestTimestampRangeFilter(unittest2.TestCase):
+class TestTimestampRangeFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import TimestampRangeFilter
@@ -337,7 +337,7 @@ class TestTimestampRangeFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestColumnRangeFilter(unittest2.TestCase):
+class TestColumnRangeFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ColumnRangeFilter
@@ -461,7 +461,7 @@ class TestColumnRangeFilter(unittest2.TestCase):
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
 
-class TestValueRegexFilter(unittest2.TestCase):
+class TestValueRegexFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ValueRegexFilter
@@ -478,7 +478,7 @@ class TestValueRegexFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestValueRangeFilter(unittest2.TestCase):
+class TestValueRangeFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ValueRangeFilter
@@ -569,7 +569,7 @@ class TestValueRangeFilter(unittest2.TestCase):
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
 
-class Test_CellCountFilter(unittest2.TestCase):
+class Test_CellCountFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import _CellCountFilter
@@ -603,7 +603,7 @@ class Test_CellCountFilter(unittest2.TestCase):
         self.assertFalse(comparison_val)
 
 
-class TestCellsRowOffsetFilter(unittest2.TestCase):
+class TestCellsRowOffsetFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import CellsRowOffsetFilter
@@ -621,7 +621,7 @@ class TestCellsRowOffsetFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestCellsRowLimitFilter(unittest2.TestCase):
+class TestCellsRowLimitFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import CellsRowLimitFilter
@@ -639,7 +639,7 @@ class TestCellsRowLimitFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestCellsColumnLimitFilter(unittest2.TestCase):
+class TestCellsColumnLimitFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import CellsColumnLimitFilter
@@ -657,7 +657,7 @@ class TestCellsColumnLimitFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestStripValueTransformerFilter(unittest2.TestCase):
+class TestStripValueTransformerFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import StripValueTransformerFilter
@@ -674,7 +674,7 @@ class TestStripValueTransformerFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class TestApplyLabelFilter(unittest2.TestCase):
+class TestApplyLabelFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ApplyLabelFilter
@@ -708,7 +708,7 @@ class TestApplyLabelFilter(unittest2.TestCase):
         self.assertEqual(pb_val, expected_pb)
 
 
-class Test_FilterCombination(unittest2.TestCase):
+class Test_FilterCombination(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import _FilterCombination
@@ -739,7 +739,7 @@ class Test_FilterCombination(unittest2.TestCase):
         self.assertNotEqual(row_filter1, row_filter2)
 
 
-class TestRowFilterChain(unittest2.TestCase):
+class TestRowFilterChain(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import RowFilterChain
@@ -793,7 +793,7 @@ class TestRowFilterChain(unittest2.TestCase):
         self.assertEqual(filter_pb, expected_pb)
 
 
-class TestRowFilterUnion(unittest2.TestCase):
+class TestRowFilterUnion(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import RowFilterUnion
@@ -847,7 +847,7 @@ class TestRowFilterUnion(unittest2.TestCase):
         self.assertEqual(filter_pb, expected_pb)
 
 
-class TestConditionalRowFilter(unittest2.TestCase):
+class TestConditionalRowFilter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.bigtable.row_filters import ConditionalRowFilter

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestTable(unittest2.TestCase):
+class TestTable(unittest.TestCase):
 
     PROJECT_ID = 'project-id'
     INSTANCE_ID = 'instance-id'
@@ -427,7 +427,7 @@ class TestTable(unittest2.TestCase):
         )])
 
 
-class Test__create_row_request(unittest2.TestCase):
+class Test__create_row_request(unittest.TestCase):
 
     def _callFUT(self, table_name, row_key=None, start_key=None, end_key=None,
                  filter_=None, limit=None):

--- a/gcloud/datastore/test_batch.py
+++ b/gcloud/datastore/test_batch.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestBatch(unittest2.TestCase):
+class TestBatch(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.datastore.batch import Batch

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
 def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
@@ -31,7 +31,7 @@ def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
     return entity_pb
 
 
-class Test__get_gcd_project(unittest2.TestCase):
+class Test__get_gcd_project(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud.datastore.client import _get_gcd_project
@@ -58,7 +58,7 @@ class Test__get_gcd_project(unittest2.TestCase):
             self.assertEqual(project, MOCK_PROJECT)
 
 
-class Test__determine_default_project(unittest2.TestCase):
+class Test__determine_default_project(unittest.TestCase):
 
     def _callFUT(self, project=None):
         from gcloud.datastore.client import (
@@ -115,7 +115,7 @@ class Test__determine_default_project(unittest2.TestCase):
         self.assertEqual(callers, ['gcd_mock', ('fallback_mock', None)])
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     PROJECT = 'PROJECT'
 

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.datastore.connection import Connection
@@ -808,7 +808,7 @@ class TestConnection(unittest2.TestCase):
             self.assertEqual(key_before, key_after)
 
 
-class Test__parse_commit_response(unittest2.TestCase):
+class Test__parse_commit_response(unittest.TestCase):
 
     def _callFUT(self, commit_response_pb):
         from gcloud.datastore.connection import _parse_commit_response

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 _PROJECT = 'PROJECT'
 _KIND = 'KIND'
 _ID = 1234
 
 
-class TestEntity(unittest2.TestCase):
+class TestEntity(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.datastore.entity import Entity

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test__new_value_pb(unittest2.TestCase):
+class Test__new_value_pb(unittest.TestCase):
 
     def _callFUT(self, entity_pb, name):
         from gcloud.datastore.helpers import _new_value_pb
@@ -33,7 +33,7 @@ class Test__new_value_pb(unittest2.TestCase):
         self.assertEqual(entity_pb.properties[name], result)
 
 
-class Test__property_tuples(unittest2.TestCase):
+class Test__property_tuples(unittest.TestCase):
 
     def _callFUT(self, entity_pb):
         from gcloud.datastore.helpers import _property_tuples
@@ -56,7 +56,7 @@ class Test__property_tuples(unittest2.TestCase):
                          sorted([(name1, val_pb1), (name2, val_pb2)]))
 
 
-class Test_entity_from_protobuf(unittest2.TestCase):
+class Test_entity_from_protobuf(unittest.TestCase):
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import entity_from_protobuf
@@ -189,7 +189,7 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         self.assertEqual(inside_entity[INSIDE_NAME], INSIDE_VALUE)
 
 
-class Test_entity_to_protobuf(unittest2.TestCase):
+class Test_entity_to_protobuf(unittest.TestCase):
 
     def _callFUT(self, entity):
         from gcloud.datastore.helpers import entity_to_protobuf
@@ -368,7 +368,7 @@ class Test_entity_to_protobuf(unittest2.TestCase):
         self._compareEntityProto(entity_pb, expected_pb)
 
 
-class Test_key_from_protobuf(unittest2.TestCase):
+class Test_key_from_protobuf(unittest.TestCase):
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import key_from_protobuf
@@ -422,7 +422,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         self.assertRaises(ValueError, self._callFUT, pb)
 
 
-class Test__pb_attr_value(unittest2.TestCase):
+class Test__pb_attr_value(unittest.TestCase):
 
     def _callFUT(self, val):
         from gcloud.datastore.helpers import _pb_attr_value
@@ -538,7 +538,7 @@ class Test__pb_attr_value(unittest2.TestCase):
         self.assertRaises(ValueError, self._callFUT, object())
 
 
-class Test__get_value_from_value_pb(unittest2.TestCase):
+class Test__get_value_from_value_pb(unittest.TestCase):
 
     def _callFUT(self, pb):
         from gcloud.datastore.helpers import _get_value_from_value_pb
@@ -653,7 +653,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
             self._callFUT(pb)
 
 
-class Test_set_protobuf_value(unittest2.TestCase):
+class Test_set_protobuf_value(unittest.TestCase):
 
     def _callFUT(self, value_pb, val):
         from gcloud.datastore.helpers import _set_protobuf_value
@@ -792,7 +792,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         self.assertEqual(pb.geo_point_value, geo_pt_pb)
 
 
-class Test__get_meaning(unittest2.TestCase):
+class Test__get_meaning(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.datastore.helpers import _get_meaning
@@ -872,7 +872,7 @@ class Test__get_meaning(unittest2.TestCase):
         self.assertEqual(result, [meaning1, None])
 
 
-class TestGeoPoint(unittest2.TestCase):
+class TestGeoPoint(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.datastore.helpers import GeoPoint

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestKey(unittest2.TestCase):
+class TestKey(unittest.TestCase):
 
     _DEFAULT_PROJECT = 'PROJECT'
 

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestQuery(unittest2.TestCase):
+class TestQuery(unittest.TestCase):
 
     _PROJECT = 'PROJECT'
 
@@ -330,7 +330,7 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(iterator._offset, 8)
 
 
-class TestIterator(unittest2.TestCase):
+class TestIterator(unittest.TestCase):
     _PROJECT = 'PROJECT'
     _NAMESPACE = 'NAMESPACE'
     _KIND = 'KIND'
@@ -611,7 +611,7 @@ class TestIterator(unittest2.TestCase):
         self.assertEqual(connection._called_with[2], EXPECTED3)
 
 
-class Test__pb_from_query(unittest2.TestCase):
+class Test__pb_from_query(unittest.TestCase):
 
     def _callFUT(self, query):
         from gcloud.datastore.query import _pb_from_query

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestTransaction(unittest2.TestCase):
+class TestTransaction(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.datastore.transaction import Transaction

--- a/gcloud/dns/test_changes.py
+++ b/gcloud/dns/test_changes.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestChanges(unittest2.TestCase):
+class TestChanges(unittest.TestCase):
     PROJECT = 'project'
     ZONE_NAME = 'example.com'
     CHANGES_NAME = 'changeset_id'

--- a/gcloud/dns/test_client.py
+++ b/gcloud/dns/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     ZONE_NAME = 'zone-name'

--- a/gcloud/dns/test_connection.py
+++ b/gcloud/dns/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.dns.connection import Connection

--- a/gcloud/dns/test_resource_record_set.py
+++ b/gcloud/dns/test_resource_record_set.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestResourceRecordSet(unittest2.TestCase):
+class TestResourceRecordSet(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.dns.resource_record_set import ResourceRecordSet

--- a/gcloud/dns/test_zone.py
+++ b/gcloud/dns/test_zone.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestManagedZone(unittest2.TestCase):
+class TestManagedZone(unittest.TestCase):
     PROJECT = 'project'
     ZONE_NAME = 'zone-name'
     DESCRIPTION = 'ZONE DESCRIPTION'

--- a/gcloud/error_reporting/test_client.py
+++ b/gcloud/error_reporting/test_client.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.error_reporting.client import Client

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
 try:
@@ -34,8 +34,8 @@ class _Base(object):
         return self._getTargetClass()(*args, **kw)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_LoggingAPI(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_LoggingAPI(_Base, unittest.TestCase):
     LOG_NAME = 'log_name'
 
     def _getTargetClass(self):
@@ -407,8 +407,8 @@ class Test_LoggingAPI(_Base, unittest2.TestCase):
         self.assertEqual(options, None)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_SinksAPI(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_SinksAPI(_Base, unittest.TestCase):
     SINK_NAME = 'sink_name'
     SINK_PATH = 'projects/%s/sinks/%s' % (_Base.PROJECT, SINK_NAME)
     DESTINATION_URI = 'faux.googleapis.com/destination'
@@ -611,8 +611,8 @@ class Test_SinksAPI(_Base, unittest2.TestCase):
         self.assertEqual(options, None)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_MetricsAPI(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_MetricsAPI(_Base, unittest.TestCase):
     METRIC_NAME = 'metric_name'
     METRIC_PATH = 'projects/%s/metrics/%s' % (_Base.PROJECT, METRIC_NAME)
     DESCRIPTION = 'Description'
@@ -815,8 +815,8 @@ class Test_MetricsAPI(_Base, unittest2.TestCase):
         self.assertEqual(options, None)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_value_pb_to_value(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_value_pb_to_value(_Base, unittest.TestCase):
 
     def _callFUT(self, value_pb):
         from gcloud.logging._gax import _value_pb_to_value

--- a/gcloud/logging/test_client.py
+++ b/gcloud/logging/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'

--- a/gcloud/logging/test_connection.py
+++ b/gcloud/logging/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'
@@ -34,7 +34,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
 
-class Test_LoggingAPI(unittest2.TestCase):
+class Test_LoggingAPI(unittest.TestCase):
 
     PROJECT = 'project'
     LIST_ENTRIES_PATH = 'entries:list'
@@ -217,7 +217,7 @@ class Test_LoggingAPI(unittest2.TestCase):
         self.assertEqual(conn._called_with['path'], path)
 
 
-class Test_SinksAPI(unittest2.TestCase):
+class Test_SinksAPI(unittest.TestCase):
 
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'
@@ -412,7 +412,7 @@ class Test_SinksAPI(unittest2.TestCase):
         self.assertEqual(conn._called_with['path'], path)
 
 
-class Test_MetricsAPI(unittest2.TestCase):
+class Test_MetricsAPI(unittest.TestCase):
 
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'

--- a/gcloud/logging/test_entries.py
+++ b/gcloud/logging/test_entries.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_logger_name_from_path(unittest2.TestCase):
+class Test_logger_name_from_path(unittest.TestCase):
 
     def _callFUT(self, path):
         from gcloud.logging.entries import logger_name_from_path
@@ -36,7 +36,7 @@ class Test_logger_name_from_path(unittest2.TestCase):
         self.assertEqual(logger_name, LOGGER_NAME)
 
 
-class Test_BaseEntry(unittest2.TestCase):
+class Test_BaseEntry(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'
@@ -188,7 +188,7 @@ class Test_BaseEntry(unittest2.TestCase):
         self.assertTrue(entry.logger is LOGGER)
 
 
-class TestProtobufEntry(unittest2.TestCase):
+class TestProtobufEntry(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'

--- a/gcloud/logging/test_logger.py
+++ b/gcloud/logging/test_logger.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestLogger(unittest2.TestCase):
+class TestLogger(unittest.TestCase):
 
     PROJECT = 'test-project'
     LOGGER_NAME = 'logger-name'
@@ -388,7 +388,7 @@ class TestLogger(unittest2.TestCase):
         self.assertEqual(client._listed, LISTED)
 
 
-class TestBatch(unittest2.TestCase):
+class TestBatch(unittest.TestCase):
 
     PROJECT = 'test-project'
 

--- a/gcloud/logging/test_metric.py
+++ b/gcloud/logging/test_metric.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestMetric(unittest2.TestCase):
+class TestMetric(unittest.TestCase):
 
     PROJECT = 'test-project'
     METRIC_NAME = 'metric-name'

--- a/gcloud/logging/test_sink.py
+++ b/gcloud/logging/test_sink.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestSink(unittest2.TestCase):
+class TestSink(unittest.TestCase):
 
     PROJECT = 'test-project'
     SINK_NAME = 'sink-name'

--- a/gcloud/monitoring/test__dataframe.py
+++ b/gcloud/monitoring/test__dataframe.py
@@ -19,7 +19,7 @@ except ImportError:
 else:
     HAVE_PANDAS = True  # pragma: NO COVER
 
-import unittest2
+import unittest
 
 
 PROJECT = 'my-project'
@@ -83,8 +83,8 @@ def generate_query_results():  # pragma: NO COVER
         )
 
 
-@unittest2.skipUnless(HAVE_PANDAS, 'No pandas')
-class Test__build_dataframe(unittest2.TestCase):  # pragma: NO COVER
+@unittest.skipUnless(HAVE_PANDAS, 'No pandas')
+class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.monitoring._dataframe import _build_dataframe
@@ -205,7 +205,7 @@ class Test__build_dataframe(unittest2.TestCase):  # pragma: NO COVER
         self.assertIsInstance(dataframe.index, pandas.DatetimeIndex)
 
 
-class Test__sorted_resource_labels(unittest2.TestCase):
+class Test__sorted_resource_labels(unittest.TestCase):
 
     def _callFUT(self, labels):
         from gcloud.monitoring._dataframe import _sorted_resource_labels

--- a/gcloud/monitoring/test_client.py
+++ b/gcloud/monitoring/test_client.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 PROJECT = 'my-project'
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.client import Client

--- a/gcloud/monitoring/test_connection.py
+++ b/gcloud/monitoring/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.connection import Connection

--- a/gcloud/monitoring/test_group.py
+++ b/gcloud/monitoring/test_group.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_group_id_from_name(unittest2.TestCase):
+class Test_group_id_from_name(unittest.TestCase):
 
     def _callFUT(self, path, project):
         from gcloud.monitoring.group import _group_id_from_name
@@ -42,7 +42,7 @@ class Test_group_id_from_name(unittest2.TestCase):
         self.assertEqual(group_id, GROUP_ID)
 
 
-class TestGroup(unittest2.TestCase):
+class TestGroup(unittest.TestCase):
 
     def setUp(self):
         self.PROJECT = 'PROJECT'

--- a/gcloud/monitoring/test_label.py
+++ b/gcloud/monitoring/test_label.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestLabelValueType(unittest2.TestCase):
+class TestLabelValueType(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.label import LabelValueType
@@ -30,7 +30,7 @@ class TestLabelValueType(unittest2.TestCase):
                 self.assertEqual(getattr(self._getTargetClass(), name), name)
 
 
-class TestLabelDescriptor(unittest2.TestCase):
+class TestLabelDescriptor(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.label import LabelDescriptor

--- a/gcloud/monitoring/test_metric.py
+++ b/gcloud/monitoring/test_metric.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestMetricKind(unittest2.TestCase):
+class TestMetricKind(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.metric import MetricKind
@@ -30,7 +30,7 @@ class TestMetricKind(unittest2.TestCase):
                 self.assertEqual(getattr(self._getTargetClass(), name), name)
 
 
-class TestValueType(unittest2.TestCase):
+class TestValueType(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.metric import ValueType
@@ -45,7 +45,7 @@ class TestValueType(unittest2.TestCase):
                 self.assertEqual(getattr(self._getTargetClass(), name), name)
 
 
-class TestMetricDescriptor(unittest2.TestCase):
+class TestMetricDescriptor(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.metric import MetricDescriptor
@@ -490,7 +490,7 @@ class TestMetricDescriptor(unittest2.TestCase):
         self.assertEqual(request, expected_request)
 
 
-class TestMetric(unittest2.TestCase):
+class TestMetric(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.metric import Metric

--- a/gcloud/monitoring/test_query.py
+++ b/gcloud/monitoring/test_query.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 PROJECT = 'my-project'
 
@@ -40,7 +40,7 @@ TS1 = '2016-04-06T22:05:01.042Z'
 TS2 = '2016-04-06T22:05:02.042Z'
 
 
-class TestAligner(unittest2.TestCase):
+class TestAligner(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.query import Aligner
@@ -55,7 +55,7 @@ class TestAligner(unittest2.TestCase):
                 self.assertEqual(getattr(self._getTargetClass(), name), name)
 
 
-class TestReducer(unittest2.TestCase):
+class TestReducer(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.query import Reducer
@@ -71,7 +71,7 @@ class TestReducer(unittest2.TestCase):
                 self.assertEqual(getattr(self._getTargetClass(), name), name)
 
 
-class TestQuery(unittest2.TestCase):
+class TestQuery(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.query import Query
@@ -497,7 +497,7 @@ class TestQuery(unittest2.TestCase):
         self.assertEqual(request, expected_request)
 
 
-class Test_Filter(unittest2.TestCase):
+class Test_Filter(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.query import _Filter
@@ -531,7 +531,7 @@ class Test_Filter(unittest2.TestCase):
         self.assertEqual(str(obj), expected)
 
 
-class Test__build_label_filter(unittest2.TestCase):
+class Test__build_label_filter(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.monitoring.query import _build_label_filter

--- a/gcloud/monitoring/test_resource.py
+++ b/gcloud/monitoring/test_resource.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestResourceDescriptor(unittest2.TestCase):
+class TestResourceDescriptor(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.resource import ResourceDescriptor
@@ -274,7 +274,7 @@ class TestResourceDescriptor(unittest2.TestCase):
         self.assertEqual(request, expected_request)
 
 
-class TestResource(unittest2.TestCase):
+class TestResource(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.resource import Resource

--- a/gcloud/monitoring/test_timeseries.py
+++ b/gcloud/monitoring/test_timeseries.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 METRIC_TYPE = 'compute.googleapis.com/instance/uptime'
 METRIC_LABELS = {'instance_name': 'instance-1'}
@@ -32,7 +32,7 @@ TS1 = '2016-04-06T22:05:01.042Z'
 TS2 = '2016-04-06T22:05:02.042Z'
 
 
-class TestTimeSeries(unittest2.TestCase):
+class TestTimeSeries(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.timeseries import TimeSeries
@@ -148,7 +148,7 @@ class TestTimeSeries(unittest2.TestCase):
         self.assertEqual(series.labels, labels)
 
 
-class TestPoint(unittest2.TestCase):
+class TestPoint(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.monitoring.timeseries import Point

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
 try:
@@ -39,8 +39,8 @@ class _Base(object):
         return self._getTargetClass()(*args, **kw)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_PublisherAPI(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.pubsub._gax import _PublisherAPI
@@ -341,8 +341,8 @@ class Test_PublisherAPI(_Base, unittest2.TestCase):
         self.assertTrue(options.page_token is INITIAL_PAGE)
 
 
-@unittest2.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_SubscriberAPI(_Base, unittest2.TestCase):
+@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     PUSH_ENDPOINT = 'https://api.example.com/push'
 

--- a/gcloud/pubsub/test__helpers.py
+++ b/gcloud/pubsub/test__helpers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_topic_name_from_path(unittest2.TestCase):
+class Test_topic_name_from_path(unittest.TestCase):
 
     def _callFUT(self, path, project):
         from gcloud.pubsub._helpers import topic_name_from_path
@@ -36,7 +36,7 @@ class Test_topic_name_from_path(unittest2.TestCase):
         self.assertEqual(topic_name, TOPIC_NAME)
 
 
-class Test_subscription_name_from_path(unittest2.TestCase):
+class Test_subscription_name_from_path(unittest.TestCase):
 
     def _callFUT(self, path, project):
         from gcloud.pubsub._helpers import subscription_name_from_path

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
     PROJECT = 'PROJECT'
     TOPIC_NAME = 'topic_name'
     TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class _Base(unittest2.TestCase):
+class _Base(unittest.TestCase):
     PROJECT = 'PROJECT'
     LIST_TOPICS_PATH = 'projects/%s/topics' % (PROJECT,)
     LIST_SUBSCRIPTIONS_PATH = 'projects/%s/subscriptions' % (PROJECT,)

--- a/gcloud/pubsub/test_iam.py
+++ b/gcloud/pubsub/test_iam.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestPolicy(unittest2.TestCase):
+class TestPolicy(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.pubsub.iam import Policy

--- a/gcloud/pubsub/test_message.py
+++ b/gcloud/pubsub/test_message.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestMessage(unittest2.TestCase):
+class TestMessage(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.pubsub.message import Message

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestSubscription(unittest2.TestCase):
+class TestSubscription(unittest.TestCase):
     PROJECT = 'PROJECT'
     TOPIC_NAME = 'topic_name'
     TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
@@ -666,7 +666,7 @@ class _FauxSubscribererAPI(object):
         return self._subscription_modify_ack_deadline_response
 
 
-class TestAutoAck(unittest2.TestCase):
+class TestAutoAck(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.pubsub.subscription import AutoAck

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestTopic(unittest2.TestCase):
+class TestTopic(unittest.TestCase):
     PROJECT = 'PROJECT'
     TOPIC_NAME = 'topic_name'
     TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
@@ -559,7 +559,7 @@ class TestTopic(unittest2.TestCase):
                          (self.TOPIC_PATH, ROLES))
 
 
-class TestBatch(unittest2.TestCase):
+class TestBatch(unittest.TestCase):
     PROJECT = 'PROJECT'
 
     def _getTargetClass(self):

--- a/gcloud/resource_manager/test_client.py
+++ b/gcloud/resource_manager/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test__ProjectIterator(unittest2.TestCase):
+class Test__ProjectIterator(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.resource_manager.client import _ProjectIterator
@@ -69,7 +69,7 @@ class Test__ProjectIterator(unittest2.TestCase):
         self.assertEqual(project.status, PROJECT_LIFECYCLE_STATE)
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.resource_manager.client import Client

--- a/gcloud/resource_manager/test_connection.py
+++ b/gcloud/resource_manager/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.resource_manager.connection import Connection

--- a/gcloud/resource_manager/test_project.py
+++ b/gcloud/resource_manager/test_project.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestProject(unittest2.TestCase):
+class TestProject(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.resource_manager.project import Project

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_PropertyMixin(unittest2.TestCase):
+class Test_PropertyMixin(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage._helpers import _PropertyMixin
@@ -94,7 +94,7 @@ class Test_PropertyMixin(unittest2.TestCase):
         self.assertEqual(derived._changes, set())
 
 
-class Test__scalar_property(unittest2.TestCase):
+class Test__scalar_property(unittest.TestCase):
 
     def _callFUT(self, fieldName):
         from gcloud.storage._helpers import _scalar_property
@@ -122,7 +122,7 @@ class Test__scalar_property(unittest2.TestCase):
         self.assertEqual(test._patched, ('solfege', 'Latido'))
 
 
-class Test__base64_md5hash(unittest2.TestCase):
+class Test__base64_md5hash(unittest.TestCase):
 
     def _callFUT(self, bytes_to_sign):
         from gcloud.storage._helpers import _base64_md5hash

--- a/gcloud/storage/test_acl.py
+++ b/gcloud/storage/test_acl.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_ACLEntity(unittest2.TestCase):
+class Test_ACLEntity(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.acl import _ACLEntity
@@ -124,7 +124,7 @@ class Test_ACLEntity(unittest2.TestCase):
         self.assertEqual(entity.get_roles(), set())
 
 
-class Test_ACL(unittest2.TestCase):
+class Test_ACL(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.acl import ACL
@@ -708,7 +708,7 @@ class Test_ACL(unittest2.TestCase):
         self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
 
-class Test_BucketACL(unittest2.TestCase):
+class Test_BucketACL(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.acl import BucketACL
@@ -728,7 +728,7 @@ class Test_BucketACL(unittest2.TestCase):
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
 
 
-class Test_DefaultObjectACL(unittest2.TestCase):
+class Test_DefaultObjectACL(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.acl import DefaultObjectACL
@@ -748,7 +748,7 @@ class Test_DefaultObjectACL(unittest2.TestCase):
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
 
 
-class Test_ObjectACL(unittest2.TestCase):
+class Test_ObjectACL(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.acl import ObjectACL

--- a/gcloud/storage/test_batch.py
+++ b/gcloud/storage/test_batch.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestMIMEApplicationHTTP(unittest2.TestCase):
+class TestMIMEApplicationHTTP(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.batch import MIMEApplicationHTTP
@@ -66,7 +66,7 @@ class TestMIMEApplicationHTTP(unittest2.TestCase):
         self.assertEqual(mah.get_payload().splitlines(), LINES)
 
 
-class TestBatch(unittest2.TestCase):
+class TestBatch(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.batch import Batch
@@ -444,7 +444,7 @@ class TestBatch(unittest2.TestCase):
         self.assertTrue(isinstance(target3._properties, _FutureDict))
 
 
-class Test__unpack_batch_response(unittest2.TestCase):
+class Test__unpack_batch_response(unittest.TestCase):
 
     def _callFUT(self, response, content):
         from gcloud.storage.batch import _unpack_batch_response
@@ -535,7 +535,7 @@ Content-Length: 0
 """
 
 
-class Test__FutureDict(unittest2.TestCase):
+class Test__FutureDict(unittest.TestCase):
 
     def _makeOne(self, *args, **kw):
         from gcloud.storage.batch import _FutureDict

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_Blob(unittest2.TestCase):
+class Test_Blob(unittest.TestCase):
 
     def _makeOne(self, *args, **kw):
         from gcloud.storage.blob import Blob

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test__BlobIterator(unittest2.TestCase):
+class Test__BlobIterator(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.bucket import _BlobIterator
@@ -85,7 +85,7 @@ class Test__BlobIterator(unittest2.TestCase):
         self.assertEqual(iterator.prefixes, set(['foo', 'bar']))
 
 
-class Test_Bucket(unittest2.TestCase):
+class Test_Bucket(unittest.TestCase):
 
     def _makeOne(self, client=None, name=None, properties=None):
         from gcloud.storage.bucket import Bucket

--- a/gcloud/storage/test_client.py
+++ b/gcloud/storage/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.client import Client
@@ -370,7 +370,7 @@ class TestClient(unittest2.TestCase):
         self.assertEqual(parse_qs(uri_parts.query), EXPECTED_QUERY)
 
 
-class Test__BucketIterator(unittest2.TestCase):
+class Test__BucketIterator(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.client import _BucketIterator

--- a/gcloud/storage/test_connection.py
+++ b/gcloud/storage/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.storage.connection import Connection

--- a/gcloud/streaming/test_buffered_stream.py
+++ b/gcloud/streaming/test_buffered_stream.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test_BufferedStream(unittest2.TestCase):
+class Test_BufferedStream(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.buffered_stream import BufferedStream

--- a/gcloud/streaming/test_exceptions.py
+++ b/gcloud/streaming/test_exceptions.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test_HttpError(unittest2.TestCase):
+class Test_HttpError(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.exceptions import HttpError
@@ -42,7 +42,7 @@ class Test_HttpError(unittest2.TestCase):
         self.assertEqual(exception.url, URL)
 
 
-class Test_RetryAfterError(unittest2.TestCase):
+class Test_RetryAfterError(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.exceptions import RetryAfterError

--- a/gcloud/streaming/test_http_wrapper.py
+++ b/gcloud/streaming/test_http_wrapper.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test__httplib2_debug_level(unittest2.TestCase):
+class Test__httplib2_debug_level(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.http_wrapper import _httplib2_debug_level
@@ -60,7 +60,7 @@ class Test__httplib2_debug_level(unittest2.TestCase):
         self.assertEqual(skip_me.debuglevel, 0)
 
 
-class Test_Request(unittest2.TestCase):
+class Test_Request(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.http_wrapper import Request
@@ -100,7 +100,7 @@ class Test_Request(unittest2.TestCase):
         self.assertEqual(request.loggable_body, '<media body>')
 
 
-class Test_Response(unittest2.TestCase):
+class Test_Response(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.http_wrapper import Response
@@ -196,7 +196,7 @@ class Test_Response(unittest2.TestCase):
         self.assertTrue(response.is_redirect)
 
 
-class Test__check_response(unittest2.TestCase):
+class Test__check_response(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import _check_response
@@ -233,7 +233,7 @@ class Test__check_response(unittest2.TestCase):
         self._callFUT(_Response(200))
 
 
-class Test__reset_http_connections(unittest2.TestCase):
+class Test__reset_http_connections(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import _reset_http_connections
@@ -251,7 +251,7 @@ class Test__reset_http_connections(unittest2.TestCase):
         self.assertTrue('skip_me' in connections)
 
 
-class Test___make_api_request_no_retry(unittest2.TestCase):
+class Test___make_api_request_no_retry(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import _make_api_request_no_retry
@@ -366,7 +366,7 @@ class Test___make_api_request_no_retry(unittest2.TestCase):
         self._verify_requested(_http, _request, connection_type=CONN_TYPE)
 
 
-class Test_make_api_request(unittest2.TestCase):
+class Test_make_api_request(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import make_api_request
@@ -453,7 +453,7 @@ class Test_make_api_request(unittest2.TestCase):
         self.assertEqual(_checked, [])  # not called by '_wo_exception'
 
 
-class Test__register_http_factory(unittest2.TestCase):
+class Test__register_http_factory(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import _register_http_factory
@@ -471,7 +471,7 @@ class Test__register_http_factory(unittest2.TestCase):
             self.assertEqual(_factories, [FACTORY])
 
 
-class Test_get_http(unittest2.TestCase):
+class Test_get_http(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.http_wrapper import get_http

--- a/gcloud/streaming/test_stream_slice.py
+++ b/gcloud/streaming/test_stream_slice.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test_StreamSlice(unittest2.TestCase):
+class Test_StreamSlice(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.streaming.stream_slice import StreamSlice

--- a/gcloud/streaming/test_transfer.py
+++ b/gcloud/streaming/test_transfer.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test__Transfer(unittest2.TestCase):
+class Test__Transfer(unittest.TestCase):
     URL = 'http://example.com/api'
 
     def _getTargetClass(self):
@@ -145,7 +145,7 @@ class Test__Transfer(unittest2.TestCase):
         self.assertTrue(stream._closed)
 
 
-class Test_Download(unittest2.TestCase):
+class Test_Download(unittest.TestCase):
     URL = "http://example.com/api"
 
     def _getTargetClass(self):
@@ -778,7 +778,7 @@ class Test_Download(unittest2.TestCase):
         self.assertEqual(download.total_size, LEN)
 
 
-class Test_Upload(unittest2.TestCase):
+class Test_Upload(unittest.TestCase):
     URL = "http://example.com/api"
     MIME_TYPE = 'application/octet-stream'
     UPLOAD_URL = 'http://example.com/upload/id=foobar'

--- a/gcloud/streaming/test_util.py
+++ b/gcloud/streaming/test_util.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 
 
-class Test_calculate_wait_for_retry(unittest2.TestCase):
+class Test_calculate_wait_for_retry(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.util import calculate_wait_for_retry
@@ -20,7 +20,7 @@ class Test_calculate_wait_for_retry(unittest2.TestCase):
             self.assertEqual(self._callFUT(4, 10), 10)
 
 
-class Test_acceptable_mime_type(unittest2.TestCase):
+class Test_acceptable_mime_type(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from gcloud.streaming.util import acceptable_mime_type

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test__LocalStack(unittest2.TestCase):
+class Test__LocalStack(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud._helpers import _LocalStack
@@ -43,7 +43,7 @@ class Test__LocalStack(unittest2.TestCase):
         self.assertEqual(list(batches), [])
 
 
-class Test__UTC(unittest2.TestCase):
+class Test__UTC(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud._helpers import _UTC
@@ -96,7 +96,7 @@ class Test__UTC(unittest2.TestCase):
         self.assertEqual(str(tz), 'UTC')
 
 
-class Test__ensure_tuple_or_list(unittest2.TestCase):
+class Test__ensure_tuple_or_list(unittest.TestCase):
 
     def _callFUT(self, arg_name, tuple_or_list):
         from gcloud._helpers import _ensure_tuple_or_list
@@ -123,7 +123,7 @@ class Test__ensure_tuple_or_list(unittest2.TestCase):
             self._callFUT('ARGNAME', invalid_tuple_or_list)
 
 
-class Test__app_engine_id(unittest2.TestCase):
+class Test__app_engine_id(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud._helpers import _app_engine_id
@@ -148,7 +148,7 @@ class Test__app_engine_id(unittest2.TestCase):
             self.assertEqual(dataset_id, APP_ENGINE_ID)
 
 
-class Test__get_credentials_file_project_id(unittest2.TestCase):
+class Test__get_credentials_file_project_id(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud._helpers import _file_project_id
@@ -180,7 +180,7 @@ class Test__get_credentials_file_project_id(unittest2.TestCase):
         self.assertEqual(None, self._callFUT())
 
 
-class Test__get_default_service_project_id(unittest2.TestCase):
+class Test__get_default_service_project_id(unittest.TestCase):
     config_path = '.config/gcloud/configurations/'
     config_file = 'config_default'
     temp_APPDATA = ''
@@ -248,7 +248,7 @@ class Test__get_default_service_project_id(unittest2.TestCase):
         self.assertEqual(None, project_id)
 
 
-class Test__compute_engine_id(unittest2.TestCase):
+class Test__compute_engine_id(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud._helpers import _compute_engine_id
@@ -285,7 +285,7 @@ class Test__compute_engine_id(unittest2.TestCase):
             self.assertEqual(dataset_id, None)
 
 
-class Test__get_production_project(unittest2.TestCase):
+class Test__get_production_project(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud._helpers import _get_production_project
@@ -312,7 +312,7 @@ class Test__get_production_project(unittest2.TestCase):
             self.assertEqual(project, MOCK_PROJECT)
 
 
-class Test__determine_default_project(unittest2.TestCase):
+class Test__determine_default_project(unittest.TestCase):
 
     def _callFUT(self, project=None):
         from gcloud._helpers import _determine_default_project
@@ -391,7 +391,7 @@ class Test__determine_default_project(unittest2.TestCase):
                                    'gae_mock', 'gce_mock'])
 
 
-class Test__millis(unittest2.TestCase):
+class Test__millis(unittest.TestCase):
 
     def _callFUT(self, value):
         from gcloud._helpers import _millis
@@ -405,7 +405,7 @@ class Test__millis(unittest2.TestCase):
         self.assertEqual(self._callFUT(WHEN), 1000)
 
 
-class Test__microseconds_from_datetime(unittest2.TestCase):
+class Test__microseconds_from_datetime(unittest.TestCase):
 
     def _callFUT(self, value):
         from gcloud._helpers import _microseconds_from_datetime
@@ -422,7 +422,7 @@ class Test__microseconds_from_datetime(unittest2.TestCase):
         self.assertEqual(result, microseconds)
 
 
-class Test__millis_from_datetime(unittest2.TestCase):
+class Test__millis_from_datetime(unittest.TestCase):
 
     def _callFUT(self, value):
         from gcloud._helpers import _millis_from_datetime
@@ -477,7 +477,7 @@ class Test__millis_from_datetime(unittest2.TestCase):
         self.assertEqual(result, MILLIS)
 
 
-class Test__datetime_from_microseconds(unittest2.TestCase):
+class Test__datetime_from_microseconds(unittest.TestCase):
 
     def _callFUT(self, value):
         from gcloud._helpers import _datetime_from_microseconds
@@ -494,7 +494,7 @@ class Test__datetime_from_microseconds(unittest2.TestCase):
         self.assertEqual(self._callFUT(NOW_MICROS), NOW)
 
 
-class Test__rfc3339_to_datetime(unittest2.TestCase):
+class Test__rfc3339_to_datetime(unittest.TestCase):
 
     def _callFUT(self, dt_str):
         from gcloud._helpers import _rfc3339_to_datetime
@@ -548,7 +548,7 @@ class Test__rfc3339_to_datetime(unittest2.TestCase):
             self._callFUT(dt_str)
 
 
-class Test__rfc3339_nanos_to_datetime(unittest2.TestCase):
+class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
 
     def _callFUT(self, dt_str):
         from gcloud._helpers import _rfc3339_nanos_to_datetime
@@ -618,7 +618,7 @@ class Test__rfc3339_nanos_to_datetime(unittest2.TestCase):
         self.assertEqual(result, expected_result)
 
 
-class Test__datetime_to_rfc3339(unittest2.TestCase):
+class Test__datetime_to_rfc3339(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud._helpers import _datetime_to_rfc3339
@@ -668,7 +668,7 @@ class Test__datetime_to_rfc3339(unittest2.TestCase):
         self.assertEqual(result, '2016-04-05T13:30:00.000000Z')
 
 
-class Test__to_bytes(unittest2.TestCase):
+class Test__to_bytes(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud._helpers import _to_bytes
@@ -695,7 +695,7 @@ class Test__to_bytes(unittest2.TestCase):
         self.assertRaises(TypeError, self._callFUT, value)
 
 
-class Test__bytes_to_unicode(unittest2.TestCase):
+class Test__bytes_to_unicode(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud._helpers import _bytes_to_unicode
@@ -716,7 +716,7 @@ class Test__bytes_to_unicode(unittest2.TestCase):
         self.assertRaises(ValueError, self._callFUT, value)
 
 
-class Test__pb_timestamp_to_datetime(unittest2.TestCase):
+class Test__pb_timestamp_to_datetime(unittest.TestCase):
 
     def _callFUT(self, timestamp):
         from gcloud._helpers import _pb_timestamp_to_datetime
@@ -737,7 +737,7 @@ class Test__pb_timestamp_to_datetime(unittest2.TestCase):
         self.assertEqual(self._callFUT(timestamp), dt_stamp)
 
 
-class Test__datetime_to_pb_timestamp(unittest2.TestCase):
+class Test__datetime_to_pb_timestamp(unittest.TestCase):
 
     def _callFUT(self, when):
         from gcloud._helpers import _datetime_to_pb_timestamp
@@ -758,7 +758,7 @@ class Test__datetime_to_pb_timestamp(unittest2.TestCase):
         self.assertEqual(self._callFUT(dt_stamp), timestamp)
 
 
-class Test__name_from_project_path(unittest2.TestCase):
+class Test__name_from_project_path(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     THING_NAME = 'THING_NAME'

--- a/gcloud/test_client.py
+++ b/gcloud/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_ClientFactoryMixin(unittest2.TestCase):
+class Test_ClientFactoryMixin(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.client import _ClientFactoryMixin
@@ -26,7 +26,7 @@ class Test_ClientFactoryMixin(unittest2.TestCase):
         self.assertFalse('__init__' in klass.__dict__)
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     def setUp(self):
         KLASS = self._getTargetClass()
@@ -115,7 +115,7 @@ class TestClient(unittest2.TestCase):
                           None, credentials=CREDENTIALS)
 
 
-class TestJSONClient(unittest2.TestCase):
+class TestJSONClient(unittest.TestCase):
 
     def setUp(self):
         KLASS = self._getTargetClass()

--- a/gcloud/test_connection.py
+++ b/gcloud/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.connection import Connection
@@ -75,7 +75,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(conn.USER_AGENT, expected_ua)
 
 
-class TestJSONConnection(unittest2.TestCase):
+class TestJSONConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.connection import JSONConnection

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_get_credentials(unittest2.TestCase):
+class Test_get_credentials(unittest.TestCase):
 
     def _callFUT(self):
         from gcloud import credentials
@@ -33,7 +33,7 @@ class Test_get_credentials(unittest2.TestCase):
         self.assertTrue(client._get_app_default_called)
 
 
-class Test_generate_signed_url(unittest2.TestCase):
+class Test_generate_signed_url(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
         from gcloud.credentials import generate_signed_url
@@ -101,7 +101,7 @@ class Test_generate_signed_url(unittest2.TestCase):
                               generation=generation)
 
 
-class Test_generate_signed_url_exception(unittest2.TestCase):
+class Test_generate_signed_url_exception(unittest.TestCase):
     def test_with_google_credentials(self):
         import time
         from gcloud.credentials import generate_signed_url
@@ -113,7 +113,7 @@ class Test_generate_signed_url_exception(unittest2.TestCase):
                           resource=RESOURCE, expiration=expiration)
 
 
-class Test__get_signed_query_params(unittest2.TestCase):
+class Test__get_signed_query_params(unittest.TestCase):
 
     def _callFUT(self, credentials, expiration, string_to_sign):
         from gcloud.credentials import _get_signed_query_params
@@ -140,7 +140,7 @@ class Test__get_signed_query_params(unittest2.TestCase):
         self.assertEqual(CREDENTIALS._signed, [STRING_TO_SIGN])
 
 
-class Test__get_expiration_seconds(unittest2.TestCase):
+class Test__get_expiration_seconds(unittest.TestCase):
 
     def _callFUT(self, expiration):
         from gcloud.credentials import _get_expiration_seconds

--- a/gcloud/test_exceptions.py
+++ b/gcloud/test_exceptions.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class Test_GCloudError(unittest2.TestCase):
+class Test_GCloudError(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.exceptions import GCloudError
@@ -46,7 +46,7 @@ class Test_GCloudError(unittest2.TestCase):
         self.assertEqual(list(e.errors), [ERROR])
 
 
-class Test_make_exception(unittest2.TestCase):
+class Test_make_exception(unittest.TestCase):
 
     def _callFUT(self, response, content, error_info=None, use_json=True):
         from gcloud.exceptions import make_exception

--- a/gcloud/test_iterator.py
+++ b/gcloud/test_iterator.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestIterator(unittest2.TestCase):
+class TestIterator(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.iterator import Iterator
@@ -172,7 +172,7 @@ class TestIterator(unittest2.TestCase):
                           iterator.get_items_from_response, object())
 
 
-class TestMethodIterator(unittest2.TestCase):
+class TestMethodIterator(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.iterator import MethodIterator

--- a/gcloud/translate/test_client.py
+++ b/gcloud/translate/test_client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestClient(unittest2.TestCase):
+class TestClient(unittest.TestCase):
 
     KEY = 'abc-123-my-key'
 

--- a/gcloud/translate/test_connection.py
+++ b/gcloud/translate/test_connection.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def _getTargetClass(self):
         from gcloud.translate.connection import Connection

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -15,7 +15,7 @@
 import operator
 import time
 
-import unittest2
+import unittest
 
 from gcloud import _helpers
 from gcloud.environment_vars import TESTS_PROJECT
@@ -43,7 +43,7 @@ def setUpModule():
     Config.CLIENT = bigquery.Client()
 
 
-class TestBigQuery(unittest2.TestCase):
+class TestBigQuery(unittest.TestCase):
 
     def setUp(self):
         self.to_delete = []

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -16,7 +16,7 @@ import datetime
 import operator
 import time
 
-import unittest2
+import unittest
 
 from gcloud import _helpers
 from gcloud._helpers import _datetime_from_microseconds
@@ -125,7 +125,7 @@ def tearDownModule():
     Config.CLIENT.stop()
 
 
-class TestInstanceAdminAPI(unittest2.TestCase):
+class TestInstanceAdminAPI(unittest.TestCase):
 
     def setUp(self):
         self.instances_to_delete = []
@@ -189,7 +189,7 @@ class TestInstanceAdminAPI(unittest2.TestCase):
         Config.INSTANCE.update()
 
 
-class TestTableAdminAPI(unittest2.TestCase):
+class TestTableAdminAPI(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -292,7 +292,7 @@ class TestTableAdminAPI(unittest2.TestCase):
         self.assertEqual(temp_table.list_column_families(), {})
 
 
-class TestDataAPI(unittest2.TestCase):
+class TestDataAPI(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/system_tests/bigtable_happybase.py
+++ b/system_tests/bigtable_happybase.py
@@ -16,7 +16,7 @@
 import operator
 import struct
 
-import unittest2
+import unittest
 
 from gcloud import _helpers
 from gcloud.bigtable import client as client_mod
@@ -84,7 +84,7 @@ def tearDownModule():
     Config.CONNECTION.close()
 
 
-class TestConnection(unittest2.TestCase):
+class TestConnection(unittest.TestCase):
 
     def test_create_and_delete_table(self):
         connection = Config.CONNECTION
@@ -105,7 +105,7 @@ class TestConnection(unittest2.TestCase):
         self.assertFalse(ALT_TABLE_NAME in connection.tables())
 
 
-class BaseTableTest(unittest2.TestCase):
+class BaseTableTest(unittest.TestCase):
 
     def setUp(self):
         self.rows_to_delete = []

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -14,9 +14,9 @@
 
 import datetime
 import os
+import unittest
 
 import httplib2
-import unittest2
 
 from gcloud import _helpers
 from gcloud._helpers import UTC
@@ -66,7 +66,7 @@ def setUpModule():
                                          http=http)
 
 
-class TestDatastore(unittest2.TestCase):
+class TestDatastore(unittest.TestCase):
 
     def setUp(self):
         self.case_entities_to_delete = []

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -14,7 +14,7 @@
 
 import time
 
-import unittest2
+import unittest
 
 from gcloud import _helpers
 from gcloud.environment_vars import TESTS_PROJECT
@@ -74,7 +74,7 @@ def setUpModule():
     Config.CLIENT = logging.Client()
 
 
-class TestLogging(unittest2.TestCase):
+class TestLogging(unittest.TestCase):
 
     def setUp(self):
         self.to_delete = []

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 from gcloud import _helpers
 from gcloud.environment_vars import TESTS_PROJECT
@@ -26,7 +26,7 @@ def setUpModule():
     _helpers.PROJECT = TESTS_PROJECT
 
 
-class TestMonitoring(unittest2.TestCase):
+class TestMonitoring(unittest.TestCase):
 
     def test_fetch_metric_descriptor(self):
         METRIC_TYPE = (
@@ -177,7 +177,7 @@ class TestMonitoring(unittest2.TestCase):
             descriptor.delete()
 
 
-class TestMonitoringGroups(unittest2.TestCase):
+class TestMonitoringGroups(unittest.TestCase):
 
     def setUp(self):
         self.to_delete = []

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -14,9 +14,9 @@
 
 import os
 import time
+import unittest
 
 import httplib2
-import unittest2
 
 from gcloud import _helpers
 from gcloud.environment_vars import PUBSUB_EMULATOR
@@ -50,7 +50,7 @@ def setUpModule():
                                       http=http)
 
 
-class TestPubsub(unittest2.TestCase):
+class TestPubsub(unittest.TestCase):
 
     def setUp(self):
         self.to_delete = []
@@ -172,7 +172,7 @@ class TestPubsub(unittest2.TestCase):
         self.assertEqual(message2.attributes['extra'], EXTRA_2)
 
     def _maybe_emulator_skip(self):
-        # NOTE: We check at run-time rather than using the @unittest2.skipIf
+        # NOTE: We check at run-time rather than using the @unittest.skipIf
         #       decorator. This matches the philosophy behind using
         #       setUpModule to determine the environment at run-time
         #       rather than at import time.

--- a/system_tests/run_system_test.py
+++ b/system_tests/run_system_test.py
@@ -14,7 +14,7 @@
 
 import argparse
 import sys
-import unittest2
+import unittest
 
 import bigquery
 import bigtable
@@ -59,13 +59,13 @@ def run_module_tests(module_name, ignore_requirements=False):
         # Make sure environ is set before running test.
         system_test_utils.check_environ()
 
-    suite = unittest2.TestSuite()
+    suite = unittest.TestSuite()
     test_mod = TEST_MODULES[module_name]
-    tests = unittest2.defaultTestLoader.loadTestsFromModule(test_mod)
+    tests = unittest.defaultTestLoader.loadTestsFromModule(test_mod)
     suite.addTest(tests)
 
     # Run tests.
-    test_result = unittest2.TextTestRunner(verbosity=2).run(suite)
+    test_result = unittest.TextTestRunner(verbosity=2).run(suite)
     # Exit if not successful.
     if not test_result.wasSuccessful():
         sys.exit(1)

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -15,10 +15,10 @@
 import os
 import tempfile
 import time
+import unittest
 
 import httplib2
 import six
-import unittest2
 
 from gcloud import _helpers
 from gcloud.environment_vars import TESTS_PROJECT
@@ -55,7 +55,7 @@ def tearDownModule():
     Config.TEST_BUCKET.delete(force=True)
 
 
-class TestStorageBuckets(unittest2.TestCase):
+class TestStorageBuckets(unittest.TestCase):
 
     def setUp(self):
         self.case_buckets_to_delete = []
@@ -91,7 +91,7 @@ class TestStorageBuckets(unittest2.TestCase):
         self.assertEqual(len(created_buckets), len(buckets_to_create))
 
 
-class TestStorageFiles(unittest2.TestCase):
+class TestStorageFiles(unittest.TestCase):
 
     FILES = {
         'logo': {

--- a/system_tests/translate.py
+++ b/system_tests/translate.py
@@ -15,7 +15,7 @@
 
 import os
 
-import unittest2
+import unittest
 
 from gcloud import translate
 
@@ -37,7 +37,7 @@ def setUpModule():
     Config.CLIENT = translate.Client(api_key=api_key)
 
 
-class TestTranslate(unittest2.TestCase):
+class TestTranslate(unittest.TestCase):
 
     def test_get_languages(self):
         result = Config.CLIENT.get_languages()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
 deps =
     nose
     nose-exclude
-    unittest2
 covercmd =
     nosetests \
       --exclude-dir=system_tests \


### PR DESCRIPTION
Now that we are off Python 2.6, we can just use the stdlib's 'unittest'.