### PR TITLE
Use lower-case gRPC header keys

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -570,8 +570,8 @@ class MetadataPlugin(object):
         """
         access_token = self._credentials.get_access_token().access_token
         headers = [
-            ('Authorization', 'Bearer ' + access_token),
-            ('User-agent', self._user_agent),
+            ('authorization', 'Bearer ' + access_token),
+            ('user-agent', self._user_agent),
         ]
         callback(headers, None)
 

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -838,8 +838,8 @@ class TestMetadataPlugin(unittest.TestCase):
         transformer = self._makeOne(credentials, user_agent)
         result = transformer(None, callback)
         cb_headers = [
-            ('Authorization', 'Bearer ' + access_token_expected),
-            ('User-agent', user_agent),
+            ('authorization', 'Bearer ' + access_token_expected),
+            ('user-agent', user_agent),
         ]
         self.assertEqual(result, None)
         self.assertEqual(callback_args, [(cb_headers, None)])


### PR DESCRIPTION
As upper-case letters are illegal per http2 spec.