### PR TITLE
Bump GAX dependencies to Py3k-compatible versions.

### DIFF
--- a/gcloud/logging/client.py
+++ b/gcloud/logging/client.py
@@ -17,11 +17,11 @@
 import os
 
 try:
-    from google.logging.v2.config_service_v2_api import (
+    from google.cloud.logging.v2.config_service_v2_api import (
         ConfigServiceV2Api as GeneratedSinksAPI)
-    from google.logging.v2.logging_service_v2_api import (
+    from google.cloud.logging.v2.logging_service_v2_api import (
         LoggingServiceV2Api as GeneratedLoggingAPI)
-    from google.logging.v2.metrics_service_v2_api import (
+    from google.cloud.logging.v2.metrics_service_v2_api import (
         MetricsServiceV2Api as GeneratedMetricsAPI)
     from gcloud.logging._gax import _LoggingAPI as GAXLoggingAPI
     from gcloud.logging._gax import _MetricsAPI as GAXMetricsAPI

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -26,9 +26,9 @@ from gcloud.pubsub.topic import Topic
 
 # pylint: disable=ungrouped-imports
 try:
-    from google.pubsub.v1.publisher_api import (
+    from google.cloud.pubsub.v1.publisher_api import (
         PublisherApi as GeneratedPublisherAPI)
-    from google.pubsub.v1.subscriber_api import (
+    from google.cloud.pubsub.v1.subscriber_api import (
         SubscriberApi as GeneratedSubscriberAPI)
     from gcloud.pubsub._gax import _PublisherAPI as GAXPublisherAPI
     from gcloud.pubsub._gax import _SubscriberAPI as GAXSubscriberAPI

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ REQUIREMENTS = [
 GRPC_EXTRAS = [
     'grpcio >= 1.0rc1',
     'google-gax >= 0.12.3, < 0.13dev',
-    'gax-google-pubsub-v1 >= 0.7.12, < 0.8dev',
-    'grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev',
-    'gax-google-logging-v2 >= 0.7.12, < 0.8dev',
-    'grpc-google-logging-v2 >= 0.7.12, < 0.8dev',
+    'gax-google-pubsub-v1 >= 0.8.0, < 0.9dev',
+    'grpc-google-pubsub-v1 >= 0.8.0, < 0.9dev',
+    'gax-google-logging-v2 >= 0.8.0, < 0.9dev',
+    'grpc-google-logging-v2 >= 0.8.0, < 0.9dev',
 ]
 
 if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,10 @@ covercmd =
 deps =
     grpcio >= 1.0rc1
     google-gax >= 0.12.3, < 0.13dev
-    gax-google-pubsub-v1 >= 0.7.12, < 0.8dev
-    grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev
-    gax-google-logging-v2 >= 0.7.12, < 0.8dev
-    grpc-google-logging-v2 >= 0.7.12, < 0.8dev
+    gax-google-pubsub-v1 >= 0.8.0, < 0.9dev
+    grpc-google-pubsub-v1 >= 0.8.0, < 0.9dev
+    gax-google-logging-v2 >= 0.8.0, < 0.9dev
+    grpc-google-logging-v2 >= 0.8.0, < 0.9dev
 
 [docs]
 deps =


### PR DESCRIPTION
Note that we have to adjust imports, because the GAX-generated wrappers are now in `google.cloud.logging.v2` and `google.cloud.pubsub.v1`.

/cc @bjwatson, @geigerj