### PR TITLE
Updating docs link in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Google Cloud Python Client
 -  `API Documentation`_
 
 .. _Homepage: https://googlecloudplatform.github.io/gcloud-python/
-.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/stable/
+.. _API Documentation: http://googlecloudplatform.github.io/gcloud-python/#/docs/master/gcloud
 
 This client supports the following Google Cloud Platform services:
 


### PR DESCRIPTION
@tswast Sorry I wanted to get rid of the branch in https://github.com/GoogleCloudPlatform/gcloud-python and the PR went stale.

----

@daspecster We previously followed the readthedocs.org of docs at

```
{URI}/stable -- last release
{URI}/latest -- HEAD of source
{URI}/0.1.0
{URI}/0.2.0
{URI}/0.2.1
...
```

Can we restore this (outside of this PR)?