### PR TITLE
Backport PR #2065 to address issue #2066, then bump version to 0.18.1 for urgent release.

### DIFF
--- a/gcloud/logging/client.py
+++ b/gcloud/logging/client.py
@@ -17,11 +17,11 @@
 import os
 
 try:
-    from google.logging.v2.config_service_v2_api import (
+    from google.cloud.logging.v2.config_service_v2_api import (
         ConfigServiceV2Api as GeneratedSinksAPI)
-    from google.logging.v2.logging_service_v2_api import (
+    from google.cloud.logging.v2.logging_service_v2_api import (
         LoggingServiceV2Api as GeneratedLoggingAPI)
-    from google.logging.v2.metrics_service_v2_api import (
+    from google.cloud.logging.v2.metrics_service_v2_api import (
         MetricsServiceV2Api as GeneratedMetricsAPI)
     from gcloud.logging._gax import _LoggingAPI as GAXLoggingAPI
     from gcloud.logging._gax import _MetricsAPI as GAXMetricsAPI

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -26,9 +26,9 @@ from gcloud.pubsub.topic import Topic
 
 # pylint: disable=ungrouped-imports
 try:
-    from google.pubsub.v1.publisher_api import (
+    from google.cloud.pubsub.v1.publisher_api import (
         PublisherApi as GeneratedPublisherAPI)
-    from google.pubsub.v1.subscriber_api import (
+    from google.cloud.pubsub.v1.subscriber_api import (
         SubscriberApi as GeneratedSubscriberAPI)
     from gcloud.pubsub._gax import _PublisherAPI as GAXPublisherAPI
     from gcloud.pubsub._gax import _SubscriberAPI as GAXSubscriberAPI

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ REQUIREMENTS = [
 
 GRPC_EXTRAS = [
     'grpcio >= 1.0rc1',
-    'google-gax >= 0.12.3, < 0.13dev',
-    'gax-google-pubsub-v1 >= 0.7.12, < 0.8dev',
-    'grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev',
-    'gax-google-logging-v2 >= 0.7.12, < 0.8dev',
-    'grpc-google-logging-v2 >= 0.7.12, < 0.8dev',
+    'google-gax >= 0.12.3',
+    'gax-google-pubsub-v1 >= 0.8.0',
+    'grpc-google-pubsub-v1 >= 0.8.0',
+    'gax-google-logging-v2 >= 0.8.0',
+    'grpc-google-logging-v2 >= 0.8.0',
 ]
 
 if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:
 
 setup(
     name='gcloud',
-    version='0.18.0',
+    version='0.18.1',
     description='API Client library for Google Cloud',
     author='Google Cloud Platform',
     author_email='jjg+gcloud-python@google.com',

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,11 @@ covercmd =
 [grpc]
 deps =
     grpcio >= 1.0rc1
-    google-gax >= 0.12.3, < 0.13dev
-    gax-google-pubsub-v1 >= 0.7.12, < 0.8dev
-    grpc-google-pubsub-v1 >= 0.7.12, < 0.8dev
-    gax-google-logging-v2 >= 0.7.12, < 0.8dev
-    grpc-google-logging-v2 >= 0.7.12, < 0.8dev
+    google-gax >= 0.12.3
+    gax-google-pubsub-v1 >= 0.8.0
+    grpc-google-pubsub-v1 >= 0.8.0
+    gax-google-logging-v2 >= 0.8.0
+    grpc-google-logging-v2 >= 0.8.0
 
 [docs]
 deps =


### PR DESCRIPTION
Issue #2065 brownbags our 0.18.0 release.