### PR TITLE
Add support for the comparison filters of Google Monitoring API

### DIFF
--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -313,6 +313,25 @@ class Query(object):
 
             metric.label.<label> = ends_with("<value>")
 
+        If the label's value type is ``INT64``, a similar notation can be
+        used to express inequalities:
+
+        ``<label>_less=<value>`` generates::
+
+        metric.label.<label> < <value>
+
+        ``<label>_lessequal=<value>`` generates::
+
+        metric.label.<label> <= <value>
+
+        ``<label>_greater=<value>`` generates::
+
+        metric.label.<label> > <value>
+
+        ``<label>_greaterequal=<value>`` generates::
+
+        metric.label.<label> >= <value>
+
         :type args: tuple
         :param args: Raw filter expression strings to include in the
             conjunction. If just one is provided and no keyword arguments
@@ -637,9 +656,8 @@ def _build_label_filter(category, *args, **kwargs):
             continue
 
         suffix = None
-        ends = ['_prefix', '_suffix', '_greater', '_greaterequal',
-                '_less', '_lessequal']
-        if key.endswith(tuple(ends)):
+        if key.endswith(('_prefix', '_suffix', '_greater', '_greaterequal',
+                         '_less', '_lessequal')):
             key, suffix = key.rsplit('_', 1)
 
         if category == 'resource' and key == 'resource_type':

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -637,7 +637,9 @@ def _build_label_filter(category, *args, **kwargs):
             continue
 
         suffix = None
-        if key.endswith('_prefix') or key.endswith('_suffix'):
+        ends = ['_prefix', '_suffix', '_greater', '_greaterequal',
+                '_less', '_lessequal']
+        if key.endswith(tuple(ends)):
             key, suffix = key.rsplit('_', 1)
 
         if category == 'resource' and key == 'resource_type':
@@ -649,6 +651,14 @@ def _build_label_filter(category, *args, **kwargs):
             term = '{key} = starts_with("{value}")'
         elif suffix == 'suffix':
             term = '{key} = ends_with("{value}")'
+        elif suffix == 'greater':
+            term = '{key} > {value}'
+        elif suffix == 'greaterequal':
+            term = '{key} >= {value}'
+        elif suffix == 'less':
+            term = '{key} < {value}'
+        elif suffix == 'lessequal':
+            term = '{key} <= {value}'
         else:
             term = '{key} = "{value}"'
 

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -318,19 +318,19 @@ class Query(object):
 
         ``<label>_less=<value>`` generates::
 
-        metric.label.<label> < <value>
+            metric.label.<label> < <value>
 
         ``<label>_lessequal=<value>`` generates::
 
-        metric.label.<label> <= <value>
+            metric.label.<label> <= <value>
 
         ``<label>_greater=<value>`` generates::
 
-        metric.label.<label> > <value>
+            metric.label.<label> > <value>
 
         ``<label>_greaterequal=<value>`` generates::
 
-        metric.label.<label> >= <value>
+            metric.label.<label> >= <value>
 
         :type args: tuple
         :param args: Raw filter expression strings to include in the

--- a/gcloud/monitoring/test_query.py
+++ b/gcloud/monitoring/test_query.py
@@ -557,6 +557,28 @@ class Test__build_label_filter(unittest.TestCase):
         )
         self.assertEqual(actual, expected)
 
+    def test_metric_label_response_code_greater_less(self):
+        actual = self._callFUT(
+            'metric',
+            response_code_greater=500,
+            response_code_less=600)
+        expected = (
+            'metric.label.response_code < 600'
+            ' AND metric.label.response_code > 500'
+        )
+        self.assertEqual(actual, expected)
+
+    def test_metric_label_response_code_greater_less_equal(self):
+        actual = self._callFUT(
+            'metric',
+            response_code_greaterequal=500,
+            response_code_lessequal=600)
+        expected = (
+            'metric.label.response_code <= 600'
+            ' AND metric.label.response_code >= 500'
+        )
+        self.assertEqual(actual, expected)
+
     def test_resource_labels(self):
         actual = self._callFUT(
             'resource',


### PR DESCRIPTION
Google Monitoring API filters support <,<=,>,>= operators as described
in its documentation:
https://cloud.google.com/monitoring/api/v3/filters.

Current version of the library only has mappings of:

1. ’{key}_prefix:{value}' -> '{key} = starts_with("{value}")'
2. ’{key}_suffix:{value}' -> '{key} = ends_with("{value}")'

This patch introduces additional mappings of:

3. ’{key}_greater:{value}' -> '{key} > {value}'
4. ’{key}_greaterequal:{value}' -> '{key} >= {value}'
5. ’{key}_less:{value}' -> '{key} < {value}'
6. ’{key}_lessequal:{value}' -> '{key} <= {value}'

So that it is possible, for example, to filter based on the
response_code values range, as shown below:

metric.type = "appengine.googleapis.com/http/server/response_count"
AND metric.label.response_code < 600
AND metric.label.response_code >= 500

This patch will allow to remove “hack” in the following tool:
https://github.com/odin-public/gcpmetrics that enables
queries to the monitoring api from the command line.