### PR TITLE
Re-enable GAX by default if it is importable.

### DIFF
--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -13,6 +13,12 @@ Authentication and Configuration
   to interact with. If you are Google App Engine or Google Compute Engine
   this will be detected automatically.
 
+- The library now enables the ``gRPC`` transport for the logging API by
+  default, assuming that the required dependencies are installed and
+  importable.  To *disable* this transport, set the
+  :envvar:`GCLOUD_DISABLE_GAX` environment variable to a non-empty string,
+  e.g.:  ``$ export GCLOUD_DISABLE_GAX=1``.
+
 - After configuring your environment, create a
   :class:`Client <gcloud.logging.client.Client>`
 

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -7,6 +7,17 @@ Authentication / Configuration
 - Use :class:`Client <gcloud.pubsub.client.Client>` objects to configure
   your applications.
 
+- In addition to any authentication configuration, you should also set the
+  :envvar:`GCLOUD_PROJECT` environment variable for the project you'd like
+  to interact with. If you are Google App Engine or Google Compute Engine
+  this will be detected automatically.
+
+- The library now enables the ``gRPC`` transport for the pubsub API by
+  default, assuming that the required dependencies are installed and
+  importable.  To *disable* this transport, set the
+  :envvar:`GCLOUD_DISABLE_GAX` environment variable to a non-empty string,
+  e.g.:  ``$ export GCLOUD_DISABLE_GAX=1``.
+
 - :class:`Client <gcloud.pubsub.client.Client>` objects hold both a ``project``
   and an authenticated connection to the PubSub service.
 

--- a/gcloud/logging/client.py
+++ b/gcloud/logging/client.py
@@ -47,7 +47,8 @@ from gcloud.logging.metric import Metric
 from gcloud.logging.sink import Sink
 
 
-_USE_GAX = _HAVE_GAX and (os.environ.get('GCLOUD_ENABLE_GAX') is not None)
+_DISABLE_GAX = os.getenv('GCLOUD_DISABLE_GAX', False)
+_USE_GAX = _HAVE_GAX and not _DISABLE_GAX
 
 
 class Client(JSONClient):

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -41,7 +41,8 @@ else:
 # pylint: enable=ungrouped-imports
 
 
-_USE_GAX = _HAVE_GAX and (os.environ.get('GCLOUD_ENABLE_GAX') is not None)
+_DISABLE_GAX = os.getenv('GCLOUD_DISABLE_GAX', False)
+_USE_GAX = _HAVE_GAX and not _DISABLE_GAX
 
 
 class Client(JSONClient):


### PR DESCRIPTION
As of the `0.8.1` versions of the wrappers, the pubsub and logging system tests pass on Python3.4 with GAX enabled.