### PR TITLE
Distinguishing between unset env. var. and missing file in system test.

### DIFF
--- a/system_tests/system_test_utils.py
+++ b/system_tests/system_test_utils.py
@@ -28,8 +28,6 @@ CREDENTIALS = os.getenv(TEST_CREDENTIALS)
 ENVIRON_ERROR_MSG = """\
 To run the system tests, you need to set some environment variables.
 Please check the CONTRIBUTING guide for instructions.
-
-Missing variables: %s
 """
 
 
@@ -47,15 +45,24 @@ class EmulatorCreds(object):
 
 def check_environ():
     missing = []
+    extra = ''
 
     if PROJECT_ID is None:
         missing.append(TESTS_PROJECT)
 
-    if CREDENTIALS is None or not os.path.isfile(CREDENTIALS):
+    if CREDENTIALS is None:
         missing.append(TEST_CREDENTIALS)
+    elif not os.path.isfile(CREDENTIALS):
+        extra = '\nThe %s path %r is not a file.' % (TEST_CREDENTIALS,
+                                                     CREDENTIALS)
 
-    if missing:
-        print(ENVIRON_ERROR_MSG % ', '.join(missing), file=sys.stderr)
+    if missing or extra:
+        msg = ENVIRON_ERROR_MSG
+        if missing:
+            msg += '\nMissing variables: ' + ', '.join(missing)
+        if extra:
+            msg += extra
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
Fixes #2084.

/cc @geigerj

----

Sample output

```bash
$ env | grep GCLOUD
$ env | grep GOOG
$
$ python system_tests/run_system_test.py --package datastore
D0811 08:35:27.609354178    9997 ev_posix.c:101]             Using polling engine: poll
To run the system tests, you need to set some environment variables.
Please check the CONTRIBUTING guide for instructions.

Missing variables: GCLOUD_TESTS_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS
$
$ GOOGLE_APPLICATION_CREDENTIALS=bye GCLOUD_TESTS_PROJECT_ID=hi \
> python system_tests/run_system_test.py --package datastore
D0811 08:35:13.398294691    9979 ev_posix.c:101]             Using polling engine: poll
To run the system tests, you need to set some environment variables.
Please check the CONTRIBUTING guide for instructions.

The GOOGLE_APPLICATION_CREDENTIALS path 'bye' is not a file.
$
$ GOOGLE_APPLICATION_CREDENTIALS=bye \
> python system_tests/run_system_test.py --package datastore
D0811 08:35:19.764175549    9988 ev_posix.c:101]             Using polling engine: poll
To run the system tests, you need to set some environment variables.
Please check the CONTRIBUTING guide for instructions.

Missing variables: GCLOUD_TESTS_PROJECT_ID
The GOOGLE_APPLICATION_CREDENTIALS path 'bye' is not a file.
$
$ GOOGLE_APPLICATION_CREDENTIALS=setup.py \
> python system_tests/run_system_test.py --package datastore
D0811 08:35:37.601515289   10006 ev_posix.c:101]             Using polling engine: poll
To run the system tests, you need to set some environment variables.
Please check the CONTRIBUTING guide for instructions.

Missing variables: GCLOUD_TESTS_PROJECT_ID
```