### PR TITLE
Updating Intersphinx links.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -291,7 +291,7 @@ html_context.update(
 # httplib2 libraries.
 intersphinx_mapping = {
     'httplib2': ('http://bitworking.org/projects/httplib2/doc/html/', None),
-    'oauth2client': ('http://oauth2client.readthedocs.org/en/latest/', None),
+    'oauth2client': ('http://oauth2client.readthedocs.io/en/latest', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/2', None),
 }


### PR DESCRIPTION
During a docs build, each of the two changed links prints a warning:

```
intersphinx inventory has moved: https://docs.python.org/ -> https://docs.python.org/2
intersphinx inventory has moved: http://oauth2client.readthedocs.org/en/latest/ -> http://oauth2client.readthedocs.io/en/latest
```