### PR TITLE
Fix JSON formatting and docsite crashing. Fixes #2114

### DIFF
--- a/docs/json/json/master/toc.json
+++ b/docs/json/json/master/toc.json
@@ -97,7 +97,7 @@
             {
                 "type": "gcloud/bigtable/table/table",
                 "title": "Table"
-            },
+            }
     ]
   },{
     "title": "Datastore",

--- a/docs/json/toc-all.json
+++ b/docs/json/toc-all.json
@@ -277,7 +277,7 @@
             {
                 "type": "gcloud/bigtable/table/table",
                 "title": "Table"
-            },
+            }
     ]
   },{
     "title": "Datastore",


### PR DESCRIPTION
This is causing the docsite to crash and not get past the front page.