### PR TITLE
Shorten custom metric type used for system testing.

### DIFF
--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -165,7 +165,7 @@ class TestMonitoring(unittest.TestCase):
             pass    # Not necessarily reached.
 
     def test_create_and_delete_metric_descriptor(self):
-        METRIC_TYPE = ('custom.googleapis.com/tmp/system_test_example' +
+        METRIC_TYPE = ('custom.googleapis.com/tmp/systest' +
                        unique_resource_id())
         METRIC_KIND = monitoring.MetricKind.GAUGE
         VALUE_TYPE = monitoring.ValueType.DOUBLE


### PR DESCRIPTION
When run on Travis, the `unique_resource_id()` function causes the type name to exceed 40 characters:  reducing the prefix length empirically allows the `create()` | `delete()` pair to work as intended.

Towards #2176.
