### PR TITLE
Add partition support to BigQuery

### DIFF
--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -229,6 +229,53 @@ class Table(object):
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('type')
+        
+    @property
+    def partitioningType(self):
+        """Time partitioning of the table.
+        :rtype: str, or ``NoneType``
+        :returns: Returns type if the table is partitioned, None otherwise.
+        """
+        partitioned = None
+        if "timePartitioning" in self._properties:
+            partitioned = self._properties.get('timePartitioning').get('type')
+        return partitioned
+    
+    @partitioningType.setter
+    def partitioningType(self, value):
+        """Update the partitioning type of the table
+
+        :type value: str
+        :param value: partitioning type only "DAY" is currently supported
+        """
+        if not isinstance(value, six.string_types) or value.upper() != "DAY":
+            raise ValueError("value must be one of ['DAY']")
+        if "timePartitioning" not in self._properties:
+            self._properties['timePartitioning'] = {}
+        self._properties['timePartitioning']['type'] = value.upper()
+        
+    @property
+    def partitionExpiration(self):
+        """Expiration time in ms for a partition
+        :rtype: int
+        :returns: Returns the time in ms for partition expiration
+        """
+        if "timePartitioning" not in self._properties:
+            self._properties['timePartitioning'] = {'type': "DAY"}
+        return self._properties.get("timePartitioning").get("expirationMs")
+    
+    @partitionExpiration.setter
+    def partitionExpiration(self, value):
+        """Update the experation time in ms for a partition
+        
+        :type value: int
+        :param value: partition experiation time in ms
+        """
+        if not isinstance(value, int):
+            raise ValueError("must be an integer representing millisseconds")
+        if "timePartitioning" not in self._properties:
+            self._properties['timePartitioning'] = {'type': "DAY"}
+        self._properties["timePartitioning"]["expirationMs"] = value
 
     @property
     def description(self):
@@ -422,6 +469,9 @@ class Table(object):
 
         if self.location is not None:
             resource['location'] = self.location
+
+        if self.partitioningType is not None:
+            resource['timePartitioning'] = self._properties['timePartitioning']
 
         if self.view_query is not None:
             view = resource['view'] = {}

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -231,7 +231,7 @@ class Table(object):
         return self._properties.get('type')
 
     @property
-    def partitioningType(self):
+    def partitioning_type(self):
         """Time partitioning of the table.
         :rtype: str, or ``NoneType``
         :returns: Returns type if the table is partitioned, None otherwise.
@@ -241,8 +241,8 @@ class Table(object):
             partitioned = self._properties.get('timePartitioning').get('type')
         return partitioned
 
-    @partitioningType.setter
-    def partitioningType(self, value):
+    @partitioning_type.setter
+    def partitioning_type(self, value):
         """Update the partitioning type of the table
 
         :type value: str
@@ -257,19 +257,19 @@ class Table(object):
             self._properties['timePartitioning']['type'] = value.upper()
 
     @property
-    def partitionExpiration(self):
+    def partition_expiration(self):
         """Expiration time in ms for a partition
         :rtype: int, or ``NoneType``
         :returns: Returns the time in ms for partition expiration
         """
         expiry = None
         if "timePartitioning" in self._properties:
-            tp = self._properties.get("timePartitioning")
-            expiry = tp.get("expirationMs")
+            time_part = self._properties.get("timePartitioning")
+            expiry = time_part.get("expirationMs")
         return expiry
 
-    @partitionExpiration.setter
-    def partitionExpiration(self, value):
+    @partition_expiration.setter
+    def partition_expiration(self, value):
         """Update the experation time in ms for a partition
 
         :type value: int
@@ -476,7 +476,7 @@ class Table(object):
         if self.location is not None:
             resource['location'] = self.location
 
-        if self.partitioningType is not None:
+        if self.partitioning_type is not None:
             resource['timePartitioning'] = self._properties['timePartitioning']
 
         if self.view_query is not None:

--- a/gcloud/bigquery/table.py
+++ b/gcloud/bigquery/table.py
@@ -229,7 +229,7 @@ class Table(object):
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('type')
-        
+
     @property
     def partitioningType(self):
         """Time partitioning of the table.
@@ -240,7 +240,7 @@ class Table(object):
         if "timePartitioning" in self._properties:
             partitioned = self._properties.get('timePartitioning').get('type')
         return partitioned
-    
+
     @partitioningType.setter
     def partitioningType(self, value):
         """Update the partitioning type of the table
@@ -250,32 +250,38 @@ class Table(object):
         """
         if not isinstance(value, six.string_types) or value.upper() != "DAY":
             raise ValueError("value must be one of ['DAY']")
-        if "timePartitioning" not in self._properties:
+        try:
+            self._properties['timePartitioning']['type'] = value.upper()
+        except KeyError:
             self._properties['timePartitioning'] = {}
-        self._properties['timePartitioning']['type'] = value.upper()
-        
+            self._properties['timePartitioning']['type'] = value.upper()
+
     @property
     def partitionExpiration(self):
         """Expiration time in ms for a partition
-        :rtype: int
+        :rtype: int, or ``NoneType``
         :returns: Returns the time in ms for partition expiration
         """
-        if "timePartitioning" not in self._properties:
-            self._properties['timePartitioning'] = {'type': "DAY"}
-        return self._properties.get("timePartitioning").get("expirationMs")
-    
+        expiry = None
+        if "timePartitioning" in self._properties:
+            tp = self._properties.get("timePartitioning")
+            expiry = tp.get("expirationMs")
+        return expiry
+
     @partitionExpiration.setter
     def partitionExpiration(self, value):
         """Update the experation time in ms for a partition
-        
+
         :type value: int
         :param value: partition experiation time in ms
         """
         if not isinstance(value, int):
             raise ValueError("must be an integer representing millisseconds")
-        if "timePartitioning" not in self._properties:
+        try:
+            self._properties["timePartitioning"]["expirationMs"] = value
+        except KeyError:
             self._properties['timePartitioning'] = {'type': "DAY"}
-        self._properties["timePartitioning"]["expirationMs"] = value
+            self._properties["timePartitioning"]["expirationMs"] = value
 
     @property
     def description(self):

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -536,9 +536,9 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
 
-        self.assertEqual(table.partitioningType, None)
-        table.partitioningType = "DAY"
-        self.assertEqual(table.partitioningType, "DAY")
+        self.assertEqual(table.partitioning_type, None)
+        table.partitioning_type = "DAY"
+        self.assertEqual(table.partitioning_type, "DAY")
         table.create()
 
         self.assertEqual(len(conn._requested), 1)
@@ -569,10 +569,10 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._makeOne(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
-        self.assertEqual(table.partitionExpiration, None)
-        table.partitionExpiration = 100
-        self.assertEqual(table.partitioningType, "DAY")
-        self.assertEqual(table.partitionExpiration, 100)
+        self.assertEqual(table.partition_expiration, None)
+        table.partition_expiration = 100
+        self.assertEqual(table.partitioning_type, "DAY")
+        self.assertEqual(table.partition_expiration, 100)
         table.create()
 
         self.assertEqual(len(conn._requested), 1)
@@ -594,7 +594,6 @@ class TestTable(unittest2.TestCase, _SchemaBase):
 
     def test_create_w_bad_partitions(self):
         from gcloud.bigquery.table import SchemaField
-        PATH = 'projects/%s/datasets/%s/tables' % (self.PROJECT, self.DS_NAME)
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
@@ -604,11 +603,11 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         with self.assertRaises(ValueError):
-            table.partitioningType = 123
+            table.partitioning_type = 123
         with self.assertRaises(ValueError):
-            table.partitioningType = "HASH"
+            table.partitioning_type = "HASH"
         with self.assertRaises(ValueError):
-            table.partitionExpiration = "NEVER"
+            table.partition_expiration = "NEVER"
 
     def test_create_w_alternate_client(self):
         import datetime

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -592,7 +592,21 @@ class TestTable(unittest2.TestCase, _SchemaBase):
         self.assertEqual(req['data'], SENT)
         self._verifyResourceProperties(table, RESOURCE)
 
-    def test_create_w_bad_partitions(self):
+    def test_partition_type_setter_none_type(self):
+        from gcloud.bigquery.table import SchemaField
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        table = self._makeOne(self.TABLE_NAME, dataset,
+                              schema=[full_name, age])
+        self.assertEqual(table.partitioning_type, None)
+        table.partitioning_type = None
+        self.assertEqual(table.partitioning_type, None)
+
+    def test_partition_type_setter_bad_type(self):
         from gcloud.bigquery.table import SchemaField
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
@@ -604,10 +618,59 @@ class TestTable(unittest2.TestCase, _SchemaBase):
                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = 123
+
+    def test_partition_type_setter_unknown_value(self):
+        from gcloud.bigquery.table import SchemaField
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        table = self._makeOne(self.TABLE_NAME, dataset,
+                              schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = "HASH"
+
+    def test_partition_experiation_bad_type(self):
+        from gcloud.bigquery.table import SchemaField
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        table = self._makeOne(self.TABLE_NAME, dataset,
+                              schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partition_expiration = "NEVER"
+
+    def test_partition_expiration(self):
+        from gcloud.bigquery.table import SchemaField
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        table = self._makeOne(self.TABLE_NAME, dataset,
+                              schema=[full_name, age])
+        self.assertEqual(table.partition_expiration, None)
+        table.partition_expiration = 100
+        self.assertEqual(table.partitioning_type, "DAY")
+        self.assertEqual(table.partition_expiration, 100)
+
+    def test_list_partitions(self):
+        from gcloud.bigquery.table import SchemaField
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
+        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
+        table = self._makeOne(self.TABLE_NAME, dataset,
+                              schema=[full_name, age])
+        self.assertEqual(table.list_partitions(), [20160804, 20160805])
 
     def test_create_w_alternate_client(self):
         import datetime
@@ -1753,6 +1816,18 @@ class _Client(object):
 
     def job_from_resource(self, resource):  # pylint: disable=unused-argument
         return self._job
+
+    def run_sync_query(self, q=None):  # pylint: disable=unused-argument
+        return _Query(self)
+
+
+class _Query(object):
+
+    def __init__(self, client=None):  # pylint: disable=unused-argument
+        self.rows = []
+
+    def run(self):
+        self.rows = [(20160804, None), (20160805, None)]
 
 
 class _Dataset(object):


### PR DESCRIPTION
This adds the ability to create a partitioned table.  It would be nice to expose a table.list_partitions() method, but currently there is not an API-based way of returning partitions.  So, for now, it simply allows users to interact with the current partitioning API.