### PR TITLE
Remove all traces of 'undelete'.

### DIFF
--- a/gcloud/bigtable/cluster.py
+++ b/gcloud/bigtable/cluster.py
@@ -67,7 +67,6 @@ class Cluster(object):
     * :meth:`create` itself
     * :meth:`update` itself
     * :meth:`delete` itself
-    * :meth:`undelete` itself
 
     .. note::
 
@@ -266,11 +265,6 @@ class Cluster(object):
         Soon afterward:
 
         * All tables within the cluster will become unavailable.
-
-        Prior to the cluster's ``delete_time``:
-
-        * The cluster can be recovered with a call to ``UndeleteCluster``.
-        * All other attempts to modify or delete the cluster will be rejected.
 
         At the cluster's ``delete_time``:
 

--- a/gcloud/bigtable/instance.py
+++ b/gcloud/bigtable/instance.py
@@ -76,7 +76,6 @@ class Instance(object):
     * :meth:`create` itself
     * :meth:`update` itself
     * :meth:`delete` itself
-    * :meth:`undelete` itself
 
     .. note::
 
@@ -277,11 +276,6 @@ class Instance(object):
         Soon afterward:
 
         * All tables within the instance will become unavailable.
-
-        Prior to the instance's ``delete_time``:
-
-        * The instance can be recovered with a call to ``UndeleteInstance``.
-        * All other attempts to modify or delete the instance will be rejected.
 
         At the instance's ``delete_time``:
 


### PR DESCRIPTION
There are no such endpoints in the Bigtable V2 API.

Closes #2209.