### PR TITLE
Add support for the comparison filters of Google Monitoring API

### DIFF
--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -637,10 +637,10 @@ def _build_label_filter(category, *args, **kwargs):
             continue
 
         suffix = None
-        if key.endswith('_prefix') or key.endswith('_suffix') or \
-            key.endswith('_greater') or key.endswith('_greaterequal') or \
-                key.endswith('_less') or key.endswith('_lessequal'):
-                    key, suffix = key.rsplit('_', 1)
+        ends = ['_prefix', '_suffix', '_greater', '_greaterequal',
+                '_less', '_lessequal']
+        if key.endswith(tuple(ends)):
+            key, suffix = key.rsplit('_', 1)
 
         if category == 'resource' and key == 'resource_type':
             key = 'resource.type'

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -637,8 +637,10 @@ def _build_label_filter(category, *args, **kwargs):
             continue
 
         suffix = None
-        if key.endswith('_prefix') or key.endswith('_suffix'):
-            key, suffix = key.rsplit('_', 1)
+        if key.endswith('_prefix') or key.endswith('_suffix') or \
+            key.endswith('_greater') or key.endswith('_greaterequal') or \
+                key.endswith('_less') or key.endswith('_lessequal'):
+                    key, suffix = key.rsplit('_', 1)
 
         if category == 'resource' and key == 'resource_type':
             key = 'resource.type'
@@ -649,6 +651,14 @@ def _build_label_filter(category, *args, **kwargs):
             term = '{key} = starts_with("{value}")'
         elif suffix == 'suffix':
             term = '{key} = ends_with("{value}")'
+        elif suffix == 'greater':
+            term = '{key} > {value}'
+        elif suffix == 'greaterequal':
+            term = '{key} >= {value}'
+        elif suffix == 'less':
+            term = '{key} < {value}'
+        elif suffix == 'lessequal':
+            term = '{key} <= {value}'
         else:
             term = '{key} = "{value}"'
 


### PR DESCRIPTION
Google Monitoring API filters have <,<=,>,>= operators as described
in https://cloud.google.com/monitoring/api/v3/filters.

Current version of the library only has mappings of:

1. ’{key}_prefix:{value}'       -> '{key} = starts_with("{value}")'
2. ’{key}_suffix:{value}'       -> '{key} = ends_with("{value}")'

This patch adds mappings of:

3. ’{key}_greater:{value}'      -> '{key} > {value}'
4. ’{key}_greaterequal:{value}' -> '{key} >= {value}'
5. ’{key}_less:{value}'         -> '{key} < {value}'
6. ’{key}_lessequal:{value}'    -> '{key} <= {value}'

So that it’s possible to express, for example, the following query:

metric.type = "appengine.googleapis.com/http/server/response_count"
AND metric.label.response_code < 600
AND metric.label.response_code >= 500

I.e. filter based on response_code value.