### PR TITLE
Move requirements out to a separate 'requirements.txt' file.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,9 +82,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install wheel nose nose-exclude cryptography"
-  # Install sometimes-problematic gRPC-related dependencies
-  - "%CMD_IN_ENV% pip install 'grpcio >= 1.0rc1' gax-google-pubsub-v1 gax-google-logging-v2"
+  - "%CMD_IN_ENV% pip install -r appveyor/requirements.txt"
 
 build_script:
   # Build the compiled extension

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,0 +1,13 @@
+# Install the build dependencies of the project. If some dependencies contain
+# compiled extensions and are not provided as pre-built wheel packages,
+# pip will build them from source using the MSVC compiler matching the
+# target Python version and architecture
+wheel
+nose
+nose-exclude
+cryptography
+grpcio >= 1.0rc1
+grpc-google-pubsub-v1
+grpc-google-logging-v2
+gax-google-pubsub-v1
+gax-google-logging-v2


### PR DESCRIPTION
Avoids quoting interactions between pinned dependencies and Windows command shell syntax.

@dhermes Once again, I will push ASAP to trigger another Appveyor build.