### PR TITLE
Turn on Mac OS X testing in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 sudo: false
 
+os:
+  - linux
+  - osx
+
 install:
   - pip install --upgrade pip
   - pip install --upgrade tox


### PR DESCRIPTION
NOTE: This feature is still in beta according to
https://docs.travis-ci.com/user/multi-os/

See #2136