### PR TITLE
Add missing exception class for '502 Bad Gateway' response code.

### DIFF
--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -151,6 +151,11 @@ class MethodNotImplemented(ServerError):
     code = 501
 
 
+class BadGateway(ServerError):
+    """Exception mapping a '502 Bad Gateway' response."""
+    code = 502
+
+
 class ServiceUnavailable(ServerError):
     """Exception mapping a '503 Service Unavailable' response."""
     code = 503


### PR DESCRIPTION
We do see such (transient) errors in the wild.