### PR TITLE
The link to the API documentation has changed.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Google Cloud Python Client
 -  `API Documentation`_
 
 .. _Homepage: https://googlecloudplatform.github.io/gcloud-python/
-.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/stable/
+.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/#/docs/master/gcloud
 
 This client supports the following Google Cloud Platform services:
 


### PR DESCRIPTION
The `/stable` path for the docs is still showing the docs for v0.17.0, not v0.18.0.

I notice that there are no previous versions selectable, though maybe that'll change with new releases?