### PR TITLE
Fixing docs-rtd tox rule.

### DIFF
--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 
+import argparse
 import os
 import sys
 import warnings
@@ -27,7 +28,6 @@ from sphinx.ext.intersphinx import fetch_inventory
 BASE_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..'))
 DOCS_DIR = os.path.join(BASE_DIR, 'docs')
-OBJECT_INVENTORY_RELPATH = os.path.join('_build', 'html', 'objects.inv')
 IGNORED_PREFIXES = ('test_', '_')
 IGNORED_MODULES = frozenset([
     'gcloud.__init__',
@@ -118,11 +118,18 @@ def get_public_modules(path, base_package=None):
     return result
 
 
-def main():
-    """Main script to verify modules included."""
+def main(build_root='_build'):
+    """Main script to verify modules included.
+
+    :type build_root: str
+    :param build_root: The root of the directory where docs are built into.
+                       Defaults to ``_build``.
+    """
+    object_inventory_relpath = os.path.join(build_root, 'html', 'objects.inv')
+
     mock_uri = ''
     inventory = fetch_inventory(SphinxApp, mock_uri,
-                                OBJECT_INVENTORY_RELPATH)
+                                object_inventory_relpath)
     sphinx_mods = set(inventory['py:module'].keys())
 
     library_dir = os.path.join(BASE_DIR, 'gcloud')
@@ -149,5 +156,20 @@ def main():
         sys.exit(1)
 
 
+def get_parser():
+    """Get simple ``argparse`` parser to determine package.
+
+    :rtype: :class:`argparse.ArgumentParser`
+    :returns: The parser for this script.
+    """
+    parser = argparse.ArgumentParser(
+        description='Run check that all GCloud modules are included in docs.')
+    parser.add_argument('--build-root', dest='build_root',
+                        help='The root directory where docs are located.')
+    return parser
+
+
 if __name__ == '__main__':
-    main()
+    parser = get_parser()
+    args = parser.parse_args()
+    main(build_root=args.build_root)

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ basepython =
 commands =
     python -c "import shutil; shutil.rmtree('docs/_build', ignore_errors=True)"
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
-    python {toxinidir}/scripts/verify_included_modules.py
+    python {toxinidir}/scripts/verify_included_modules.py --build-root _build
 deps =
     {[testenv]deps}
     {[docs]deps}
@@ -99,7 +99,7 @@ basepython = {[testenv:docs]basepython}
 commands =
     python -c "import shutil; shutil.rmtree('docs/_build_rtd', ignore_errors=True)"
     sphinx-build -W -b html -d docs/_build_rtd/doctrees docs docs/_build_rtd/html
-    python {toxinidir}/scripts/verify_included_modules.py
+    python {toxinidir}/scripts/verify_included_modules.py --build-root _build_rtd
 deps =
     {[testing]deps}
     {[docs]deps}


### PR DESCRIPTION
It was previously broken because module verification assumed the docs were built in the `_build` directory.