### PR TITLE
Remove *s from kwargs in docstrings

### DIFF
--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -468,9 +468,9 @@ class Client(_BaseClient, _ClientProjectMixin):
         >>> connection.run_query('project', query.to_protobuf())
         [<list of Entity Protobufs>], cursor, more_results, skipped_results
 
-        :type **kwargs: dict
-        :param **kwargs: Parameters for initializing and instance of
-                         :class:`gcloud.datastore.query.Query`.
+        :type kwargs: dict
+        :param kwargs: Parameters for initializing and instance of
+                       :class:`gcloud.datastore.query.Query`.
 
         :rtype: :class:`gcloud.datastore.query.Query`
         :returns: An instance of :class:`gcloud.datastore.query.Query`


### PR DESCRIPTION
Fixes this error: 

http://stackoverflow.com/questions/30454549/a-literal-in-restructuredtext

Seems simplest/cleanest thing to do is just drop the *.s. Could alternatively follow that accepted answer's hacky solution or follow up with Sphinx, I don't see an issue about it in their issue tracker