### PR TITLE
Manually run tox -e cover to check for 100% test coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ script:
   - tox -e py27
   - tox -e py34
   - tox -e lint
+  - tox -e cover
   - tox -e system-tests
   - tox -e system-tests3
   - tox -e json-docs
 
 after_success:
   - tox -e coveralls
-  - tox -e codecov
 
 deploy:
   provider: pypi

--- a/README.rst
+++ b/README.rst
@@ -326,8 +326,8 @@ Apache 2.0 - See `LICENSE`_ for more information.
 
 .. |build| image:: https://travis-ci.org/GoogleCloudPlatform/gcloud-python.svg?branch=master
    :target: https://travis-ci.org/GoogleCloudPlatform/gcloud-python
-.. |coverage| image:: https://codecov.io/gh/GoogleCloudPlatform/gcloud-python/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/GoogleCloudPlatform/gcloud-python
+.. |coverage| image:: https://coveralls.io/repos/GoogleCloudPlatform/gcloud-python/badge.png?branch=master
+   :target: https://coveralls.io/r/GoogleCloudPlatform/gcloud-python?branch=master
 .. |pypi| image:: https://img.shields.io/pypi/v/gcloud.svg
    :target: https://pypi.python.org/pypi/gcloud
 .. |versions| image:: https://img.shields.io/pypi/pyversions/gcloud.svg

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-comment: false
-coverage:
-    status:
-        patch:
-            default:
-                target: '100'
-        project:
-            default:
-                target: '100'

--- a/tox.ini
+++ b/tox.ini
@@ -64,28 +64,6 @@ deps =
     coveralls
 passenv = {[testenv:system-tests]passenv}
 
-[testenv:codecov]
-basepython =
-    {[testenv:cover]basepython}
-passenv =
-    CI
-    TRAVIS_BUILD_ID
-    TRAVIS
-    TRAVIS_BRANCH
-    TRAVIS_JOB_NUMBER
-    TRAVIS_PULL_REQUEST
-    TRAVIS_JOB_ID
-    TRAVIS_REPO_SLUG
-    TRAVIS_COMMIT
-deps =
-    {[testenv:cover]deps}
-    codecov>=1.4.0
-commands =
-    {[testenv:cover]commands}
-    codecov
-setenv =
-    PYTHONPATH =
-
 [testenv:docs]
 basepython =
     python2.7


### PR DESCRIPTION
This also removes codecov references.